### PR TITLE
define INSTALL_LIB_PATH for cmd-record.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ LIBMCOUNT_COMMON_OBJS := $(filter-out $(objdir)/libmcount/plthook.op,$(LIBMCOUNT
 COMMON_DEPS := $(objdir)/.config $(UFTRACE_HDRS)
 
 CFLAGS_$(objdir)/mcount.op = -pthread
-CFLAGS_$(objdir)/uftrace.o = -DINSTALL_LIB_PATH='"$(libdir)"'
+CFLAGS_$(objdir)/cmd-record.o = -DINSTALL_LIB_PATH='"$(libdir)"'
 LDFLAGS_$(objdir)/uftrace = -L$(objdir)/libtraceevent -ltraceevent -ldl
 
 CFLAGS_$(objdir)/libmcount/mcount-fast.op = -DDISABLE_MCOUNT_FILTER


### PR DESCRIPTION
and not uftrace.c, because that symbol is only used in cmd-record.c. without this change, it looks like passing --libdir to configure has no effect.