### PR TITLE
build: switch to bash for configure script

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #-*- mode: shell-script; -*-
 
 prefix=/usr/local


### PR DESCRIPTION
build: switch to bash for configure script
/bin/sh means system default shell.
But it can be variable by linux distributions vendor or user flavor

IMHO, this patch provides better compatibility for various build environments