### PR TITLE
don't try to spawn pagers during test

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -21,7 +21,7 @@ class TestBase:
     TEST_SUCCESS_FIXED = -8
 
     objdir = os.environ['objdir'] or '..'
-    ftrace = objdir + '/uftrace -L' + objdir
+    ftrace = objdir + '/uftrace --no-pager -L' + objdir
 
     default_cflags = ['-fno-inline', '-fno-builtin', '-fno-omit-frame-pointer']
 


### PR DESCRIPTION
uftrace correctly avoids spawning a pager when stdout is not a tty, and
runtest.py correctly runs uftrace connected to pipes, but (many? most?)
individual tests spawn uftrace themselves without connecting it to
any pipes.

thus, if you try to run runtests.py yourself in an interactive shell
with a tty, uftrace may try to spawn many many pagers in the course of
the test. and depending on your pager availability and configuration,
*each pager* might require interaction with the user before it will
quit.

you can, of course, use `runtests.py | cat` to avoid the whole pager
mess entirely, but this also has the effect of removing the coloring
from runtests.py output, which is extremely useful.

instead, this change adds `--no-pager` to every uftrace invocation under
tests.