### PR TITLE
doc: Update time filter option in other man pages

### DIFF
--- a/doc/uftrace-dump.md
+++ b/doc/uftrace-dump.md
@@ -41,6 +41,9 @@ OPTIONS
 -T *TRG*, \--trigger=*TRG*
 :   Set trigger on selected functions.  This option can be used more than once.  See `uftrace-replay` for triggers.
 
+-t *TIME*, \--time-filter=*TIME*
+:   Do not show small functions under the time threshold.  If some functions explicitly have 'trace' trigger, those are always traced regardless of execution time.
+
 \--tid=*TID*[,*TID*,...]
 :   Only print functions from given threads.  To see the list of threads in the data file, you can use `uftrace-report --threads` or `uftrace-info` command.
 

--- a/doc/uftrace-graph.md
+++ b/doc/uftrace-graph.md
@@ -28,6 +28,9 @@ OPTIONS
 -T *TRG*, \--trigger=*TRG*
 :   Set trigger on selected functions.  This option can be used more than once.  See `uftrace-replay` for triggers.
 
+-t *TIME*, \--time-filter=*TIME*
+:   Do not show small functions under the time threshold.  If some functions explicitly have 'trace' trigger, those are always traced regardless of execution time.
+
 \--tid=*TID*[,*TID*,...]
 :   Only print functions from given threads.  To see the list of threads in the data file, you can use `uftrace-report --threads` or `uftrace-info` command.
 

--- a/doc/uftrace-replay.md
+++ b/doc/uftrace-replay.md
@@ -31,6 +31,9 @@ OPTIONS
 -T *TRG*, \--trigger=*TRG*
 :   Set trigger on selected functions.  This option can be used more than once.  See *TRIGGERS*.
 
+-t *TIME*, \--time-filter=*TIME*
+:   Do not show small functions under the time threshold.  If some functions explicitly have 'trace' trigger, those are always traced regardless of execution time.
+
 \--tid=*TID*[,*TID*,...]
 :   Only print functions from given threads.  To see the list of threads in the data file, you can use `uftrace-report --threads` or `uftrace-info` command.
 

--- a/doc/uftrace-report.md
+++ b/doc/uftrace-report.md
@@ -52,6 +52,9 @@ OPTIONS
 -T *TRG*, \--trigger=*TRG*
 :   Set trigger on selected functions.  This option can be used more than once.  See `uftrace-replay` for triggers.
 
+-t *TIME*, \--time-filter=*TIME*
+:   Do not show small functions under the time threshold.  If some functions explicitly have 'trace' trigger, those are always traced regardless of execution time.
+
 \--tid=*TID*[,*TID*,...]
 :   Only print functions from given threads.  To see the list of threads in the data file, you can use `uftrace-report --threads` or `uftrace-info` command.
 


### PR DESCRIPTION
Since time filter is supported in replay, report, dump, and graph
commands now, their man pages have to be updated as well.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>