### PR TITLE
use "LINKFLAGS" for `ld` invocations

### DIFF
--- a/arch/arm/Makefile
+++ b/arch/arm/Makefile
@@ -1,5 +1,5 @@
 ASFLAGS = -fPIC
-LDFLAGS = -r
+LINKFLAGS = -r
 
 sdir = $(srcdir)/arch/arm
 odir = $(objdir)/arch/arm
@@ -11,7 +11,7 @@ ARCH_ENTRY_SRC = $(wildcard $(sdir)/*.S)
 all: $(odir)/entry.op
 
 $(odir)/entry.op: $(patsubst $(sdir)/%.S,$(odir)/%.op,$(ARCH_ENTRY_SRC))
-	$(QUIET_LINK)$(LD) $(LDFLAGS) -o $@ $^
+	$(QUIET_LINK)$(LD) $(LINKFLAGS) -o $@ $^
 
 $(odir)/%.op: $(sdir)/%.S
 	$(QUIET_ASM)$(CC) $(ASFLAGS) -c -o $@ $<

--- a/arch/x86_64/Makefile
+++ b/arch/x86_64/Makefile
@@ -1,5 +1,5 @@
 ASFLAGS = -fPIC
-LDFLAGS = -r
+LINKFLAGS = -r
 
 sdir = $(srcdir)/arch/x86_64
 odir = $(objdir)/arch/x86_64
@@ -11,7 +11,7 @@ ARCH_ENTRY_SRC = $(wildcard $(sdir)/*.S)
 all: $(odir)/entry.op
 
 $(odir)/entry.op: $(patsubst $(sdir)/%.S,$(odir)/%.op,$(ARCH_ENTRY_SRC))
-	$(QUIET_LINK)$(LD) $(LDFLAGS) -o $@ $^
+	$(QUIET_LINK)$(LD) $(LINKFLAGS) -o $@ $^
 
 $(odir)/%.op: $(sdir)/%.S
 	$(QUIET_ASM)$(CC) $(ASFLAGS) -c -o $@ $<


### PR DESCRIPTION
instead of "LDFLAGS", as that is supposed to be used for invocations of
gcc that are intended to call ld underneath, and not ld directly.
before this change, if a user overrode LDFLAGS for the main Makefile,
then it would also be overridden for these Makefiles as well, and would
often breaks (try, for example, `make LDFLAGS=-Wl,-z,now`).