### PR TITLE
Tweaks to build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ INSTALL = install
 
 export ARCH CC AR LD RM srcdir objdir
 
-COMMON_CFLAGS := -O2 -g -D_GNU_SOURCE $(CFLAGS)
+COMMON_CFLAGS := -O2 -g -D_GNU_SOURCE $(CFLAGS) $(CPPFLAGS)
 COMMON_CFLAGS +=  -iquote $(srcdir) -iquote $(objdir) -iquote $(srcdir)/arch/$(ARCH)
 #CFLAGS-DEBUG = -g -D_GNU_SOURCE $(CFLAGS_$@)
 COMMON_LDFLAGS := -lelf -lrt -ldl -pthread $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,14 @@ COMMON_CFLAGS += -W -Wall -Wno-unused-parameter -Wno-missing-field-initializers
 
 #
 # Note that the plain CFLAGS and LDFLAGS can be changed
-# by config/Makefile later but LIB_*FLAGS are not.
+# by config/Makefile later but *_*FLAGS can not.
 #
-UFTRACE_CFLAGS = $(COMMON_CFLAGS) $(CFLAGS_$@)
-LIB_CFLAGS = $(COMMON_CFLAGS) $(CFLAGS_$@) -fPIC -fvisibility=hidden
+UFTRACE_CFLAGS = $(COMMON_CFLAGS) $(CFLAGS_$@) $(CFLAGS_uftrace)
+TRACEEVENT_CFLAGS = $(COMMON_CFLAGS) $(CFLAGS_$@) $(CFLAGS_traceevent)
+LIB_CFLAGS = $(COMMON_CFLAGS) $(CFLAGS_$@) $(CFLAGS_lib) -fPIC -fvisibility=hidden
 
-UFTRACE_LDFLAGS = $(COMMON_LDFLAGS) $(LDFLAGS_$@)
-LIB_LDFLAGS = $(COMMON_LDFLAGS) $(LDFLAGS_$@)
+UFTRACE_LDFLAGS = $(COMMON_LDFLAGS) $(LDFLAGS_$@) $(LDFLAGS_uftrace)
+LIB_LDFLAGS = $(COMMON_LDFLAGS) $(LDFLAGS_$@) $(LDFLAGS_lib)
 
 VERSION_GIT := $(shell git describe --tags 2> /dev/null || echo v$(VERSION))
 
@@ -211,7 +212,7 @@ $(objdir)/libmcount/libmcount-fast-single.so: $(LIBMCOUNT_FAST_SINGLE_OBJS) $(ob
 	$(QUIET_LINK)$(CC) -shared -o $@ $^ $(LIB_LDFLAGS)
 
 $(objdir)/libtraceevent/libtraceevent.a: PHONY
-	@$(MAKE) -C $(srcdir)/libtraceevent BUILD_SRC=$(srcdir)/libtraceevent BUILD_OUTPUT=$(objdir)/libtraceevent
+	@$(MAKE) -C $(srcdir)/libtraceevent BUILD_SRC=$(srcdir)/libtraceevent BUILD_OUTPUT=$(objdir)/libtraceevent CONFIG_FLAGS="$(TRACEEVENT_CFLAGS)"
 
 $(objdir)/uftrace.o: $(srcdir)/uftrace.c $(objdir)/version.h $(COMMON_DEPS)
 	$(QUIET_CC)$(CC) $(UFTRACE_CFLAGS) -c -o $@ $<

--- a/arch/arm/Makefile
+++ b/arch/arm/Makefile
@@ -1,5 +1,5 @@
 ASFLAGS = -fPIC
-LDFLAGS = -r
+LINKFLAGS = -r
 
 sdir = $(srcdir)/arch/arm
 odir = $(objdir)/arch/arm
@@ -11,7 +11,7 @@ ARCH_ENTRY_SRC = $(wildcard $(sdir)/*.S)
 all: $(odir)/entry.op
 
 $(odir)/entry.op: $(patsubst $(sdir)/%.S,$(odir)/%.op,$(ARCH_ENTRY_SRC))
-	$(QUIET_LINK)$(LD) $(LDFLAGS) -o $@ $^
+	$(QUIET_LINK)$(LD) $(LINKFLAGS) -o $@ $^
 
 $(odir)/%.op: $(sdir)/%.S
 	$(QUIET_ASM)$(CC) $(ASFLAGS) -c -o $@ $<

--- a/arch/x86_64/Makefile
+++ b/arch/x86_64/Makefile
@@ -1,5 +1,5 @@
 ASFLAGS = -fPIC
-LDFLAGS = -r
+LINKFLAGS = -r
 
 sdir = $(srcdir)/arch/x86_64
 odir = $(objdir)/arch/x86_64
@@ -11,7 +11,7 @@ ARCH_ENTRY_SRC = $(wildcard $(sdir)/*.S)
 all: $(odir)/entry.op
 
 $(odir)/entry.op: $(patsubst $(sdir)/%.S,$(odir)/%.op,$(ARCH_ENTRY_SRC))
-	$(QUIET_LINK)$(LD) $(LDFLAGS) -o $@ $^
+	$(QUIET_LINK)$(LD) $(LINKFLAGS) -o $@ $^
 
 $(odir)/%.op: $(sdir)/%.S
 	$(QUIET_ASM)$(CC) $(ASFLAGS) -c -o $@ $<


### PR DESCRIPTION
Taken together, this will allow the Debian packaging to add the recommended hardening flags to the various pieces of the final result.