### PR TITLE
fstack: Initialize next_time variable for removing warning

### DIFF
--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -1041,7 +1041,7 @@ static int read_user_stack(struct ftrace_file_handle *handle,
 			   struct ftrace_task_handle **task)
 {
 	int i, next_i = -1;
-	uint64_t next_time;
+	uint64_t next_time = 0;
 	struct ftrace_ret_stack *tmp;
 
 	for (i = 0; i < handle->info.nr_tid; i++) {


### PR DESCRIPTION
When fstack.c file compiles using gcc version 4.5.2(Ubuntu/Linaro
4.5.2-8ubuntu4), uninitialized next_time variable causes warning
by calling __read_rstack function. So, init next_time variable
to 0 for removing warning.

Signed-off-by: Wangyong Choi <choiwangyong@gmail.com>