### PR TITLE
mcount: Disable 'recover' trigger in cygprof_entry

### DIFF
--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -542,6 +542,9 @@ static int cygprof_entry(unsigned long parent, unsigned long child)
 
 	filtered = mcount_entry_filter_check(mtdp, child, &tr);
 
+	/* 'recover' trigger is only for -pg entry */
+	tr.flags &= ~TRIGGER_FL_RECOVER;
+
 	rstack = &mtdp->rstack[mtdp->idx++];
 
 	/*


### PR DESCRIPTION
'recover' trigger assumes that return addresses in the current call
stack are replaced to mcount_exit by mcount_entry in binaries built with
'-pg' option.  So this patch simply disables 'recover' trigger in
cygprof_entry generated by '-finstrument-functions' option.

We may have to consider some cases when -pg and -finstrument-functions
are mixed in a single binary in the future.

Signed-off-by: Honggyu Kim <hong.gyu.kim@lge.com>