### PR TITLE
Shutting off compiler warnings from libtraceevent

### DIFF
--- a/libtraceevent/event-parse.c
+++ b/libtraceevent/event-parse.c
@@ -1548,7 +1548,7 @@ static int event_read_fields(struct event_format *event, struct format_field **f
 			else if (field->flags & FIELD_IS_LONG)
 				field->elementsize = event->pevent ?
 						     event->pevent->long_size :
-						     sizeof(long);
+						     (int)sizeof(long);
 		} else
 			field->elementsize = field->size;
 

--- a/libtraceevent/event-parse.c
+++ b/libtraceevent/event-parse.c
@@ -3301,7 +3301,7 @@ struct event_format *
 pevent_find_event_by_name(struct pevent *pevent,
 			  const char *sys, const char *name)
 {
-	struct event_format *event;
+	struct event_format *event = NULL;
 	int i;
 
 	if (pevent->last_event &&
@@ -4245,7 +4245,7 @@ static void pretty_print(struct trace_seq *s, void *data, int size, struct event
 	char format[32];
 	int show_func;
 	int len_as_arg;
-	int len_arg;
+	int len_arg = 0;
 	int len;
 	int ls;
 
@@ -4495,8 +4495,8 @@ void pevent_data_lat_fmt(struct pevent *pevent,
 	static int migrate_disable_exists;
 	unsigned int lat_flags;
 	unsigned int pc;
-	int lock_depth;
-	int migrate_disable;
+	int lock_depth = -1;
+	int migrate_disable = 0;
 	int hardirq;
 	int softirq;
 	void *data = record->data;

--- a/libtraceevent/kbuffer-parse.c
+++ b/libtraceevent/kbuffer-parse.c
@@ -611,7 +611,7 @@ unsigned long long kbuffer_timestamp(struct kbuffer *kbuf)
  * data and timestamp, and kbuffer_next_event() will increment from
  * this record.
  */
-void *kbuffer_read_at_offset(struct kbuffer *kbuf, int offset,
+void *kbuffer_read_at_offset(struct kbuffer *kbuf, unsigned offset,
 			     unsigned long long *ts)
 {
 	void *data;

--- a/libtraceevent/kbuffer-parse.c
+++ b/libtraceevent/kbuffer-parse.c
@@ -294,7 +294,7 @@ static unsigned int old_update_pointers(struct kbuffer *kbuf)
 	unsigned int type;
 	unsigned int len;
 	unsigned int delta;
-	unsigned int length;
+	unsigned int length = 0;
 	void *ptr = kbuf->data + kbuf->curr;
 
 	type_len_ts = read_4(kbuf, ptr);

--- a/libtraceevent/kbuffer.h
+++ b/libtraceevent/kbuffer.h
@@ -52,7 +52,7 @@ unsigned long long kbuffer_timestamp(struct kbuffer *kbuf);
 
 void *kbuffer_translate_data(int swap, void *data, unsigned int *size);
 
-void *kbuffer_read_at_offset(struct kbuffer *kbuf, int offset, unsigned long long *ts);
+void *kbuffer_read_at_offset(struct kbuffer *kbuf, unsigned int offset, unsigned long long *ts);
 
 int kbuffer_curr_index(struct kbuffer *kbuf);
 

--- a/libtraceevent/parse-filter.c
+++ b/libtraceevent/parse-filter.c
@@ -2108,7 +2108,8 @@ static char *op_to_str(struct event_filter *filter, struct filter_arg *arg)
 				default:
 					break;
 				}
-				asprintf(&str, val ? "TRUE" : "FALSE");
+				if (asprintf(&str, val ? "TRUE" : "FALSE") < 0)
+					return NULL;
 				break;
 			}
 		}
@@ -2126,7 +2127,8 @@ static char *op_to_str(struct event_filter *filter, struct filter_arg *arg)
 			break;
 		}
 
-		asprintf(&str, "(%s) %s (%s)", left, op, right);
+		if (asprintf(&str, "(%s) %s (%s)", left, op, right) < 0)
+			return NULL;
 		break;
 
 	case FILTER_OP_NOT:
@@ -2142,10 +2144,12 @@ static char *op_to_str(struct event_filter *filter, struct filter_arg *arg)
 			right_val = 0;
 		if (right_val >= 0) {
 			/* just return the opposite */
-			asprintf(&str, right_val ? "FALSE" : "TRUE");
+			if (asprintf(&str, right_val ? "FALSE" : "TRUE") < 0)
+				return NULL;
 			break;
 		}
-		asprintf(&str, "%s(%s)", op, right);
+		if (asprintf(&str, "%s(%s)", op, right) < 0)
+			return NULL;
 		break;
 
 	default:
@@ -2161,7 +2165,8 @@ static char *val_to_str(struct event_filter *filter, struct filter_arg *arg)
 {
 	char *str = NULL;
 
-	asprintf(&str, "%lld", arg->value.val);
+	if (asprintf(&str, "%lld", arg->value.val) < 0)
+		return NULL;
 
 	return str;
 }
@@ -2219,7 +2224,8 @@ static char *exp_to_str(struct event_filter *filter, struct filter_arg *arg)
 		break;
 	}
 
-	asprintf(&str, "%s %s %s", lstr, op, rstr);
+	if (asprintf(&str, "%s %s %s", lstr, op, rstr) < 0)
+		return NULL;
 out:
 	free(lstr);
 	free(rstr);
@@ -2263,7 +2269,8 @@ static char *num_to_str(struct event_filter *filter, struct filter_arg *arg)
 		if (!op)
 			op = "<=";
 
-		asprintf(&str, "%s %s %s", lstr, op, rstr);
+		if (asprintf(&str, "%s %s %s", lstr, op, rstr) < 0)
+			return NULL;
 		break;
 
 	default:
@@ -2298,8 +2305,9 @@ static char *str_to_str(struct event_filter *filter, struct filter_arg *arg)
 		if (!op)
 			op = "!~";
 
-		asprintf(&str, "%s %s \"%s\"",
-			 arg->str.field->name, op, arg->str.val);
+		if (asprintf(&str, "%s %s \"%s\"",
+			 arg->str.field->name, op, arg->str.val) < 0)
+			return NULL;
 		break;
 
 	default:
@@ -2315,7 +2323,8 @@ static char *arg_to_str(struct event_filter *filter, struct filter_arg *arg)
 
 	switch (arg->type) {
 	case FILTER_ARG_BOOLEAN:
-		asprintf(&str, arg->boolean.value ? "TRUE" : "FALSE");
+		if (asprintf(&str, arg->boolean.value ? "TRUE" : "FALSE") < 0)
+			return NULL;
 		return str;
 
 	case FILTER_ARG_OP:

--- a/libtraceevent/parse-filter.c
+++ b/libtraceevent/parse-filter.c
@@ -43,8 +43,8 @@ static void show_error(char *error_buf, const char *fmt, ...)
 	unsigned long long index;
 	const char *input;
 	va_list ap;
-	int len;
-	int i;
+	unsigned len;
+	unsigned i;
 
 	input = pevent_get_input_buf();
 	index = pevent_get_input_buf_ptr();

--- a/libtraceevent/trace-seq.c
+++ b/libtraceevent/trace-seq.c
@@ -192,7 +192,7 @@ trace_seq_vprintf(struct trace_seq *s, const char *fmt, va_list args)
  */
 int trace_seq_puts(struct trace_seq *s, const char *str)
 {
-	int len;
+	size_t len;
 
 	TRACE_SEQ_CHECK_RET0(s);
 


### PR DESCRIPTION
This removes below compiler warnings:
  1. ignoring return value [-Wunused-result]
  2. may be used uninitialized [-Wmaybe-uninitialized]
  3. comparison between signed and unsigned integer expressions [-Wsign-compare]
  4. signed and unsigned type in conditional expression [-Wsign-compare]