### PR TITLE
kernel: Honor --kernel-only for replay and graph

### DIFF
--- a/cmd-graph.c
+++ b/cmd-graph.c
@@ -395,6 +395,11 @@ static int build_graph(struct opts *opts, struct ftrace_file_handle *handle,
 		struct sym *sym = NULL;
 		char *name;
 
+		if (opts->kernel_only && !task->is_kernel) {
+			/* skip user functions if --kernel-only is set */
+			continue;
+		}
+
 		if (opts->kernel_skip_out) {
 			/* skip kernel functions outside user functions */
 			if (!task->user_stack_count &&

--- a/cmd-replay.c
+++ b/cmd-replay.c
@@ -572,6 +572,11 @@ int command_replay(int argc, char *argv[], struct opts *opts)
 	while (read_rstack(&handle, &task) == 0 && !ftrace_done) {
 		uint64_t curr_time = task->rstack->time;
 
+		if (opts->kernel_only && !task->is_kernel) {
+			/* skip user functions if --kernel-only is set */
+			continue;
+		}
+
 		/*
 		 * data sanity check: timestamp should be ordered.
 		 * But print_graph_rstack() may change task->rstack

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -1310,11 +1310,13 @@ retry:
 user:
 		utask->rstack = &utask->ustack;
 		task = utask;
+		task->is_kernel = false;
 	}
 	else {
 kernel:
 		ktask->rstack = &ktask->kstack;
 		task = ktask;
+		task->is_kernel = true;
 
 		if (kernel->missed_events[k]) {
 			static struct ftrace_ret_stack lost_rstack;

--- a/utils/fstack.h
+++ b/utils/fstack.h
@@ -45,6 +45,7 @@ struct ftrace_task_handle {
 	int user_display_depth;
 	int column_index;
 	enum context ctx;
+	bool is_kernel;
 	struct filter {
 		int	in_count;
 		int	out_count;


### PR DESCRIPTION
The --kernel-only option was used only to dump kernel functions only.
It can be useful for replay and graph commands as well especially in
some systems that do not exactly match between kernel and user
timestamps.

In that case, we can only see kernel functions by ignoring user funtions
so that timestamps of user functions cannot confuse kernel function
record.

Signed-off-by: Honggyu Kim <hong.gyu.kim@lge.com>