### PR TITLE
Enable --kernel-only for replay, report, and graph

### DIFF
--- a/cmd-graph.c
+++ b/cmd-graph.c
@@ -395,6 +395,10 @@ static int build_graph(struct opts *opts, struct ftrace_file_handle *handle,
 		struct sym *sym = NULL;
 		char *name;
 
+		/* skip user functions if --kernel-only is set */
+		if (opts->kernel_only && !is_kernel_address(frs->addr))
+			continue;
+
 		if (opts->kernel_skip_out) {
 			/* skip kernel functions outside user functions */
 			if (!task->user_stack_count &&

--- a/cmd-replay.c
+++ b/cmd-replay.c
@@ -570,10 +570,11 @@ int command_replay(int argc, char *argv[], struct opts *opts)
 		pr_out("# DURATION    TID     FUNCTION\n");
 
 	while (read_rstack(&handle, &task) == 0 && !ftrace_done) {
-		uint64_t curr_time = task->rstack->time;
+		struct ftrace_ret_stack *rstack = task->rstack;
+		uint64_t curr_time = rstack->time;
 
 		/* skip user functions if --kernel-only is set */
-		if (opts->kernel_only && !is_kernel_address(task->rstack->addr))
+		if (opts->kernel_only && !is_kernel_address(rstack->addr))
 			continue;
 
 		/*
@@ -584,7 +585,7 @@ int command_replay(int argc, char *argv[], struct opts *opts)
 		if (curr_time) {
 			if (prev_time > curr_time)
 				print_warning(task);
-			prev_time = task->rstack->time;
+			prev_time = rstack->time;
 		}
 
 		if (opts->flat)

--- a/cmd-replay.c
+++ b/cmd-replay.c
@@ -572,6 +572,10 @@ int command_replay(int argc, char *argv[], struct opts *opts)
 	while (read_rstack(&handle, &task) == 0 && !ftrace_done) {
 		uint64_t curr_time = task->rstack->time;
 
+		/* skip user functions if --kernel-only is set */
+		if (opts->kernel_only && !is_kernel_address(task->rstack->addr))
+			continue;
+
 		/*
 		 * data sanity check: timestamp should be ordered.
 		 * But print_graph_rstack() may change task->rstack

--- a/cmd-report.c
+++ b/cmd-report.c
@@ -125,6 +125,10 @@ static void build_function_tree(struct ftrace_file_handle *handle,
 		if (rstack->type != FTRACE_EXIT)
 			continue;
 
+		/* skip user functions if --kernel-only is set */
+		if (opts->kernel_only && !is_kernel_address(rstack->addr))
+			continue;
+
 		if (opts->kernel_skip_out) {
 			/* skip kernel functions outside user functions */
 			if (is_kernel_address(task->func_stack[0].addr) &&
@@ -571,6 +575,10 @@ static void report_threads(struct ftrace_file_handle *handle, struct opts *opts)
 		if (rstack->type == FTRACE_ENTRY && task->func)
 			continue;
 		if (rstack->type == FTRACE_LOST)
+			continue;
+
+		/* skip user functions if --kernel-only is set */
+		if (opts->kernel_only && !is_kernel_address(rstack->addr))
 			continue;
 
 		if (opts->kernel_skip_out) {

--- a/doc/uftrace-dump.md
+++ b/doc/uftrace-dump.md
@@ -30,7 +30,7 @@ OPTIONS
 :   Dump kernel functions as well as user functions.
 
 \--kernel-only
-:   Dump kernel functions only.  Implies `--kernel`.
+:   Dump kernel functions only without user functions.  Implies `--kernel`.
 
 -F *FUNC*, \--filter=*FUNC*
 :   Set filter to trace selected functions only.  This option can be used more than once.  See `uftrace-replay`(1) for an explanation of filters.

--- a/doc/uftrace-graph.md
+++ b/doc/uftrace-graph.md
@@ -49,6 +49,9 @@ OPTIONS
 \--kernel-skip-out
 :   Do not show kernel functions called outside of user functions.  This option is deprecated and set to true by default.
 
+\--kernel-only
+:   Show kernel functions only without user functions.  Implies `--kernel`.
+
 
 EXAMPLES
 ========

--- a/doc/uftrace-graph.md
+++ b/doc/uftrace-graph.md
@@ -40,6 +40,15 @@ OPTIONS
 --max-stack=*DEPTH*
 :   Allocate internal graph structure up to *DEPTH*.
 
+-k, \--kernel
+:   Trace kernel functions as well as user functions.
+
+\--kernel-full
+:   Show all kernel functions called outside of user functions.  This option is the inverse of `--kernel-skip-out`.  Implies `--kernel`.
+
+\--kernel-skip-out
+:   Do not show kernel functions called outside of user functions.  This option is deprecated and set to true by default.
+
 
 EXAMPLES
 ========

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -106,6 +106,9 @@ OPTIONS
 \--kernel-full
 :   Show all kernel functions called outside of user functions.  This option is the inverse of `--kernel-skip-out`.  Implies `--kernel`.
 
+\--kernel-only
+:   Show kernel functions only without user functions.  Implies `--kernel`.
+
 
 FILTERS
 =======

--- a/doc/uftrace-replay.md
+++ b/doc/uftrace-replay.md
@@ -64,6 +64,9 @@ OPTIONS
 \--kernel-skip-out
 :   Do not show kernel functions called outside of user functions.  This option is deprecated and set to true by default.
 
+\--kernel-only
+:   Show kernel functions only without user functions.  Implies `--kernel`.
+
 
 FILTERS
 =======

--- a/doc/uftrace-report.md
+++ b/doc/uftrace-report.md
@@ -43,6 +43,9 @@ OPTIONS
 --kernel-full
 :   Show all kernel functions, including those called outside of user functions.
 
+\--kernel-only
+:   Show kernel functions only without user functions.  Implies `--kernel`.
+
 -F *FUNC*, \--filter=*FUNC*
 :   Set filter to trace selected functions only.  This option can be used more than once.  See `uftrace-replay`(1) for an explanation of filters.
 


### PR DESCRIPTION
This branch enables --kernel-only option not only for dump command but also for replay, report, and graph commands.