### PR TITLE
tests: run record sub-processes with --no-pager

### DIFF
--- a/tests/t023_replay_filter.py
+++ b/tests/t023_replay_filter.py
@@ -22,7 +22,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-allocfree')
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-allocfree')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t024_report_basic.py
+++ b/tests/t024_report_basic.py
@@ -20,7 +20,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t025_report_s_call.py
+++ b/tests/t025_report_s_call.py
@@ -20,7 +20,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-sort')
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-sort')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t027_replay_filter_d.py
+++ b/tests/t027_replay_filter_d.py
@@ -30,7 +30,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-allocfree')
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-allocfree')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t028_replay_backtrace.py
+++ b/tests/t028_replay_backtrace.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-allocfree')
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-allocfree')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t030_replay_trigger.py
+++ b/tests/t030_replay_trigger.py
@@ -22,7 +22,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-allocfree')
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-allocfree')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t036_replay_filter_N.py
+++ b/tests/t036_replay_filter_N.py
@@ -27,7 +27,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-namespace')
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-namespace')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t040_replay_onoff.py
+++ b/tests/t040_replay_onoff.py
@@ -24,7 +24,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-namespace')
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-namespace')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t041_replay_onoff_N.py
+++ b/tests/t041_replay_onoff_N.py
@@ -23,7 +23,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-namespace')
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-namespace')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t044_report_avg_total.py
+++ b/tests/t044_report_avg_total.py
@@ -20,7 +20,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-sort')
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-sort')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t045_report_avg_self.py
+++ b/tests/t045_report_avg_self.py
@@ -20,7 +20,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-sort')
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-sort')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t046_report_threads.py
+++ b/tests/t046_report_threads.py
@@ -18,7 +18,7 @@ class TestCase(TestBase):
 """, ldflags='-pthread')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-thread-name')
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-thread-name')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t067_report_diff.py
+++ b/tests/t067_report_diff.py
@@ -24,9 +24,9 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, XDIR, 't-abc')
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, XDIR, 't-abc')
         sp.call(record_cmd.split())
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, YDIR, 't-abc')
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, YDIR, 't-abc')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t069_graph.py
+++ b/tests/t069_graph.py
@@ -29,7 +29,7 @@ calling functions
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t070_graph_backtrace.py
+++ b/tests/t070_graph_backtrace.py
@@ -28,7 +28,7 @@ calling functions
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-abc')
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-abc')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t071_graph_depth.py
+++ b/tests/t071_graph_depth.py
@@ -45,7 +45,7 @@ calling functions
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-namespace')
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-namespace')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t076_lib_replay_F.py
+++ b/tests/t076_lib_replay_F.py
@@ -63,7 +63,7 @@ class TestCase(TestBase):
         return '\n'.join(result)
 
     def pre(self):
-        record_cmd = '%s record --force -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record --force -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t077_lib_replay_T.py
+++ b/tests/t077_lib_replay_T.py
@@ -63,7 +63,7 @@ class TestCase(TestBase):
         return '\n'.join(result)
 
     def pre(self):
-        record_cmd = '%s record --force --no-libcall -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record --force --no-libcall -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t079_replay_kernel_D.py
+++ b/tests/t079_replay_kernel_D.py
@@ -29,7 +29,7 @@ class TestCase(TestBase):
         if os.path.exists('/.dockerenv'):
             return TestBase.TEST_SKIP
 
-        record_cmd = '%s record -K3 -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -K3 -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t080_replay_kernel_D2.py
+++ b/tests/t080_replay_kernel_D2.py
@@ -25,7 +25,7 @@ class TestCase(TestBase):
         if os.path.exists('/.dockerenv'):
             return TestBase.TEST_SKIP
 
-        record_cmd = '%s record -K3 -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -K3 -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t088_graph_session.py
+++ b/tests/t088_graph_session.py
@@ -54,7 +54,7 @@ calling functions
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t089_graph_exit.py
+++ b/tests/t089_graph_exit.py
@@ -26,7 +26,7 @@ calling functions
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t090_report_recursive.py
+++ b/tests/t090_report_recursive.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t091_replay_tid.py
+++ b/tests/t091_replay_tid.py
@@ -23,7 +23,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t092_report_tid.py
+++ b/tests/t092_report_tid.py
@@ -22,7 +22,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t093_report_filter.py
+++ b/tests/t093_report_filter.py
@@ -18,7 +18,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t094_report_depth.py
+++ b/tests/t094_report_depth.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t095_graph_tid.py
+++ b/tests/t095_graph_tid.py
@@ -28,7 +28,7 @@ calling functions
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t096_graph_filter.py
+++ b/tests/t096_graph_filter.py
@@ -27,7 +27,7 @@ calling functions
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t097_dump_basic.py
+++ b/tests/t097_dump_basic.py
@@ -34,7 +34,7 @@ reading 5231.dat
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t098_dump_tid.py
+++ b/tests/t098_dump_tid.py
@@ -35,7 +35,7 @@ reading 5188.dat
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t099_dump_filter.py
+++ b/tests/t099_dump_filter.py
@@ -26,7 +26,7 @@ reading 5231.dat
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t100_dump_depth.py
+++ b/tests/t100_dump_depth.py
@@ -26,7 +26,7 @@ reading 5231.dat
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t101_dump_chrome.py
+++ b/tests/t101_dump_chrome.py
@@ -24,7 +24,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t102_dump_flamegraph.py
+++ b/tests/t102_dump_flamegraph.py
@@ -15,7 +15,7 @@ main;a;b;c 1
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t103_dump_kernel.py
+++ b/tests/t103_dump_kernel.py
@@ -54,7 +54,7 @@ class TestCase(TestBase):
         if os.path.exists('/.dockerenv'):
             return TestBase.TEST_SKIP
 
-        record_cmd = '%s record -k -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -k -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t104_graph_kernel.py
+++ b/tests/t104_graph_kernel.py
@@ -52,7 +52,7 @@ calling functions
         if os.path.exists('/.dockerenv'):
             return TestBase.TEST_SKIP
 
-        record_cmd = '%s record -k -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -k -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t105_replay_time.py
+++ b/tests/t105_replay_time.py
@@ -19,7 +19,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t106_report_time.py
+++ b/tests/t106_report_time.py
@@ -17,7 +17,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t107_dump_time.py
+++ b/tests/t107_dump_time.py
@@ -24,7 +24,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t108_graph_time.py
+++ b/tests/t108_graph_time.py
@@ -28,7 +28,7 @@ calling functions
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t109_replay_time_A.py
+++ b/tests/t109_replay_time_A.py
@@ -24,7 +24,7 @@ class TestCase(TestBase):
         return TestBase.build(self, cflags, ldflags)
 
     def pre(self):
-        record_cmd = "%s record -A %s -A %s -R %s -d %s %s" % \
+        record_cmd = "%s --no-pager record -A %s -A %s -R %s -d %s %s" % \
                      (TestBase.ftrace, 'main@arg1', '(malloc|free|usleep)@plt,arg1', \
                       'malloc@retval', TDIR, 't-' + self.name)
         sp.call(record_cmd.split())

--- a/tests/t110_replay_time_T.py
+++ b/tests/t110_replay_time_T.py
@@ -22,7 +22,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = "%s record -d %s %s" % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = "%s --no-pager record -d %s %s" % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t111_kernel_tid.py
+++ b/tests/t111_kernel_tid.py
@@ -43,7 +43,7 @@ class TestCase(TestBase):
         if os.path.exists('/.dockerenv'):
             return TestBase.TEST_SKIP
 
-        record_cmd = '%s record -k -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -k -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t112_replay_skip.py
+++ b/tests/t112_replay_skip.py
@@ -22,7 +22,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = "%s record -d %s %s" % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = "%s --no-pager record -d %s %s" % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t114_replay_trg_time.py
+++ b/tests/t114_replay_trg_time.py
@@ -22,7 +22,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t115_replay_field.py
+++ b/tests/t115_replay_field.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s --no-pager record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 


### PR DESCRIPTION
Prevent opening a pager during `make test` runs.

This patch allows me to add a `%check` section to a RPM spec file that I am preparing for inclusion in Fedora. Without it, rpmbuild, or a script it runs, will halt with a pager (usually `/usr/bin/less` or something) open during test execution and thus making the build fail.