### PR TITLE
uftrace: Fix --tid option usage

### DIFF
--- a/doc/uftrace-dump.md
+++ b/doc/uftrace-dump.md
@@ -45,7 +45,7 @@ OPTIONS
 :   Do not show functions which run under the time threshold.  If some functions explicitly have the 'trace' trigger applied, those are always traced regardless of execution time.
 
 \--tid=*TID*[,*TID*,...]
-:   Only print functions called by the given threads.  To see the list of threads in the data file, you can use `uftrace report --threads` or `uftrace info`.
+:   Only print functions called by the given threads.  To see the list of threads in the data file, you can use `uftrace report --threads` or `uftrace info`.  This option can also be used more than once.
 
 -D *DEPTH*, \--depth *DEPTH*
 :   Set trace limit in nesting level.

--- a/doc/uftrace-graph.md
+++ b/doc/uftrace-graph.md
@@ -32,7 +32,7 @@ OPTIONS
 :   Do not show functions which run under the time threshold.  If some functions explicitly have the 'trace' trigger applied, those are always traced regardless of execution time.
 
 \--tid=*TID*[,*TID*,...]
-:   Only print functions called by the given threads.  To see the list of threads in the data file, you can use `uftrace report --threads` or `uftrace info`.
+:   Only print functions called by the given threads.  To see the list of threads in the data file, you can use `uftrace report --threads` or `uftrace info`.  This option can also be used more than once.
 
 -D *DEPTH*, \--depth *DEPTH*
 :   Set trace limit in nesting level.

--- a/doc/uftrace-replay.md
+++ b/doc/uftrace-replay.md
@@ -35,7 +35,7 @@ OPTIONS
 :   Do not show functions which run under the time threshold.  If some functions explicitly have the 'trace' trigger applied, those are always traced regardless of execution time.
 
 \--tid=*TID*[,*TID*,...]
-:   Only print functions called by the given threads.  To see the list of threads in the data file, you can use `uftrace report --threads` or `uftrace info`.
+:   Only print functions called by the given threads.  To see the list of threads in the data file, you can use `uftrace report --threads` or `uftrace info`.  This option can also be used more than once.
 
 -D *DEPTH*, \--depth *DEPTH*
 :   Set trace limit in nesting level.

--- a/doc/uftrace-report.md
+++ b/doc/uftrace-report.md
@@ -59,7 +59,7 @@ OPTIONS
 :   Do not account functions which run under the time threshold.  If some functions explicitly have the 'trace' trigger applied, those are always accounted regardless of execution time.
 
 \--tid=*TID*[,*TID*,...]
-:   Only print functions called by the given threads.  To see the list of threads in the data file, you can use `uftrace report --threads` or `uftrace info`.
+:   Only print functions called by the given threads.  To see the list of threads in the data file, you can use `uftrace report --threads` or `uftrace info`.  This option can also be used more than once.
 
 -D *DEPTH*, \--depth *DEPTH*
 :   Set trace limit in nesting level.

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -136,7 +136,7 @@ void setup_task_filter(char *tid_filter, struct ftrace_file_handle *handle)
 	do {
 		int id;
 
-		if (*p == ',' || *p == ':')
+		if (*p == ',' || *p == ';')
 			p++;
 
 		id = strtol(p, &p, 10);


### PR DESCRIPTION
--tid option provides flexible usages such as the following ways:

  $ uftrace replay --tid 1000,1004
      or
  $ uftrace replay --tid 1000 --tid 1004

But having --tid option more than twice does not work due to parsing
error so this patch fixes it and updates the man pages as well.

Suggested-by: Namhyung Kim <namhyung@gmail.com>
Signed-off-by: Honggyu Kim <hong.gyu.kim@lge.com>