### PR TITLE
build: Fix a permission problem in configure

### DIFF
--- a/check-deps/Makefile
+++ b/check-deps/Makefile
@@ -21,6 +21,7 @@ $(CHECK_LIST): %: __%.c
 
 check-tstamp: PHONY
 	@touch $@
+	@if [ `id -u` -eq 0 ]; then chmod 666 $@; fi
 
 check-clean:
 	@$(RM) $(CHECK_LIST) check-tstamp *.o

--- a/configure
+++ b/configure
@@ -99,6 +99,9 @@ echo override LDFLAGS = $LDFLAGS >> $output
 echo                             >> $output
 echo override srcdir := $srcdir  >> $output
 echo override objdir := $objdir  >> $output
+if [ $(id -u) -eq 0 ]; then
+    chmod 666 $output
+fi
 
 if [ "$srcdir" != "$objdir" ]; then
     cat > $objdir/Makefile <<EOF
@@ -129,4 +132,7 @@ test: all
 
 .PHONY: all clean prepare test install
 EOF
+    if [ $(id -u) -eq 0 ]; then
+        chmod 666 $objdir/Makefile
+    fi
 fi


### PR DESCRIPTION
The current 'make clean' does not clean up the timestamp files that are
generated during 'configure' executed to prevent the permission problems
such as the following example.

  $ sudo ./configure

  $ ./configure --prefix=$HOME/usr
  touch: cannot touch 'check-tstamp': Permission denied

  $ sudo make clean
      ...

  $ ./configure --prefix=$HOME/usr
  touch: cannot touch 'check-tstamp': Permission denied

Signed-off-by: Honggyu Kim <hong.gyu.kim@lge.com>