### PR TITLE
session: Save sessions per pid instead of tid

### DIFF
--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -133,9 +133,34 @@ int read_task_txt_file(char *dirname, bool needs_session, bool sym_rel_addr)
 			if (!needs_session)
 				continue;
 
-			sscanf(line + 5, "timestamp=%lu.%lu tid=%d sid=%s",
-			       &sec, &nsec, &sess.task.tid, (char *)&sess.sid);
+			sscanf(line + 5, "timestamp=%lu.%lu",
+				   &sec, &nsec);
 
+			// Get the session ID
+			pos = strstr(line, "sid=");
+			if (pos == NULL)
+				pr_err_ns("invalid task.txt format");
+			sscanf(pos, "sid=%s",
+				   (char *)&sess.sid);
+
+			// Get the pid or tid
+			pos = strstr(line, "pid=");
+			if (pos != NULL) {
+				sscanf(pos, "pid=%d",
+					   &sess.task.pid);
+				sess.task.tid = sess.task.pid;
+			}
+			else {
+				// Fallback if the pid is not present, it might be the tid
+				pos = strstr(line, "tid=");
+				if (pos == NULL)
+					pr_err_ns("invalid pid or tid format");
+				sscanf(pos, "tid=%d",
+					   &sess.task.tid);
+				sess.task.pid = sess.task.tid;
+			}
+
+			// Get the execname
 			pos = strstr(line, "exename=");
 			if (pos == NULL)
 				pr_err_ns("invalid task.txt format");
@@ -144,7 +169,6 @@ int read_task_txt_file(char *dirname, bool needs_session, bool sym_rel_addr)
 			if (pos)
 				*pos = '\0';
 
-			sess.task.pid = sess.task.tid;
 			sess.task.time = (uint64_t)sec * NSEC_PER_SEC + nsec;
 			sess.namelen = strlen(exename);
 
@@ -217,8 +241,8 @@ void write_session_info(const char *dirname, struct ftrace_msg_sess *smsg,
 		pr_err("cannot open %s", fname);
 
 	snprint_timestamp(ts, sizeof(ts), smsg->task.time);
-	fprintf(fp, "SESS timestamp=%s tid=%d sid=%s exename=\"%s\"\n",
-		ts, smsg->task.tid, smsg->sid, exename);
+	fprintf(fp, "SESS timestamp=%s pid=%d sid=%s exename=\"%s\"\n",
+		ts, smsg->task.pid, smsg->sid, exename);
 
 	fclose(fp);
 	free(fname);


### PR DESCRIPTION
Prevents issue #40 from happening in the future, where a task does not have
a session because the session is identified by tid instead of pid.

Signed-off-by: Geneviève Bastien <gbastien@versatic.net>