### PR TITLE
session: Save sessions per pid instead of tid v2

### DIFF
--- a/tests/t129_session_tid.py
+++ b/tests/t129_session_tid.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+import subprocess as sp
+
+TDIR='xxx'
+
+# Test that task.txt files with a tid in the SESS line still work
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'abc', """
+# DURATION    TID     FUNCTION
+  62.202 us [28141] | __cxa_atexit();
+            [28141] | main() {
+            [28141] |   a() {
+            [28141] |     b() {
+            [28141] |       c() {
+   0.753 us [28141] |         getpid();
+   1.430 us [28141] |       } /* c */
+   1.915 us [28141] |     } /* b */
+   2.405 us [28141] |   } /* a */
+   3.005 us [28141] | } /* main */
+""")
+
+    def build(self, name, cflags='', ldflags=''):
+        ret  = TestBase.build(self, 'abc', cflags, ldflags)
+        return ret
+        
+    def pre(self):
+        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-abc')
+        sp.call(record_cmd.split())
+        # Replace pid by tid on the SESS line to test backward-compatibility
+        sed_cmd = 'sed -i "/SESS/s/pid/tid/g" %s/task.txt' % (TDIR)
+        sp.call(sed_cmd, shell=True)
+        return TestBase.TEST_SUCCESS
+
+    def runcmd(self):
+        return '%s replay -d %s' % (TestBase.ftrace, TDIR)
+
+    def post(self, ret):
+        sp.call(['rm', '-rf', TDIR])
+        return ret
+        

--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -133,9 +133,10 @@ int read_task_txt_file(char *dirname, bool needs_session, bool sym_rel_addr)
 			if (!needs_session)
 				continue;
 
-			sscanf(line + 5, "timestamp=%lu.%lu tid=%d sid=%s",
-			       &sec, &nsec, &sess.task.tid, (char *)&sess.sid);
+			sscanf(line + 5, "timestamp=%lu.%lu %*[^i]id=%d sid=%s",
+			       &sec, &nsec, &sess.task.pid, (char *)&sess.sid);
 
+			// Get the execname
 			pos = strstr(line, "exename=");
 			if (pos == NULL)
 				pr_err_ns("invalid task.txt format");
@@ -144,7 +145,7 @@ int read_task_txt_file(char *dirname, bool needs_session, bool sym_rel_addr)
 			if (pos)
 				*pos = '\0';
 
-			sess.task.pid = sess.task.tid;
+			sess.task.tid = sess.task.pid;
 			sess.task.time = (uint64_t)sec * NSEC_PER_SEC + nsec;
 			sess.namelen = strlen(exename);
 
@@ -217,8 +218,8 @@ void write_session_info(const char *dirname, struct ftrace_msg_sess *smsg,
 		pr_err("cannot open %s", fname);
 
 	snprint_timestamp(ts, sizeof(ts), smsg->task.time);
-	fprintf(fp, "SESS timestamp=%s tid=%d sid=%s exename=\"%s\"\n",
-		ts, smsg->task.tid, smsg->sid, exename);
+	fprintf(fp, "SESS timestamp=%s pid=%d sid=%s exename=\"%s\"\n",
+	        ts, smsg->task.pid, smsg->sid, exename);
 
 	fclose(fp);
 	free(fname);


### PR DESCRIPTION
Prevents issue #40 from happening in the future, where a task does not have
a session because the session is identified by tid instead of pid.