### PR TITLE
ftrace: Change warning msg color from red to yellow

### DIFF
--- a/utils/debug.c
+++ b/utils/debug.c
@@ -145,7 +145,7 @@ void __pr_warn(const char *fmt, ...)
 {
 	va_list ap;
 
-	color(TERM_COLOR_RED, logfp);
+	color(TERM_COLOR_YELLOW, logfp);
 
 	va_start(ap, fmt);
 	vfprintf(logfp, fmt, ap);

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -122,7 +122,7 @@ extern void setup_signal(void);
 	__pr_err(PR_FMT ": %s:%d:%s\n ERROR: " fmt,		\
 		 __FILE__, __LINE__, __func__, ## __VA_ARGS__)
 
-#define pr_warn(fmt, ...)	__pr_warn(fmt, ## __VA_ARGS__)
+#define pr_warn(fmt, ...)	__pr_warn("WARN: " fmt, ## __VA_ARGS__)
 
 #define pr_cont(fmt, ...)	__pr_log(fmt, ## __VA_ARGS__)
 #define pr_out(fmt, ...)	__pr_out(fmt, ## __VA_ARGS__)


### PR DESCRIPTION
Currently not only __pr_err but also __pr_warn
use red color. So I suggest changing to yellow color.
And I think it is better to add a prefix "WARN:" such as pr_err

Signed-off-by: Taeung Song <treeze.taeung@gmail.com>