### PR TITLE
info: Skip a case of missing task file

### DIFF
--- a/cmd-info.c
+++ b/cmd-info.c
@@ -764,9 +764,7 @@ int command_info(int argc, char *argv[], struct opts *opts)
 	struct ftrace_file_handle handle;
 	const char *fmt = "# %-20s: %s\n";
 
-	ret = open_data_file(opts, &handle);
-	if (ret < 0)
-		return -1;
+	open_data_file(opts, &handle);
 
 	snprintf(buf, sizeof(buf), "%s/info", opts->dirname);
 

--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -356,7 +356,7 @@ retry:
 		// read task.txt first and then try old task file
 		if (read_task_txt_file(opts->dirname, true, sym_rel) < 0 &&
 		    read_task_file(opts->dirname, true, sym_rel) < 0)
-			pr_err("invalid task file");
+			pr_warn("invalid task file\n");
 	}
 
 	if (handle->hdr.feat_mask & (ARGUMENT | RETVAL))


### PR DESCRIPTION
Even though a task file is missing, uftrace info
should work regardless of it.

Signed-off-by: Taeung Song <treeze.taeung@gmail.com>