### PR TITLE
record: Allow a float value for time filter

### DIFF
--- a/tests/t122_time_range2.py
+++ b/tests/t122_time_range2.py
@@ -9,13 +9,13 @@ START=0
 class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'abc', """
-#     TIMESTAMP       FUNCTION
-    74469.340765344 |       c() {
-    74469.340765524 |         getpid();
-    74469.340766935 |       } /* c */
-    74469.340767195 |     } /* b */
-    74469.340767372 |   } /* a */
-    74469.340767541 | } /* main */
+#  ELAPSED    FUNCTION
+   4.343 us |       c() {
+   4.447 us |         getpid();
+   5.137 us |       } /* c */
+   5.436 us |     } /* b */
+   5.544 us |   } /* a */
+   5.626 us | } /* main */
 """, sort='simple')
 
     def pre(self):
@@ -28,14 +28,14 @@ class TestCase(TestBase):
         replay_cmd = '%s replay -d %s -f elapsed -F main' % (TestBase.ftrace, TDIR)
         p = sp.Popen(replay_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
         r = p.communicate()[0].decode()
-        START = r.split('\n')[4].split()[0] # skip header, main, a and b (= 4)
-        START = int(float(START) * 1000)
+        START, unit = r.split('\n')[4].split()[0:2] # skip header, main, a and b (= 4)
+        START += unit
         p.wait()
 
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -f elapsed -r +%s~ -d %s' % (TestBase.ftrace, START, TDIR)
+        return '%s replay -f elapsed -r %s~ -d %s' % (TestBase.ftrace, START, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/uftrace.c
+++ b/uftrace.c
@@ -397,8 +397,8 @@ static bool has_time_unit(const char *str)
 
 static uint64_t parse_timestamp(char *str, bool *elapsed)
 {
-	uint64_t sec, nsec = 0;
-	char *pos = NULL;
+	char *time;
+	uint64_t nsec;
 
 	if (*str == '\0')
 		return 0;
@@ -408,29 +408,11 @@ static uint64_t parse_timestamp(char *str, bool *elapsed)
 		return parse_time(str, 3);
 	}
 
-	sec = strtoull(str, &pos, 10);
-	if (*pos != '.' && *pos != '\0') {
-		pr_use("invalid timestamp string\n");
+	if (asprintf(&time, "%ssec", str) < 0)
 		return -1;
-	}
-
-	if (*pos == '.')
-		pos++;
-
-	if (strlen(pos)) {
-		int i, n = strlen(pos);
-
-		if (n > 9) {
-			pr_use("invalid timestamp string\n");
-			return -2;
-		}
-
-		nsec = strtoul(pos, NULL, 10);
-		for (i = n; i < 9; i++)
-			nsec *= 10;
-	}
-
-	return sec * NSEC_PER_SEC + nsec;
+	nsec = parse_time(time, 9);
+	free(time);
+	return nsec;
 }
 
 static bool parse_time_range(struct uftrace_time_range *range, char *arg)

--- a/uftrace.c
+++ b/uftrace.c
@@ -304,6 +304,32 @@ static int get_digits(uint64_t num)
 	return digits;
 }
 
+static uint64_t parse_min(uint64_t min, uint64_t decimal, int decimal_places)
+{
+	uint64_t nsec = min * 60 * NSEC_PER_SEC;
+
+	if (decimal) {
+		decimal_places += get_digits(decimal);
+		decimal *= 6;
+
+		/* decide a unit from the number of decimal places */
+		switch (decimal_places) {
+		case 1:
+			nsec += decimal * NSEC_PER_SEC;
+			break;
+		case 2:
+			decimal *= 10;
+		case 3:
+			decimal *= 10;
+			nsec += decimal * NSEC_PER_MSEC;
+			break;
+		default:
+			break;
+		}
+	}
+	return nsec;
+}
+
 static uint64_t parse_time(char *arg, int limited_digits)
 {
 	char *unit, *pos;
@@ -343,6 +369,8 @@ static uint64_t parse_time(char *arg, int limited_digits)
 		exp = 6; /* 10^6 */
 	else if (!strcasecmp(unit, "s") || !strcasecmp(unit, "sec"))
 		exp = 9; /* 10^9 */
+	else if (!strcasecmp(unit, "m") || !strcasecmp(unit, "min"))
+		return parse_min(val, decimal, decimal_places);
 	else
 		pr_warn("The unit '%s' isn't supported\n", unit);
 

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -37,6 +37,7 @@
 #define unlikely(x)  __builtin_expect(!!(x), 0)
 
 #define NSEC_PER_SEC  1000000000
+#define NSEC_PER_MSEC 1000000
 
 extern int debug;
 extern FILE *logfp;


### PR DESCRIPTION
We can use --time-filter or -t option
to filter functions by time as below.

    $ uftrace -t 1us ./a.out

But currently we can't use a float value for the threshold
because uftrace only handle the value as uint64_t type.
So fix codes to enable the user to use a float value for it e.g.

    $ uftrace -t 0.3us ./a.out

Signed-off-by: Taeung Song <treeze.taeung@gmail.com>