### PR TITLE
uftrace: Supplement help message for a time-range option

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -140,7 +140,7 @@ static struct argp_option ftrace_options[] = {
 	{ "flame-graph", OPT_flame_graph, 0, 0, "Dump recorded data in FlameGraph format" },
 	{ "sample-time", OPT_sample_time, "TIME", 0, "Show flame graph with this sampliing time" },
 	{ "output-fields", 'f', "FIELD", 0, "Show FIELDs in the replay output" },
-	{ "time-range", 'r', "TIME~TIME", 0, "Show output within the TIME range only" },
+	{ "time-range", 'r', "TIME~TIME", 0, "Show output within the TIME(timestamp or elapsed time) range only" },
 	{ 0 }
 };
 


### PR DESCRIPTION
The user can check a time-range usage with help message as below

    $ uftrace --help | grep time-range
      -r, --time-range=TIME~TIME Show output within the TIME range only

But I think the user can be confusing
because they can't know what does TIME mean
e.g. duration, timestamp, elapsed time etc.

Sure, `uftrace replay` man pages contain this
but I think it is better that there is the mention
not only in man page but also help message.

So I modify the help message for time-range.

Signed-off-by: Taeung Song <treeze.taeung@gmail.com>