### PR TITLE
Display timestamp or elapsed time by default when using time-range

### DIFF
--- a/cmd-replay.c
+++ b/cmd-replay.c
@@ -17,7 +17,7 @@ static int column_index;
 static int prev_tid = -1;
 
 enum replay_field_id {
-	REPLAY_F_NONE           = 0,
+	REPLAY_F_NONE           = -1,
 	REPLAY_F_DURATION,
 	REPLAY_F_TID,
 	REPLAY_F_ADDR,
@@ -172,6 +172,7 @@ static void print_header(void)
 	pr_out(" FUNCTION\n");
 }
 
+/* index of this table should be matched to replay_field_id */
 struct replay_field *field_table[] = {
 	&field_duration,
 	&field_tid,
@@ -229,12 +230,12 @@ static void setup_field(struct opts *opts)
 	if (opts->fields == NULL) {
 		if (opts->range.start > 0 || opts->range.stop > 0) {
 			if (opts->range.start_elapsed || opts->range.stop_elapsed)
-				add_field(field_table[5]);
+				add_field(field_table[REPLAY_F_ELAPSED]);
 			else
-				add_field(field_table[3]);
+				add_field(field_table[REPLAY_F_TIMESTAMP]);
 		}
-		add_field(field_table[0]);
-		add_field(field_table[1]);
+		add_field(field_table[REPLAY_F_DURATION]);
+		add_field(field_table[REPLAY_F_TID]);
 		return;
 	}
 
@@ -245,8 +246,8 @@ static void setup_field(struct opts *opts)
 
 	if (*str == '+') {
 		/* prepend default fields */
-		add_field(field_table[0]);  /* duration */
-		add_field(field_table[1]);  /* tid */
+		add_field(field_table[REPLAY_F_DURATION]);
+		add_field(field_table[REPLAY_F_TID]);
 		s++;
 	}
 

--- a/cmd-replay.c
+++ b/cmd-replay.c
@@ -225,6 +225,19 @@ static void setup_field(struct opts *opts)
 	unsigned i;
 	char *str, *p, *s;
 
+	/* default fields */
+	if (opts->fields == NULL) {
+		if (opts->range.start > 0 || opts->range.stop > 0) {
+			if (opts->range.start_elapsed || opts->range.stop_elapsed)
+				add_field(field_table[5]);
+			else
+				add_field(field_table[3]);
+		}
+		add_field(field_table[0]);
+		add_field(field_table[1]);
+		return;
+	}
+
 	if (!strcmp(opts->fields, "none"))
 		return;
 

--- a/uftrace.c
+++ b/uftrace.c
@@ -704,7 +704,7 @@ int main(int argc, char *argv[])
 		.column_offset	= 8,
 		.comment	= true,
 		.kernel_skip_out= true,
-		.fields         = OPT_FIELD_DEFAULT,
+		.fields         = NULL,
 	};
 	struct argp argp = {
 		.options = ftrace_options,

--- a/uftrace.h
+++ b/uftrace.h
@@ -25,7 +25,6 @@
 #define OPT_RSTACK_DEFAULT  1024
 #define OPT_DEPTH_MAX       OPT_RSTACK_MAX
 #define OPT_DEPTH_DEFAULT   OPT_RSTACK_DEFAULT
-#define OPT_FIELD_DEFAULT   (char *)"duration,tid"
 
 struct ftrace_file_header {
 	char magic[UFTRACE_MAGIC_LEN];


### PR DESCRIPTION
Hi Namhyung :smile: 

This is small PR mentioned at #66 
Additionally I used `enum replay_field_id` instead of just integer values
for **index of field_table array** in order to better readability. 