### PR TITLE
symbol: Fix a symbol-finding bug on ARM

### DIFF
--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -910,6 +910,7 @@ static void mcount_startup(void)
 
 	mcount_exename = read_exename();
 	record_proc_maps(dirname, session_name(), &symtabs);
+	set_kernel_base(dirname, session_name());
 	load_symtabs(&symtabs, NULL, mcount_exename);
 
 #ifndef DISABLE_MCOUNT_FILTER

--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -11,6 +11,7 @@
 #include "uftrace.h"
 #include "utils/utils.h"
 #include "utils/fstack.h"
+#include "utils/symbol.h"
 #include "libmcount/mcount.h"
 
 
@@ -137,6 +138,8 @@ int read_task_txt_file(char *dirname, bool needs_session, bool sym_rel_addr)
 
 			sscanf(line + 5, "timestamp=%lu.%lu %*[^i]id=%d sid=%s",
 			       &sec, &nsec, &sess.task.pid, (char *)&sess.sid);
+
+			set_kernel_base(dirname, (char *)&sess.sid);
 
 			// Get the execname
 			pos = strstr(line, "exename=");

--- a/utils/symbol.h
+++ b/utils/symbol.h
@@ -74,11 +74,9 @@ struct symtabs {
 # define KADDR_SHIFT  31
 #endif
 
-static inline bool is_kernel_address(unsigned long addr)
-{
-	return !!(addr & (1UL << KADDR_SHIFT));
-}
+bool is_kernel_address(unsigned long addr);
 unsigned long get_real_address(unsigned long addr);
+void set_kernel_base(char *dirname, const char *session_id);
 
 struct sym * find_symtabs(struct symtabs *symtabs, unsigned long addr);
 struct sym * find_symname(struct symtab *symtab, const char *name);


### PR DESCRIPTION
Hi @namhyung 

This is PR for #56.
I ran the record and replay command on both of arm32 and x86_64 using same data file from arm32.

**get uftrace.data on arm32**

| VMSPLIT   |      ARM      |  x86_64 |
|:----------:|:-----:|:-----:|
| 1G |  OK | OK |
| 2G |  OK | OK |
| 3G | OK | OK |
| 3GOPT | OK | OK |

**get uftrace.data on x86_64**

| VMSPLIT   |      ARM      |  x86_64 |
|:----------:|:-----:|:-----:|
| FIXED | ERR | OK |

