### PR TITLE
build unittests with -no-pie

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
 TEST_CFLAGS  := -D_GNU_SOURCE -DUNIT_TEST -I$(srcdir) -I$(objdir) -g
 TEST_CFLAGS  += -include $(srcdir)/tests/unittest.h
-TEST_LDFLAGS := -L$(objdir)/libtraceevent -ltraceevent -lelf -pthread -lrt -ldl
+TEST_LDFLAGS := -L$(objdir)/libtraceevent -ltraceevent -lelf -pthread -lrt -ldl -no-pie
 
 UNIT_TEST_SRC := $(wildcard $(srcdir)/*.c $(srcdir)/utils/*.c)
 UNIT_TEST_SRC += $(wildcard $(srcdir)/arch/$(ARCH)/*.c)


### PR DESCRIPTION
Newer releases of Debian and Ubuntu have begun making GCC build with
PIE by default. This is good for security, but breaks special uses
like the lookup of test cases through libelf in "unittests". To be more
specific, without this change, the unittests executable will quickly
segfault on Debian 9 (stretch) or Ubuntu 16.10 (yakkety) or newer
releases.

Add the -no-pie option to the GCC command line when building unittests.

This might break on systems where GCC does not yet understand that
option. I'm not sure yet how best to detect that situation.