### PR TITLE
suppress unittest colored output with #define

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ endif
 RM = rm -f
 INSTALL = install
 
-export ARCH CC AR LD RM srcdir objdir
+export ARCH CC AR LD RM srcdir objdir CFLAGS_unittest
 
 COMMON_CFLAGS := -O2 -g -D_GNU_SOURCE $(CFLAGS) $(CPPFLAGS)
 COMMON_CFLAGS +=  -iquote $(srcdir) -iquote $(objdir) -iquote $(srcdir)/arch/$(ARCH)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,5 @@
 TEST_CFLAGS  := -D_GNU_SOURCE -DUNIT_TEST -I$(srcdir) -I$(objdir) -g
-TEST_CFLAGS  += -include $(srcdir)/tests/unittest.h
+TEST_CFLAGS  += -include $(srcdir)/tests/unittest.h $(CFLAGS_unittest)
 TEST_LDFLAGS := -L$(objdir)/libtraceevent -ltraceevent -lelf -pthread -lrt -ldl
 
 UNIT_TEST_SRC := $(wildcard $(srcdir)/*.c $(srcdir)/utils/*.c)

--- a/tests/unittest.h
+++ b/tests/unittest.h
@@ -78,12 +78,19 @@ struct ftrace_unit_test test_ ## t = {		\
 						\
 int func_ ## t(void)
 
-
 #define TERM_COLOR_NORMAL	""
-#define TERM_COLOR_RESET	"\033[0m"
-#define TERM_COLOR_BOLD		"\033[1m"
-#define TERM_COLOR_RED		"\033[31m"
-#define TERM_COLOR_GREEN	"\033[32m"
-#define TERM_COLOR_YELLOW	"\033[33m"
+#ifdef UFTRACE_TEST_SUPPRESS_COLORS
+# define TERM_COLOR_RESET	""
+# define TERM_COLOR_BOLD	""
+# define TERM_COLOR_RED		""
+# define TERM_COLOR_GREEN	""
+# define TERM_COLOR_YELLOW	""
+#else
+# define TERM_COLOR_RESET	"\033[0m"
+# define TERM_COLOR_BOLD	"\033[1m"
+# define TERM_COLOR_RED		"\033[31m"
+# define TERM_COLOR_GREEN	"\033[32m"
+# define TERM_COLOR_YELLOW	"\033[33m"
+#endif
 
 #endif /* __FTRACE_UNIT_TEST_H__ */

--- a/utils/debug.c
+++ b/utils/debug.c
@@ -18,6 +18,17 @@
 #include "utils/utils.h"
 
 #define TERM_COLOR_NORMAL	""
+#ifdef UFTRACE_TEST_SUPPRESS_COLORS
+#define TERM_COLOR_RESET	""
+#define TERM_COLOR_BOLD		""
+#define TERM_COLOR_RED		""
+#define TERM_COLOR_GREEN	""
+#define TERM_COLOR_YELLOW	""
+#define TERM_COLOR_BLUE		""
+#define TERM_COLOR_MAGENTA	""
+#define TERM_COLOR_CYAN		""
+#define TERM_COLOR_GRAY		""
+#else
 #define TERM_COLOR_RESET	"\033[0m"
 #define TERM_COLOR_BOLD		"\033[1m"
 #define TERM_COLOR_RED		"\033[31m"
@@ -27,6 +38,7 @@
 #define TERM_COLOR_MAGENTA	"\033[35m"
 #define TERM_COLOR_CYAN		"\033[36m"
 #define TERM_COLOR_GRAY		"\033[37m"
+#endif
 
 int debug;
 FILE *logfp;


### PR DESCRIPTION
I need to be able to disable the ansi color sequences during debian builds. I was addressing this problem previously by piping the test output through a sed script, but that started causing some minor issues because of the buffering (like error messages from failed test runs being printed in the wrong place, because the stderr stream was not being buffered the same way).

You might have a better idea of what the Right Way is to opt out of colored output, but if nothing else, this should do!