### PR TITLE
symbol: Fix a reading 64-bit address from kallsyms on 32-bit systems

### DIFF
--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -819,7 +819,7 @@ int load_symbol_file(struct symtabs *symtabs, const char *symfile,
 		if (pos)
 			*pos = '\0';
 
-		addr = strtoul(line, &pos, 16);
+		addr = strtoull(line, &pos, 16);
 
 		if (*pos++ != ' ') {
 			pr_dbg2("invalid symbol file format before type\n");
@@ -1027,7 +1027,7 @@ static int load_module_symbol(struct symtab *symtab, const char *symfile,
 		if (pos)
 			*pos = '\0';
 
-		addr = strtoul(line, &pos, 16);
+		addr = strtoull(line, &pos, 16);
 
 		if (*pos++ != ' ') {
 			pr_dbg2("invalid symbol file format before type\n");


### PR DESCRIPTION
Hi, @namhyung,
This is small PR to fix a reading 64-bit address from kallsyms on 32-bit systems.

Basically, uftrace allows that replay can be run on any architceture.
So, we can execute the `uftrace replay --kernel` on x86_64 machine 
from uftrace.data which was stored at 32-bit ARM architecture, and 
it works well. By the way, In the opposite case, the result as follows:

```
$ uftrace replay --kernel
DURATION    TID     FUNCTION
1.074 us   [20819] | __monstartup();
0.774 us   [20819] | __cxa_atexit();
	   [20819] | main() {
	   [20819] |   printf() {
	   [20819] |     <ffff811effb0>() {
0.947 us   [20819] |       <ffff81019d20>();
5.223 us   [20819] |     } /* <ffff811effb0> */
3.599 us   [20819] |     <ffff8101a430>();
4.112 us   [20819] |     <ffff81064010>();
1.111 us   [20819] |     <ffff81019d20>();
39.893 us  [20819] |     <ffff811ebb60>();
5.647 us   [20819] |     <ffff81019d20>();
6.050 us   [20819] |     <ffff817b8a90>();
1.144 us   [20819] |     <ffff81019d20>();
81.627 us  [20819] |   } /* printf */
82.494 us  [20819] | } /* main */

uftrace stopped tracing with remaining functions
================================================
task: 20819
[0] <ffff8107a510>
```

This patch is to fix the decribed problem.
