### PR TITLE
test: Overwrite build() for dynamic kernel tracing

### DIFF
--- a/tests/t138_kernel_dynamic.py
+++ b/tests/t138_kernel_dynamic.py
@@ -7,15 +7,15 @@ class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'openclose', """
 # DURATION    TID     FUNCTION
-            [ 9875] | main() {
-            [ 9875] |   open() {
-  14.416 us [ 9875] |     sys_open();
-  19.099 us [ 9875] |   } /* open */
-            [ 9875] |   close() {
-   3.380 us [ 9875] |     sys_close();
-   9.720 us [ 9875] |   } /* close */
-  37.051 us [ 9875] | } /* main */
-""")
+   0.636 us [  403] | __monstartup();
+   0.623 us [  403] | __cxa_atexit();
+            [  403] | open() {
+   4.433 us [  403] |   sys_open();
+   6.000 us [  403] | } /* open */
+            [  403] | close() {
+   0.282 us [  403] |   sys_close();
+   1.731 us [  403] | } /* close */
+""", sort='simple')
 
     def pre(self):
         if os.geteuid() != 0:
@@ -24,6 +24,9 @@ class TestCase(TestBase):
             return TestBase.TEST_SKIP
 
         return TestBase.TEST_SUCCESS
+
+    def build(self, name, cflags='', ldflags=''):
+        return TestBase.build(self, name, '-pg -mfentry -mnop-mcount', ldflags)
 
     def runcmd(self):
         return '%s -k -P %s %s openclose' % \


### PR DESCRIPTION
For dynamic kernel tracing,
overwrite build() of class TestCase
because of **missed** gcc options `-mfentry -mnop-mcount`.
In addition, change the result output of this test case.

### Before:
```
$ sudo ./runtest.py -v kernel_dynamic | grep "build command:" | head -1
build command: gcc -o t-openclose -fno-inline -fno-builtin -fno-omit-frame-pointer  -pg -O0  s-openclose.c
```
### After:
```
$ sudo ./runtest.py -v kernel_dynamic | grep "build command:" | head -1
build command: gcc -o t-openclose -fno-inline -fno-builtin -fno-omit-frame-pointer  -pg -mfentry -mnop-mcount  s-openclose.c 
```

And I have a question,
@namhyung Why is the my below test output different from https://github.com/namhyung/uftrace/commit/00c826095c84cc420c4cecc7650a10aa90c27d8f ?

My case is:

```
$ gcc -o tests/t-openclose -pg -mfentry -mnop-mcount tests/s-openclose.c
```
```
$ sudo uftrace -k -P sys_*@kernel tests/t-openclose
# DURATION    TID     FUNCTION
   0.640 us [ 1582] | __monstartup();
   0.510 us [ 1582] | __cxa_atexit();
            [ 1582] | open() {
   3.612 us [ 1582] |   sys_open();
   5.094 us [ 1582] | } /* open */
            [ 1582] | close() {
   0.295 us [ 1582] |   sys_close();
   1.719 us [ 1582] | } /* close */
```

Your output: https://github.com/namhyung/uftrace/commit/00c826095c84cc420c4cecc7650a10aa90c27d8f

```
  $ sudo uftrace -k -P sys_*@kernel tests/t-openclose
  # DURATION    TID     FUNCTION
              [ 9875] | main() {
              [ 9875] |   open() {
    14.416 us [ 9875] |     sys_open();
    19.099 us [ 9875] |   } /* open */
              [ 9875] |   close() {
     3.380 us [ 9875] |     sys_close();
     9.720 us [ 9875] |   } /* close */
    37.051 us [ 9875] | } /* main */
```