### PR TITLE
dump, mcount: Use a macro NSEC_PER_SEC instead of just integer 1000000000

### DIFF
--- a/cmd-dump.c
+++ b/cmd-dump.c
@@ -79,8 +79,8 @@ static const char * rstack_type(struct ftrace_ret_stack *frs)
 
 static void pr_time(uint64_t timestamp)
 {
-	unsigned sec   = timestamp / 1000000000;
-	unsigned nsec  = timestamp % 1000000000;
+	unsigned sec   = timestamp / NSEC_PER_SEC;
+	unsigned nsec  = timestamp % NSEC_PER_SEC;
 
 	pr_out("%u.%09u  ", sec, nsec);
 }

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -62,7 +62,7 @@ uint64_t mcount_gettime(void)
 {
 	struct timespec ts;
 	clock_gettime(CLOCK_MONOTONIC, &ts);
-	return (uint64_t)ts.tv_sec * 1000000000 + ts.tv_nsec;
+	return (uint64_t)ts.tv_sec * NSEC_PER_SEC + ts.tv_nsec;
 }
 
 int gettid(struct mcount_thread_data *mtdp)


### PR DESCRIPTION
Hi @namhyung 

I found little things that can be refactored with the macro `NSEC_PER_SEC` 100000000
on my way that I've been looking over recent your commits. 😄 