### PR TITLE
demangle: Keep _GLOBAL__sub_I_ prefix in symbols

### DIFF
--- a/utils/demangle.c
+++ b/utils/demangle.c
@@ -1471,16 +1471,6 @@ static char *demangle_full(char *str)
  */
 char *demangle(char *str)
 {
-	static const size_t size_of_gsi = sizeof("_GLOBAL__sub_I") - 1;
-
-	/* skip global initialize (constructor?) functions */
-	if (strncmp(str, "_GLOBAL__sub_I", size_of_gsi) == 0) {
-		str += size_of_gsi;
-
-		while (*str++ != '_')
-			continue;
-	}
-
 	switch (demangler) {
 	case DEMANGLE_SIMPLE:
 		return demangle_simple(str);


### PR DESCRIPTION
It doesn't seem to be necessary to skip '_GLOBAL__sub_I_' prefix from the
given symbol.  Some of users got confused by that as if main() function
is called twice just like the stackoverflow question.

This patch removes the '_GLOBAL__sub_I_' prefix and the result is as
follows:

  $ uftrace ./a.out
  A is created
  A is destroyed
  # DURATION    TID     FUNCTION
     0.744 us [121820] | __cxa_atexit();
              [121820] | _GLOBAL__sub_I_main() {
              [121820] |   __static_initialization_and_destruction_0() {
    57.113 us [121820] |     std::ios_base::Init::Init();
     0.115 us [121820] |     __cxa_atexit();
    57.961 us [121820] |   } /* __static_initialization_and_destruction_0 */
    58.110 us [121820] | } /* _GLOBAL__sub_I_main */
              [121820] | main() {
              [121820] |   A::A() {
     6.913 us [121820] |     std::operator <<();
     4.977 us [121820] |     std::basic_ostream::operator <<();
    12.333 us [121820] |   } /* A::A */
              [121820] |   A::~A() {
     0.248 us [121820] |     std::operator <<();
     0.566 us [121820] |     std::basic_ostream::operator <<();
     1.111 us [121820] |   } /* A::~A */
    13.645 us [121820] | } /* main */
     1.088 us [121820] | std::ios_base::Init::~Init();

Link: http://stackoverflow.com/questions/43268745/how-to-understand-2-main-functions-after-using-uftrace-to-profile-the-c-prog
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>