### PR TITLE
Add the fallthrough comments to avoid the warning of gcc 7

### DIFF
--- a/libtraceevent/event-parse.c
+++ b/libtraceevent/event-parse.c
@@ -2916,6 +2916,7 @@ process_arg_token(struct event_format *event, struct print_arg *arg,
 			type = process_paren(event, arg, &token);
 			break;
 		}
+		/* fall through */
 	case EVENT_OP:
 		/* handle single ops */
 		arg->type = PRINT_OP;

--- a/libtraceevent/parse-filter.c
+++ b/libtraceevent/parse-filter.c
@@ -1624,9 +1624,11 @@ int pevent_filter_clear_trivial(struct event_filter *filter,
 		case FILTER_TRIVIAL_FALSE:
 			if (filter_type->filter->boolean.value)
 				continue;
+			break;
 		case FILTER_TRIVIAL_TRUE:
 			if (!filter_type->filter->boolean.value)
 				continue;
+			break;
 		default:
 			break;
 		}

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -304,6 +304,7 @@ static uint64_t parse_min(uint64_t min, uint64_t decimal, int decimal_places)
 			break;
 		case 2:
 			decimal *= 10;
+			/* fall through */
 		case 3:
 			decimal *= 10;
 			nsec += decimal * NSEC_PER_MSEC;


### PR DESCRIPTION

gcc 7 has added a default warning about fallthrough unlike gcc 6:

  https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html

So add the fallthrough comments into the switch statements
that are cause of the below warning. This commit handles #89
```
  /home/taeung/git/uftrace/utils/utils.c: In function ‘parse_min’:
  /home/taeung/git/uftrace/utils/utils.c:288:12: warning: this statement may fall through [-Wimplicit-fallthrough=]
      decimal *= 10;
      ~~~~~~~~^~~~~
  /home/taeung/git/uftrace/utils/utils.c:289:3: note: here
     case 3:
     ^~~~
    CC       arch/x86_64/cpuinfo.o
    CC       arch/x86_64/regs.o
    LINK     arch/x86_64/uftrace.o
    FLAGS:   * new build flags or cross compiler
    CC FPIC  libtraceevent/event-parse.o
  /home/taeung/git/uftrace/libtraceevent/event-parse.c: In function ‘process_arg_token’:
  /home/taeung/git/uftrace/libtraceevent/event-parse.c:2914:6: warning: this statement may fall through [-Wimplicit-fallthrough=]
     if (strcmp(token, "(") == 0) {
        ^
  /home/taeung/git/uftrace/libtraceevent/event-parse.c:2919:2: note: here
    case EVENT_OP:
    ^~~~
    CC FPIC  libtraceevent/event-plugin.o
    CC FPIC  libtraceevent/trace-seq.o
    CC FPIC  libtraceevent/parse-filter.o
  /home/taeung/git/uftrace/libtraceevent/parse-filter.c: In function ‘pevent_filter_clear_trivial’:
  /home/taeung/git/uftrace/libtraceevent/parse-filter.c:1625:7: warning: this statement may fall through [-Wimplicit-fallthrough=]
      if (filter_type->filter->boolean.value)
         ^
  /home/taeung/git/uftrace/libtraceevent/parse-filter.c:1627:3: note: here
     case FILTER_TRIVIAL_TRUE:
     ^~~~
```
Signed-off-by: Taeung Song <treeze.taeung@gmail.com>