### PR TITLE
Fix dump test scripts

### DIFF
--- a/tests/t097_dump_basic.py
+++ b/tests/t097_dump_basic.py
@@ -46,4 +46,8 @@ reading 5231.dat
         return ret
 
     def fixup(self, cflags, result):
-        return result.replace("2 (64 bit)", "1 (32 bit)")
+        import platform
+
+        if platform.architecture()[0] == '32bit':
+            result = result.replace("2 (64 bit)", "1 (32 bit)")
+        return result

--- a/tests/t097_dump_basic.py
+++ b/tests/t097_dump_basic.py
@@ -50,4 +50,7 @@ reading 5231.dat
 
         if platform.architecture()[0] == '32bit':
             result = result.replace("2 (64 bit)", "1 (32 bit)")
+        p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
+        if 'BuildID' not in p.communicate()[0].decode():
+            result = result.replace("0x3ff", "0x3fd")
         return result

--- a/tests/t098_dump_tid.py
+++ b/tests/t098_dump_tid.py
@@ -58,4 +58,8 @@ reading 5188.dat
         return ret
 
     def fixup(self, cflags, result):
-        return result.replace("2 (64 bit)", "1 (32 bit)")
+        import platform
+
+        if platform.architecture()[0] == '32bit':
+            result = result.replace("2 (64 bit)", "1 (32 bit)")
+        return result

--- a/tests/t098_dump_tid.py
+++ b/tests/t098_dump_tid.py
@@ -62,4 +62,7 @@ reading 5188.dat
 
         if platform.architecture()[0] == '32bit':
             result = result.replace("2 (64 bit)", "1 (32 bit)")
+        p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
+        if 'BuildID' not in p.communicate()[0].decode():
+            result = result.replace("0x3ff", "0x3fd")
         return result

--- a/tests/t099_dump_filter.py
+++ b/tests/t099_dump_filter.py
@@ -42,4 +42,7 @@ reading 5231.dat
 
         if platform.architecture()[0] == '32bit':
             result = result.replace("2 (64 bit)", "1 (32 bit)")
+        p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
+        if 'BuildID' not in p.communicate()[0].decode():
+            result = result.replace("0x3ff", "0x3fd")
         return result

--- a/tests/t099_dump_filter.py
+++ b/tests/t099_dump_filter.py
@@ -38,4 +38,8 @@ reading 5231.dat
         return ret
 
     def fixup(self, cflags, result):
-        return result.replace("2 (64 bit)", "1 (32 bit)")
+        import platform
+
+        if platform.architecture()[0] == '32bit':
+            result = result.replace("2 (64 bit)", "1 (32 bit)")
+        return result

--- a/tests/t100_dump_depth.py
+++ b/tests/t100_dump_depth.py
@@ -42,4 +42,7 @@ reading 5231.dat
 
         if platform.architecture()[0] == '32bit':
             result = result.replace("2 (64 bit)", "1 (32 bit)")
+        p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
+        if 'BuildID' not in p.communicate()[0].decode():
+            result = result.replace("0x3ff", "0x3fd")
         return result

--- a/tests/t100_dump_depth.py
+++ b/tests/t100_dump_depth.py
@@ -38,4 +38,8 @@ reading 5231.dat
         return ret
 
     def fixup(self, cflags, result):
-        return result.replace("2 (64 bit)", "1 (32 bit)")
+        import platform
+
+        if platform.architecture()[0] == '32bit':
+            result = result.replace("2 (64 bit)", "1 (32 bit)")
+        return result


### PR DESCRIPTION
Hi @namhyung ,

I fixed several dump test scripts.
 * Correctly check architecture (64 bit or 32 bit) in fixup()
 * Use fixup() when the target program don't contain `build-id`

I found the problem when using GCC 7 (no default `build-id` option) as below.
(GCC 5 and 6 haven't this problem)
```
$ gcc -dumpversion
7.0.1

$ ./runtest.py dump
Test case                 pg             finstrument-fu
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
097 dump_basic          : NG NG NG NG NG NG NG NG NG NG
098 dump_tid            : NG NG NG NG NG NG NG NG NG NG
099 dump_filter         : NG NG NG NG NG NG NG NG NG NG
100 dump_depth          : NG NG NG NG NG NG NG NG NG NG
...
```
Detailedly
```
$ ./runtest.py -d dump
Test case                 pg             finstrument-fu
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
t097_dump_basic: diff result of -pg -O0
--- expect	2017-05-01 23:25:59.504314659 +0900
+++ result	2017-05-01 23:25:59.504314659 +0900
@@ -4,5 +4,5 @@
 uftrace file header: endian        = 1 (little)
-uftrace file header: class         = 1 (32 bit)
+uftrace file header: class         = 2 (64 bit)
 uftrace file header: features      = 0x63 (PLTHOOK | TASK_SESSION | SYM_REL_ADDR | MAX_STACK)
-uftrace file header: info          = 0x3ff
+uftrace file header: info          = 0x3fd
 [entry] depth: 0 main
...
```
The reason is that expected output `info mask` (i.e. `0x3ff` 1111111111) is different from
the result (i.e. `0x3fd` 1111111101), because the test program (i.e. `t-abc`) don't contain `build-id`.

So I fix it and the first patch is to avoid side effect on the above situation.
If you don't want to allow that the target program don't contain `build-id`, I'll close this PR. 