### PR TITLE
doc: Add examples for X-ray dynamic tracing to live and record man pages

### DIFF
--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -355,6 +355,28 @@ In addition, you can enable all functions at load time using '.' that matches to
        2.451 us [19387] |   } /* a */
        3.289 us [19387] | } /* main */
 
+Clang/LLVM 4.0 provides a dynamic instrumentation technique called [X-ray](http://llvm.org/docs/XRay.html).  It's similar to a combination of `gcc -mfentry -mnop-mcount` and `-finstrument-functions`.  The uftrace also supports dynamic tracing on the excutables built with the `X-ray`.
+
+For example, you can build the target program by clang with the below option and equally use `-P` option for dynamic tracing like below:
+
+    $ clang -fxray-instrument -fxray-instruction-threshold=1 -o abc-xray  tests/s-abc.c
+    $ uftrace -P main abc-xray
+    # DURATION    TID     FUNCTION
+                [11093] | main() {
+       1.659 us [11093] |   getpid();
+       5.963 us [11093] | } /* main */
+
+    $ uftrace -P . abc-xray
+    # DURATION    TID     FUNCTION
+                [11098] | main() {
+		[11098] |   a() {
+		[11098] |     b() {
+		[11098] |       c() {
+       0.753 us [11098] |         getpid();
+       1.430 us [11098] |       } /* c */
+       1.915 us [11098] |     } /* b */
+       2.405 us [11098] |   } /* a */
+       3.005 us [11098] | } /* main */
 
 SEE ALSO
 ========

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -331,6 +331,30 @@ In addition, you can enable all functions at load time using '.' that matches to
        2.451 us [19387] |   } /* a */
        3.289 us [19387] | } /* main */
 
+Clang/LLVM 4.0 provides a dynamic instrumentation technique called [X-ray](http://llvm.org/docs/XRay.html).  It's similar to a combination of `gcc -mfentry -mnop-mcount` and `-finstrument-functions`.  The uftrace also supports dynamic tracing on the excutables built with the `X-ray`.
+
+For example, you can build the target program by clang with the below option and equally use `-P` option for dynamic tracing like below:
+
+    $ clang -fxray-instrument -fxray-instruction-threshold=1 -o abc-xray  tests/s-abc.c
+    $ uftrace record -P main abc-xray
+    $ uftrace replay
+    # DURATION    TID     FUNCTION
+                [11093] | main() {
+       1.659 us [11093] |   getpid();
+       5.963 us [11093] | } /* main */
+
+    $ uftrace record -P . abc-xray
+    $ uftrace replay
+    # DURATION    TID     FUNCTION
+                [11098] | main() {
+		[11098] |   a() {
+		[11098] |     b() {
+		[11098] |       c() {
+       0.753 us [11098] |         getpid();
+       1.430 us [11098] |       } /* c */
+       1.915 us [11098] |     } /* b */
+       2.405 us [11098] |   } /* a */
+       3.005 us [11098] | } /* main */
 
 SEE ALSO
 ========


### PR DESCRIPTION
Currently uftrace supports the dynamic tracing feature 'X-ray'
of Clang/LLVM 4.0 so add examples for it to live and record man pages.

I referred to your mention on #88 😄 
If you give me some feedback, I'll update this PR. 