### PR TITLE
Make the configure script more packaging-friendly

### DIFF
--- a/configure
+++ b/configure
@@ -107,21 +107,24 @@ if [ ! -e ${srcdir}/check-deps/have_libelf ]; then
     exit 1
 fi
 
-echo "# this file is generated automatically" > $output
-echo override prefix := $prefix  >> $output
-echo override bindir := $bindir  >> $output
-echo override libdir := $libdir  >> $output
-echo override mandir := $mandir  >> $output
-echo override etcdir := $etcdir  >> $output
-echo                             >> $output
-echo override ARCH   := $ARCH    >> $output
-echo override CC     := $CC      >> $output
-echo override LD     := $LD      >> $output
-echo override CFLAGS  = $CFLAGS  >> $output
-echo override LDFLAGS = $LDFLAGS >> $output
-echo                             >> $output
-echo override srcdir := $srcdir  >> $output
-echo override objdir := $objdir  >> $output
+cat >$output <<EOF
+# this file is generated automatically
+override prefix := $prefix
+override bindir := $bindir
+override libdir := $libdir
+override mandir := $mandir
+override etcdir := $etcdir
+
+override ARCH   := $ARCH
+override CC     := $CC
+override LD     := $LD
+override CFLAGS  = $CFLAGS
+override LDFLAGS = $LDFLAGS
+
+override srcdir := $srcdir
+override objdir := $objdir
+EOF
+
 if [ $(id -u) -eq 0 ]; then
     chmod 666 $output
 fi

--- a/configure
+++ b/configure
@@ -76,11 +76,8 @@ libdir=${libdir:-${prefix}/lib}
 etcdir=${etcdir:-${prefix}/etc}
 mandir=${mandir:-${prefix}/share/man}
 
-if echo ${etcdir} | grep -qs /usr/local; then
-    etcdir=$(echo ${etcdir} | sed -e "s^/usr/local^^")
-fi
-if echo ${etcdir} | grep -qs /usr; then
-    etcdir=$(echo ${etcdir} | sed -e "s^/usr^^")
+if [ "$etcdir" = /usr/etc ]; then
+    etcdir=/etc
 fi
 if [ -n "$sysconfdir" ]; then
     etcdir=$sysconfdir

--- a/configure
+++ b/configure
@@ -46,8 +46,7 @@ while getopts ":ho:-:p" opt; do
                 help)  usage ;;
                 *=*)   opt=${OPTARG%%=*}; val=${OPTARG#*=}
                        eval "${opt/-/_}='$val'" ;;
-                *)     val="${!OPTIND}"; OPTIND=$((OPTIND + 1));
-                       eval "$OPTARG=$val" ;;
+                *)     ;;
             esac
 	    ;;
         o)       output=$OPTARG ;;

--- a/configure
+++ b/configure
@@ -16,6 +16,7 @@ usage() {
   --libdir=<DIR>     set library install dir as <DIR>     (default: \${prefix}/lib)
   --mandir=<DIR>     set manual doc install dir as <DIR>  (default: \${prefix}/share/man)
   --objdir=<DIR>     set build dir as <DIR>               (default: \${PWD})
+  --sysconfdir=<DIR> override the etc dir as <DIR>
 
   -p                 preserve old setting
 "
@@ -80,6 +81,9 @@ if echo ${etcdir} | grep -qs /usr/local; then
 fi
 if echo ${etcdir} | grep -qs /usr; then
     etcdir=$(echo ${etcdir} | sed -e "s^/usr^^")
+fi
+if [ -n "$sysconfdir" ]; then
+    etcdir=$sysconfdir
 fi
 
 CC=${CC:-${CROSS_COMPILE}gcc}

--- a/configure
+++ b/configure
@@ -56,7 +56,7 @@ while getopts ":ho:-:p" opt; do
 done
 shift $((OPTIND - 1))
 
-for arg in "$@"; do
+for arg; do
     opt=${arg%%=*}
     val=${arg#*=}
     eval "$opt='$val'"

--- a/configure
+++ b/configure
@@ -45,7 +45,7 @@ while getopts ":ho:-:p" opt; do
 	    case "$OPTARG" in
                 help)  usage ;;
                 *=*)   opt=${OPTARG%%=*}; val=${OPTARG#*=}
-                       eval "$opt=$val" ;;
+                       eval "${opt/-/_}='$val'" ;;
                 *)     val="${!OPTIND}"; OPTIND=$((OPTIND + 1));
                        eval "$OPTARG=$val" ;;
             esac


### PR DESCRIPTION
Hello,

Someone's trying to introduce `uftrace` on Fedora [1] and I'd like to see this move forward. One problem is that the configure script doesn't meet packaging expectations, which is fixed in 77dcd9c ca9d704. That should make downstream maintainers lives easier since they'd less likely need to manually update the packaging whenever a guideline changes.

I also polished the script a bit.

Dridi

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1398922