### PR TITLE
mcount: Fix PLT hook segfault about 16-byte alignment on GCC7

### DIFF
--- a/arch/x86_64/plthook.S
+++ b/arch/x86_64/plthook.S
@@ -19,6 +19,11 @@ plt_hooker:
 	movq %r9, 8(%rsp)
 	.cfi_offset r9, -64
 
+	/* check stack alignment before calling plthook_entry() */
+	lea (%rsp), %rdi
+	callq is_aligned
+	cmpq $0, %rax
+
 	/* child idx */
 	movq 64(%rsp), %rsi
 	/* address of parent ip */
@@ -27,9 +32,15 @@ plt_hooker:
 	movq 56(%rsp), %rdx
 	/* mcount_args */
 	lea 8(%rsp), %rcx
-
+	jne .L1
 	call plthook_entry
-
+	jmp .L2
+.L1:
+	/* For the 16-byte stack alignment */
+	sub $8, %rsp
+	call plthook_entry
+	add $8, %rsp
+.L2:
 	movq 8(%rsp), %r9
 	movq 16(%rsp), %r8
 	movq 24(%rsp), %rcx

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -26,6 +26,12 @@ static bool *plthook_dynsym_resolved;
 static unsigned long got_addr;
 static bool segv_handled;
 
+int is_aligned(unsigned long sp)
+{
+	/* check the 16-byte stack alignment */
+	return sp % 16;
+}
+
 void segv_handler(int sig, siginfo_t *si, void *ctx)
 {
 	if (si->si_code == SEGV_ACCERR) {


### PR DESCRIPTION
I'm not sure you agree this PR, but I'd appreciate some feedback on this. 😄 

If uftrace is built by GCC7, plthook_entry() has `movaps` insn.
So the stack pointer must be aligned on a 16-byte boundary.
This was handled by the commit 7b80ea8c2 ("mcount: Fix segfault on GCC7")

However, the commit didn't handle the below `-pg -mfentry` case:
```
  $ gcc -o hello -pg -mfentry hello.c

  $ uftrace ./hello
  child terminated by signal: 11: Segmentation fault
  # DURATION    TID     FUNCTION
     1.741 us [14660] | __monstartup();
     1.519 us [14660] | __cxa_atexit();
```
So fix it, this situation was mentioned on #100.
