### PR TITLE
mcount: Only call mcount_startup() one time

### DIFF
--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -1236,12 +1236,10 @@ __visible_default void * dlopen(const char *filename, int flags)
  */
 void __visible_default __monstartup(unsigned long low, unsigned long high)
 {
-	mcount_startup();
 }
 
 void __visible_default _mcleanup(void)
 {
-	mcount_cleanup();
 }
 
 void __visible_default mcount_restore(void)
@@ -1271,8 +1269,7 @@ void __visible_default __cyg_profile_func_exit(void *child, void *parent)
 static void __attribute__((constructor))
 mcount_init(void)
 {
-	if (!mcount_setup_done)
-		mcount_startup();
+	mcount_startup();
 }
 
 static void __attribute__((destructor))


### PR DESCRIPTION
I found this situation with GDB.

Currently mcount_init() is first called before __monstartup(),
so check mcount_setup_done in __monstartup(), not mcount_init(),
to not call mcount_startup() twice.

Fixes: cb38d982 ("mcount: Staticize startup and cleanup routines")

Or,
check the `mcount_setup_done` variable on both ?