### PR TITLE
std::string support for argument/retval display

### DIFF
--- a/cmd-dump.c
+++ b/cmd-dump.c
@@ -304,8 +304,9 @@ static void pr_args(struct fstack_arguments *args)
 		if (spec->idx == RETVAL_IDX)
 			continue;
 
-		if (spec->fmt == ARG_FMT_STR) {
-			char buf[64];
+		if (spec->fmt == ARG_FMT_STR ||
+		    spec->fmt == ARG_FMT_STD_STRING) {
+			char buf[64] = {0};
 			const int null_str = -1;
 
 			size = *(unsigned short *)ptr;
@@ -314,7 +315,10 @@ static void pr_args(struct fstack_arguments *args)
 			if (!memcmp(buf, &null_str, 4))
 				strcpy(buf, "NULL");
 
-			pr_out("  args[%d] str: %s\n", i , buf);
+			if (spec->fmt == ARG_FMT_STD_STRING)
+				pr_out("  args[%d] std::string: %s\n", i , buf);
+			else
+				pr_out("  args[%d] str: %s\n", i , buf);
 			size += 2;
 		}
 		else {
@@ -344,8 +348,9 @@ static void pr_retval(struct fstack_arguments *args)
 		if (spec->idx != RETVAL_IDX)
 			continue;
 
-		if (spec->fmt == ARG_FMT_STR) {
-			char buf[64];
+		if (spec->fmt == ARG_FMT_STR ||
+		    spec->fmt == ARG_FMT_STD_STRING) {
+			char buf[64] = {0};
 			const int null_str = -1;
 
 			size = *(unsigned short *)ptr;
@@ -354,7 +359,10 @@ static void pr_retval(struct fstack_arguments *args)
 			if (!memcmp(buf, &null_str, 4))
 				strcpy(buf, "NULL");
 
-			pr_out("  retval[%d] str: %s\n", i , buf);
+			if (spec->fmt == ARG_FMT_STD_STRING)
+				pr_out("  retval[%d] std::string: %s\n", i , buf);
+			else
+				pr_out("  retval[%d] str: %s\n", i , buf);
 			size += 2;
 		}
 		else {

--- a/cmd-replay.c
+++ b/cmd-replay.c
@@ -486,7 +486,8 @@ void get_argspec_string(struct ftrace_task_handle *task,
 			break;
 		}
 
-		if (spec->fmt == ARG_FMT_STR) {
+		if (spec->fmt == ARG_FMT_STR ||
+		    spec->fmt == ARG_FMT_STD_STRING) {
 			unsigned short slen;
 			unsigned short newline = 0;
 			char last_ch;

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -252,14 +252,14 @@ The uftrace tool supports recording function arguments and/or return values usin
     <int_spec>    :=  "arg" N [ "/" <format> [ <size> ] ] [ "%" ( <reg> | <stack> ) ]
     <float_spec>  :=  "fparg" N [ "/" ( <size> | "80" ) ] [ "%" ( <reg> | <stack> ) ]
     <ret_spec>    :=  "retval" [ "/" <format> [ <size> ] ]
-    <format>      :=  "i" | "u" | "x" | "s" | "c" | "f"
+    <format>      :=  "i" | "u" | "x" | "s" | "c" | "f" | "S"
     <size>        :=  "8" | "16" | "32" | "64"
     <reg>         :=  <arch-specific register name>  # "rdi", "xmm0", "r0", ...
     <stack>       :=  "stack" [ "+" ] <offset>
 
 The `-A`/`--argument` option takes argN where N is an index of the arguments.  The index starts from 1 and corresponds to the argument passing order of the calling convention on the system.  Note that the indexes of arguments are separately counted for integer (or pointer) and floating-point type, and they can interfere depending on the calling convention.  The argN is for integer arguments and fpargN is for floating-point arguments.
 
-Users can optionally specify a format and size for the arguments and/or return values.  Without this, uftrace treats them as 'long int' type for integers and 'double' for floating-point numbers.  The "i" format makes it signed integer type and "u" format is for unsigned type.  Both are printed as decimal while "x" format makes it printed as hexadecimal.  The "s" format is for string type and "c" format is for character type.  Finally, the "f" format is for floating-point type and is meaningful only for return value (generally).  Note that fpargN doesn't take the format field since it's always floating-point.
+Users can optionally specify a format and size for the arguments and/or return values.  Without this, uftrace treats them as 'long int' type for integers and 'double' for floating-point numbers.  The "i" format makes it signed integer type and "u" format is for unsigned type.  Both are printed as decimal while "x" format makes it printed as hexadecimal.  The "s" format is for null-terminated string type and "c" format is for character type.  The "f" format is for floating-point type and is meaningful only for return value (generally).  Note that fpargN doesn't take the format field since it's always floating-point.  Finally, the "S" format is for std::string, but it only supports libstdc++ library as of yet.
 
 Please beware when using string type arguments since it can crash the program if the (pointer) value is invalid.
 

--- a/libmcount/record.c
+++ b/libmcount/record.c
@@ -245,9 +245,22 @@ static unsigned save_to_argbuf(void *argbuf, struct list_head *args_spec,
 		else
 			mcount_arch_get_arg(ctx, spec);
 
-		if (spec->fmt == ARG_FMT_STR) {
+		if (spec->fmt == ARG_FMT_STR ||
+		    spec->fmt == ARG_FMT_STD_STRING) {
 			unsigned short len;
 			char *str = ctx->val.p;
+
+			if (spec->fmt == ARG_FMT_STD_STRING) {
+				/*
+				 * This is libstdc++ implementation dependent.
+				 * So doesn't work on others such as libc++.
+				 */
+				long *base = ctx->val.p;
+				long *_M_string_length = base + 1;
+				char *_M_dataplus = (char*)(*base);
+				len = *_M_string_length;
+				str = _M_dataplus;
+			}
 
 			if (str) {
 				unsigned i;

--- a/tests/s-std-string.cpp
+++ b/tests/s-std-string.cpp
@@ -1,0 +1,26 @@
+#include <string>
+
+std::string s[] = {"Hello", "World!", "std::string support is done!"};
+
+__attribute__((noinline))
+void std_string_arg(std::string& s)
+{
+  s = s;
+}
+
+__attribute__((noinline))
+std::string std_string_ret(int index)
+{
+  return s[index];
+}
+
+int main()
+{
+  std_string_arg(s[0]);
+  std_string_arg(s[1]);
+  std_string_arg(s[2]);
+
+  std_string_ret(0);
+  std_string_ret(1);
+  std_string_ret(2);
+}

--- a/tests/t146_std_string.py
+++ b/tests/t146_std_string.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'std-string', lang='C++', result="""
+# DURATION    TID     FUNCTION
+            [71555] | main() {
+   7.549 us [71555] |   std_string_arg("Hello");
+   0.218 us [71555] |   std_string_arg("World!");
+   0.150 us [71555] |   std_string_arg("std::string support is done!");
+   0.240 us [71555] |   std_string_ret::cxx11() = "Hello";
+   0.124 us [71555] |   std_string_ret::cxx11() = "World!";
+   0.110 us [71555] |   std_string_ret::cxx11() = "std::string support is done!";
+  10.346 us [71555] | } /* main */
+""")
+
+    def build(self, name, cflags='', ldflags=''):
+        # cygprof doesn't support arguments now
+        if cflags.find('-finstrument-functions') >= 0:
+            return TestBase.TEST_SKIP
+
+        return TestBase.build(self, name, cflags, ldflags)
+
+    # To handle g++ 4.xx version
+    def fixup(self, cflags, result):
+        return result.replace("std_string_ret::cxx11()", "std_string_ret()")
+
+    def runcmd(self):
+        arg = '-A ^std_string_arg@arg1/S'
+        retval = '-R ^std_string_ret@retval/S'
+        opts = '-F main -F ^std_string_ -D 1'
+        name = 't-' + self.name
+        return '%s %s %s %s %s' % (TestBase.ftrace, arg, retval, opts, name)

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -321,6 +321,9 @@ static int parse_spec(char *str, struct ftrace_arg_spec *arg, char *suffix)
 		fmt = ARG_FMT_FLOAT;
 		size = sizeof(double);
 		break;
+	case 'S':
+		fmt = ARG_FMT_STD_STRING;
+		break;
 	default:
 		pr_use("unsupported argument type: %s\n", str);
 		return -1;

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -42,6 +42,7 @@ enum ftrace_arg_format {
 	ARG_FMT_STR,
 	ARG_FMT_CHAR,
 	ARG_FMT_FLOAT,
+	ARG_FMT_STD_STRING,
 };
 
 #define ARG_TYPE_INDEX  0

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -899,7 +899,7 @@ static int read_task_arg(struct ftrace_task_handle *task,
 	unsigned size = spec->size;
 	int rem;
 
-	if (spec->fmt == ARG_FMT_STR) {
+	if (spec->fmt == ARG_FMT_STR || spec->fmt == ARG_FMT_STD_STRING) {
 		args->data = xrealloc(args->data, args->len + 2);
 
 		if (fread(args->data + args->len, 2, 1, fp) != 1) {


### PR DESCRIPTION
Since std::string is widely used in C++ programs, so it'd be useful to support it when displaying arguments and return values.
Currently, it only supports std::string in libstdc++ library.