### PR TITLE
[RFC] Support Python binding for mcount entry and exit

### DIFF
--- a/cmd-record.c
+++ b/cmd-record.c
@@ -264,6 +264,9 @@ static void setup_child_environ(struct opts *opts, int pfd)
 		setenv("LD_PRELOAD", buf, 1);
 
 	setenv("XRAY_OPTIONS", "patch_premain=false", 1);
+
+	if (opts->script_file)
+		setenv("UFTRACE_SCRIPT", opts->script_file, 1);
 }
 
 static uint64_t calc_feat_mask(struct opts *opts)

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -1017,6 +1017,7 @@ static void mcount_startup(void)
 	plthook_str = getenv("UFTRACE_PLTHOOK");
 	patch_str = getenv("UFTRACE_PATCH");
 	event_str = getenv("UFTRACE_EVENT");
+	script_str = getenv("UFTRACE_SCRIPT");
 
 	if (logfd_str) {
 		int fd = strtol(logfd_str, NULL, 0);

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -11,6 +11,7 @@
 #define PR_DOMAIN  DBG_MCOUNT
 
 #include "libmcount/mcount.h"
+#include "libmcount/pyhook.h"
 #include "mcount-arch.h"
 #include "utils/filter.h"
 #include "utils/compiler.h"

--- a/libmcount/pyhook.c
+++ b/libmcount/pyhook.c
@@ -1,0 +1,290 @@
+/*
+ * Python binding for function entry and exit
+ *
+ * Copyright (C) 2017, LG Electronics, Honggyu Kim <hong.gyu.kim@lge.com>
+ *
+ * Released under the GPL v2.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <stdbool.h>
+#include <dlfcn.h>
+
+#include "pyhook.h"
+#include "utils/utils.h"
+#include "utils/symbol.h"
+
+/* python library name, it only supports python 2.7 as of now */
+static const char *libpython = "libpython2.7.so";
+
+/* python library handle returned by dlopen() */
+static void *python_handle;
+
+static PyAPI_FUNC(void) (*__Py_Initialize)(void);
+static PyAPI_FUNC(void) (*__PySys_SetPath)(char *);
+static PyAPI_FUNC(void) (*__PyErr_Print)(void);
+static PyAPI_FUNC(int) (*__PyCallable_Check)(PyObject *);
+static PyAPI_FUNC(PyObject *) (*__PyImport_Import)(PyObject *name);
+static PyAPI_FUNC(PyObject *) (*__PyTuple_New)(Py_ssize_t size);
+static PyAPI_FUNC(PyObject *) (*__PyErr_Occurred)(void);
+static PyAPI_FUNC(int) (*__PyTuple_SetItem)(PyObject *, Py_ssize_t, PyObject *);
+static PyAPI_FUNC(PyObject *) (*__PyObject_GetAttrString)(PyObject *, const char *);
+static PyAPI_FUNC(PyObject *) (*__PyObject_CallObject)(PyObject *callable_object, PyObject *args);
+
+static PyAPI_FUNC(PyObject *) (*__PyString_FromString)(const char *);
+static PyAPI_FUNC(PyObject *) (*__PyInt_FromLong)(long);
+static PyAPI_FUNC(PyObject *) (*__PyLong_FromUnsignedLongLong)(unsigned PY_LONG_LONG);
+
+static PyAPI_FUNC(char *) (*__PyString_AsString)(PyObject *);
+static PyAPI_FUNC(long) (*__PyLong_AsLong)(PyObject *);
+
+static PyAPI_FUNC(PyObject *) (*__PyDict_New)(void);
+static PyAPI_FUNC(int) (*__PyDict_SetItem)(PyObject *mp, PyObject *key, PyObject *item);
+static PyAPI_FUNC(int) (*__PyDict_SetItemString)(PyObject *dp, const char *key, PyObject *item);
+static PyAPI_FUNC(PyObject *) (*__PyDict_GetItem)(PyObject *mp, PyObject *key);
+
+static PyAPI_FUNC(PyObject *) (*__PyLong_FromLong)(long);
+
+static PyObject *pName, *pModule, *pFuncEntry, *pFuncExit;
+
+extern struct symtabs symtabs;
+
+enum py_args {
+	PY_ARG_TID = 0,
+	PY_ARG_DEPTH,
+	PY_ARG_START_TIME,
+	PY_ARG_END_TIME,
+	PY_ARG_ENTRY_ADDR,
+	PY_ARG_RET_ADDR,
+	PY_ARG_SYMNAME,
+	PY_ARG_RETVAL,
+};
+
+/* The order has to be aligned with enum py_args above. */
+static const char *py_args_table[] = {
+	"tid",
+	"depth",
+	"start_time",
+	"end_time",
+	"entry_addr",
+	"ret_addr",
+	"symname",
+	"retval",
+};
+
+#define INIT_PY_API_FUNC(func) \
+	do { \
+		__##func = dlsym(python_handle, #func); \
+		if (!__##func) { \
+			pr_err("dlsym for \"" #func "\" is failed!\n"); \
+			return -1; \
+		} \
+	} while (0)
+
+static char *remove_py_suffix(char *py_name)
+{
+	char *ext = strrchr(py_name, '.');
+
+	if (!ext)
+		return NULL;
+
+	*ext = '\0';
+	return py_name;
+}
+
+/* Import python module that is given by -p option */
+static int import_python_module(char *py_pathname)
+{
+	char py_sysdir[PATH_MAX];
+	absolute_dirname(py_pathname, py_sysdir);
+
+	/* Set path to import a python module. */
+	__PySys_SetPath(py_sysdir);
+	pr_dbg("PySys_SetPath(\"%s\") is done!\n", py_sysdir);
+
+	char *py_basename = basename(py_pathname);
+	remove_py_suffix(py_basename);
+
+	pName = __PyString_FromString(py_basename);
+	pModule = __PyImport_Import(pName);
+	if (pModule == NULL) {
+		__PyErr_Print();
+		pr_warn("%s.py cannot be imported!\n", py_pathname);
+		return -1;
+	}
+
+	return 0;
+}
+
+int python_uftrace_entry(struct mcount_ret_stack *rstack)
+{
+	if (unlikely(!pFuncEntry))
+		return -1;
+
+	int tid = rstack->tid;
+	int depth = rstack->depth;
+	uint64_t start_time = rstack->start_time;
+	unsigned long entry_addr = rstack->child_ip;
+	unsigned long ret_addr = *(rstack->parent_loc);
+
+	struct sym *sym = find_symtabs(&symtabs, entry_addr);
+	char *symname = symbol_getname(sym, entry_addr);
+
+	/* Entire arguments are passed into a single dictionary. */
+	PyObject *pDict = __PyDict_New();
+
+	PyObject *pTid = __PyInt_FromLong(tid);
+	PyObject *pDepth = __PyInt_FromLong(depth);
+	PyObject *pStartTime = __PyLong_FromUnsignedLongLong(start_time);
+	PyObject *pEntryAddr = __PyInt_FromLong(entry_addr);
+	PyObject *pRetAddr = __PyInt_FromLong(ret_addr);
+	PyObject *pSym  = __PyString_FromString(symname);
+
+	__PyDict_SetItemString(pDict, py_args_table[PY_ARG_TID], pTid);
+	__PyDict_SetItemString(pDict, py_args_table[PY_ARG_DEPTH], pDepth);
+	__PyDict_SetItemString(pDict, py_args_table[PY_ARG_START_TIME], pStartTime);
+	__PyDict_SetItemString(pDict, py_args_table[PY_ARG_ENTRY_ADDR], pEntryAddr);
+	__PyDict_SetItemString(pDict, py_args_table[PY_ARG_RET_ADDR], pRetAddr);
+	__PyDict_SetItemString(pDict, py_args_table[PY_ARG_SYMNAME], pSym);
+
+	/* Argument list must be passed in a tuple. */
+	PyObject *pythonArgument = __PyTuple_New(1);
+	__PyTuple_SetItem(pythonArgument, 0, pDict);
+
+	/* Call python function "uftrace_entry". */
+	PyObject *pReturn = __PyObject_CallObject(pFuncEntry, pythonArgument);
+
+	if (likely(pReturn != NULL)) {
+		pr_dbg3("[python] uftrace_entry returns %#x\n",
+			__PyLong_AsLong(pReturn));
+	}
+	else
+		__PyErr_Print();
+
+	return 0;
+}
+
+int python_uftrace_exit(struct mcount_ret_stack *rstack, long *retval)
+{
+	if (unlikely(!pFuncExit))
+		return -1;
+
+	int tid = rstack->tid;
+	int depth = rstack->depth;
+	uint64_t start_time = rstack->start_time;
+	uint64_t end_time = rstack->end_time;
+	unsigned long entry_addr = rstack->child_ip;
+	unsigned long ret_addr = rstack->parent_ip;
+
+	struct sym *sym = find_symtabs(&symtabs, entry_addr);
+	char *symname = symbol_getname(sym, entry_addr);
+
+	/* Entire arguments are passed into a single dictionary. */
+	PyObject *pDict = __PyDict_New();
+
+	PyObject *pTid = __PyInt_FromLong(tid);
+	PyObject *pDepth = __PyInt_FromLong(depth);
+	PyObject *pStartTime = __PyLong_FromUnsignedLongLong(start_time);
+	PyObject *pEndTime = __PyLong_FromUnsignedLongLong(end_time);
+	PyObject *pRetAddr = __PyInt_FromLong(ret_addr);
+	PyObject *pSym  = __PyString_FromString(symname);
+
+	__PyDict_SetItemString(pDict, py_args_table[PY_ARG_TID], pTid);
+	__PyDict_SetItemString(pDict, py_args_table[PY_ARG_DEPTH], pDepth);
+	__PyDict_SetItemString(pDict, py_args_table[PY_ARG_START_TIME], pStartTime);
+	__PyDict_SetItemString(pDict, py_args_table[PY_ARG_END_TIME], pEndTime);
+	__PyDict_SetItemString(pDict, py_args_table[PY_ARG_RET_ADDR], pRetAddr);
+	__PyDict_SetItemString(pDict, py_args_table[PY_ARG_SYMNAME], pSym);
+
+	if (retval) {
+		PyObject *pRetVal = __PyInt_FromLong(*retval);
+		__PyDict_SetItemString(pDict, py_args_table[PY_ARG_RETVAL], pRetVal);
+	}
+
+	/* Argument list must be passed in a tuple. */
+	PyObject *pythonArgument = __PyTuple_New(1);
+	__PyTuple_SetItem(pythonArgument, 0, pDict);
+
+	/* Call python function "uftrace_exit". */
+	PyObject *pReturn = __PyObject_CallObject(pFuncExit, pythonArgument);
+
+	if (likely(pReturn != NULL)) {
+		pr_dbg3("[python] uftrace_exit returns %#x\n",
+			__PyLong_AsLong(pReturn));
+	}
+	else
+		__PyErr_Print();
+
+	return 0;
+}
+
+int python_init(char *py_pathname)
+{
+	pr_dbg("initialize python\n");
+
+	/* Bind script_uftrace functions to python's. */
+	script_uftrace_entry = python_uftrace_entry;
+	script_uftrace_exit = python_uftrace_exit;
+
+	python_handle = dlopen(libpython, RTLD_LAZY);
+	if (!python_handle) {
+		pr_warn("%s cannot be loaded!\n", libpython);
+		return -1;
+	}
+
+	INIT_PY_API_FUNC(Py_Initialize);
+	INIT_PY_API_FUNC(PySys_SetPath);
+	INIT_PY_API_FUNC(PyErr_Print);
+	INIT_PY_API_FUNC(PyCallable_Check);
+	INIT_PY_API_FUNC(PyImport_Import);
+	INIT_PY_API_FUNC(PyTuple_New);
+	INIT_PY_API_FUNC(PyErr_Occurred);
+
+	INIT_PY_API_FUNC(PyTuple_SetItem);
+	INIT_PY_API_FUNC(PyObject_GetAttrString);
+	INIT_PY_API_FUNC(PyObject_CallObject);
+
+	INIT_PY_API_FUNC(PyString_FromString);
+	INIT_PY_API_FUNC(PyInt_FromLong);
+	INIT_PY_API_FUNC(PyLong_FromUnsignedLongLong);
+	INIT_PY_API_FUNC(PyString_AsString);
+	INIT_PY_API_FUNC(PyLong_AsLong);
+
+	INIT_PY_API_FUNC(PyDict_New);
+	INIT_PY_API_FUNC(PyLong_FromLong);
+	INIT_PY_API_FUNC(PyDict_SetItem);
+	INIT_PY_API_FUNC(PyDict_SetItemString);
+	INIT_PY_API_FUNC(PyDict_GetItem);
+
+	__Py_Initialize();
+
+	/* Import python module that is passed by -p option. */
+	if (import_python_module(py_pathname) < 0)
+		return -1;
+
+	pFuncEntry = __PyObject_GetAttrString(pModule, "uftrace_entry");
+	if (!pFuncEntry || !__PyCallable_Check(pFuncEntry)) {
+		if (__PyErr_Occurred())
+			__PyErr_Print();
+		pr_warn("uftrace_entry is not callable!\n");
+		pFuncEntry = NULL;
+	}
+	pFuncExit = __PyObject_GetAttrString(pModule, "uftrace_exit");
+	if (!pFuncExit || !__PyCallable_Check(pFuncExit)) {
+		if (__PyErr_Occurred())
+			__PyErr_Print();
+		pr_warn("uftrace_exit is not callable!\n");
+		pFuncExit = NULL;
+	}
+
+	if (!pFuncEntry && !pFuncExit) {
+		pr_warn("python_initialization for \"%s.py\" is failed!\n",
+			py_pathname);
+		return -1;
+	}
+
+	pr_dbg("python_initialization for \"%s.py\" is done!\n", py_pathname);
+
+	return 0;
+}

--- a/libmcount/pyhook.h
+++ b/libmcount/pyhook.h
@@ -1,0 +1,16 @@
+/*
+ * Python binding for function entry and exit
+ *
+ * Copyright (C) 2017, LG Electronics, Honggyu Kim <hong.gyu.kim@lge.com>
+ *
+ * Released under the GPL v2.
+ */
+#ifndef PYHOOK_H
+#define PYHOOK_H
+
+#include "script.h"
+#include <python2.7/Python.h>
+
+int python_init(char *py_pathname);
+
+#endif

--- a/libmcount/script.c
+++ b/libmcount/script.c
@@ -1,0 +1,15 @@
+/*
+ * Script binding for function entry and exit
+ *
+ * Copyright (C) 2017, LG Electronics, Honggyu Kim <hong.gyu.kim@lge.com>
+ *
+ * Released under the GPL v2.
+ */
+
+#include "libmcount/script.h"
+
+/* This will be set by getenv("UFTRACE_SCRIPT") */
+char *script_str;
+
+int (*script_uftrace_entry)(struct mcount_ret_stack *rstack);
+int (*script_uftrace_exit)(struct mcount_ret_stack *rstack, long *retval);

--- a/libmcount/script.h
+++ b/libmcount/script.h
@@ -1,0 +1,18 @@
+/*
+ * Script binding for function entry and exit
+ *
+ * Copyright (C) 2017, LG Electronics, Honggyu Kim <hong.gyu.kim@lge.com>
+ *
+ * Released under the GPL v2.
+ */
+#ifndef SCRIPT_H
+#define SCRIPT_H
+
+#include "libmcount/mcount.h"
+
+extern char *script_str;
+
+extern int (*script_uftrace_entry)(struct mcount_ret_stack *rstack);
+extern int (*script_uftrace_exit)(struct mcount_ret_stack *rstack, long *retval);
+
+#endif

--- a/scripts/replay.py
+++ b/scripts/replay.py
@@ -1,0 +1,57 @@
+print("# DURATION    TID     FUNCTION")
+
+def uftrace_entry(args):
+    # read arguments
+    _tid = args["tid"]
+    _depth = args["depth"]
+    _start_time = args["start_time"]
+    _symname = args["symname"]
+    _entry_addr = args["entry_addr"]
+
+    indent = _depth * 2
+    space = " " * indent
+
+    buf = " %10s [%d] | %s%s() {" % ("", _tid, space, _symname)
+    print(buf)
+    return _entry_addr
+
+def uftrace_exit(args):
+    # read arguments
+    _tid = args["tid"]
+    _depth = args["depth"]
+    _start_time = args["start_time"]
+    _end_time = args["end_time"]
+    _ret_addr = args["ret_addr"]
+    _symname = args["symname"]
+
+    indent = _depth * 2
+    space = " " * indent
+
+    (time, unit) = get_time_and_unit(_start_time, _end_time)
+    buf = " %7.3f %s [%d] | %s}" % (time, unit, _tid, space)
+
+    if "retval" in args:
+        buf += " = %s" % str(args["retval"])
+    buf += ";"
+    buf = "%s /* %s */" % (buf, _symname)
+    print(buf)
+    return _ret_addr
+
+def get_time_and_unit(start_time, end_time):
+    duration = float(end_time - start_time)
+    time_unit = ""
+
+    if duration < 1000:
+        divider = 1
+        time_unit = "ns"
+    elif duration < 1000000:
+        divider = 1000
+        time_unit = "us"
+    elif duration < 1000000000:
+        divider = 1000000
+        time_unit = "ms"
+    else:
+        divider = 1000000000
+        time_unit = " s"
+
+    return (duration / divider, time_unit)

--- a/uftrace.c
+++ b/uftrace.c
@@ -57,6 +57,7 @@ enum options {
 	OPT_max_stack,
 	OPT_port,
 	OPT_nopager,
+	OPT_sort,
 	OPT_avg_total,
 	OPT_avg_self,
 	OPT_color,
@@ -110,7 +111,7 @@ static struct argp_option ftrace_options[] = {
 	{ "host", 'H', "HOST", 0, "Send trace data to HOST instead of write to file" },
 	{ "port", OPT_port, "PORT", 0, "Use PORT for network connection" },
 	{ "no-pager", OPT_nopager, 0, 0, "Do not use pager" },
-	{ "sort", 's', "KEY[,KEY,...]", 0, "Sort reported functions by KEYs" },
+	{ "sort", OPT_sort, "KEY[,KEY,...]", 0, "Sort reported functions by KEYs" },
 	{ "avg-total", OPT_avg_total, 0, 0, "Show average/min/max of total function time" },
 	{ "avg-self", OPT_avg_self, 0, 0, "Show average/min/max of self function time" },
 	{ "color", OPT_color, "SET", 0, "Use color for output: yes, no, auto" },
@@ -144,6 +145,7 @@ static struct argp_option ftrace_options[] = {
 	{ "patch", 'P', "FUNC", 0, "Apply dynamic patching for FUNCs" },
 	{ "event", 'E', "EVENT", 0, "Enable EVENT to save more information" },
 	{ "list-event", OPT_list_event, 0, 0, "List avaiable events" },
+	{ "script", 's', "SCRIPT", 0, "Run the given SCRIPT in function entry and exit" },
 	{ 0 }
 };
 
@@ -401,10 +403,6 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 		opts->host = arg;
 		break;
 
-	case 's':
-		opts->sort_keys = opt_add_string(opts->sort_keys, arg);
-		break;
-
 	case 't':
 		opts->threshold = parse_time(arg, 3);
 		if (opts->range.start || opts->range.stop) {
@@ -445,6 +443,10 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 		}
 		else
 			opts->event = opt_add_string(opts->event, arg);
+		break;
+
+	case 's':
+		opts->script_file = arg;
 		break;
 
 	case OPT_flat:
@@ -506,6 +508,10 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 
 	case OPT_nopager:
 		opts->use_pager = false;
+		break;
+
+	case OPT_sort:
+		opts->sort_keys = opt_add_string(opts->sort_keys, arg);
 		break;
 
 	case OPT_avg_total:

--- a/uftrace.h
+++ b/uftrace.h
@@ -202,6 +202,7 @@ struct opts {
 	char *fields;
 	char *patch;
 	char *event;
+	char *script_file;
 	int mode;
 	int idx;
 	int depth;

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -6,6 +6,7 @@
 #include <errno.h>
 #include <sys/uio.h>
 #include <sys/stat.h>
+#include <libgen.h>
 
 #include "utils/utils.h"
 
@@ -391,4 +392,29 @@ char * strjoin(char *left, char *right, char *delim)
 
 	strcpy(new + len - rlen - 1, right);
 	return new;
+}
+
+/**
+ * absolute_dirname - return the canonicalized absolute dirname
+ *
+ * @path: pathname string that can be either absolute or relative path
+ * @resolved_path: input buffer that will store absolute dirname
+ *
+ * This function parses the @path and sets absolute dirname to @resolved_path.
+ *
+ * Given @path sets @resolved_path as follows:
+ *
+ *    @path                   | @resolved_path
+ *   -------------------------+----------------
+ *    mcount.py               | $PWD
+ *    tests/mcount.py         | $PWD/tests
+ *    ./tests/mcount.py       | $PWD/./tests
+ *    /root/uftrace/mcount.py | /root/uftrace
+ */
+char *absolute_dirname(const char *path, char *resolved_path)
+{
+	realpath(path, resolved_path);
+	dirname(resolved_path);
+
+	return resolved_path;
 }

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -249,4 +249,6 @@ uint64_t parse_time(char *arg, int limited_digits);
 
 char * strjoin(char *left, char *right, char *delim);
 
+char *absolute_dirname(const char *path, char *resolved_path);
+
 #endif /* __FTRACE_UTILS_H__ */


### PR DESCRIPTION
This PR supports Python binding for mcount entry and exit so that one can easily add a python script with `-p` option to hook function entry and exit and do whatever they want.

The user can write a python script with two functions, `mcount_entry` and `mcount_exit`.
- `mcount_entry` accepts two parameters including the function entry address and the return(call site) address.
- `mcount_exit` accepts two parameters including the function return address and the return value if it has.

The example input python script `mcount_replay.py` is as follows:
```
indent = 0

def mcount_entry(entry_addr, ret_addr):
    global indent
    space = " " * indent

    buf = "%s%s() {" % (space, hex(entry_addr))
    print(buf)
    indent += 2
    return entry_addr

def mcount_exit(ret_addr, retval):
    global indent
    indent -= 2
    space = " " * indent

    buf = "%s}" % space
    if retval:
        buf += " = %s" % str(retval)
    buf += ";"
    print(buf)
    return ret_addr
```
The above script can be passed to `uftrace` with `-p` option as follows:
```
$ uftrace -p mcount_replay -R .*@retval ./t-abc
0x400721() {
  0x4006c6() {
    0x4006d9() {
      0x4006ec() {
      } = 90186;
    } = 90187;
  } = 90186;
};
# DURATION    TID     FUNCTION
   0.725 us [290186] | __monstartup() = 0x7fb738f286a0;
   0.410 us [290186] | __cxa_atexit() = 0;
            [290186] | main() {
            [290186] |   a() {
            [290186] |     b() {
            [290186] |       c() {
   0.441 us [290186] |         getpid() = 0x46d8a;
   4.715 us [290186] |       } = 90186; /* c */
  10.044 us [290186] |     } = 90187; /* b */
  12.395 us [290186] |   } = 90186; /* a */
  15.360 us [290186] | } = 0; /* main */
```
It looks like the `uftrace replay` output and it prints function entry addresses and it also prints return values if it have.

The benefits of Python binding are as follows:
- It shows the output in real `live`, not showing the trace log after the program is finished. The user can see the immediate function call and return events while running programs and it may be useful when running deamon programs.
- It also doesn't have to record the data at all if user wants to save device storage.
- Lastly, it doesn't have to be recompiled to see different output but just rewrite the python script. It's especially useful when tracing in embedded devices that do not have a native compiler.