### PR TITLE
Add a method to trigger some command line when trace data received (during uftrace recv)

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -83,6 +83,7 @@ enum options {
 	OPT_kernel_full,
 	OPT_kernel_only,
 	OPT_list_event,
+	OPT_run_cmd,
 };
 
 static struct argp_option ftrace_options[] = {
@@ -144,6 +145,7 @@ static struct argp_option ftrace_options[] = {
 	{ "patch", 'P', "FUNC", 0, "Apply dynamic patching for FUNCs" },
 	{ "event", 'E', "EVENT", 0, "Enable EVENT to save more information" },
 	{ "list-event", OPT_list_event, 0, 0, "List avaiable events" },
+	{ "run-cmd", OPT_run_cmd, "CMDLINE", 0, "Command line that want to execute after tracing data received" },
 	{ 0 }
 };
 
@@ -638,6 +640,14 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 
 	case OPT_list_event:
 		opts->list_event = true;
+		break;
+
+	case OPT_run_cmd:
+		if (opts->run_cmd) {
+			pr_warn("intermediate --run-cmd argument is ignored.\n");
+			free_parsed_cmdline(opts->run_cmd);
+		}
+		opts->run_cmd = parse_cmdline(arg, NULL);
 		break;
 
 	case ARGP_KEY_ARG:

--- a/uftrace.h
+++ b/uftrace.h
@@ -172,6 +172,7 @@ struct opts {
 	char *fields;
 	char *patch;
 	char *event;
+	char **run_cmd;
 	int mode;
 	int idx;
 	int depth;

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -244,4 +244,7 @@ uint64_t parse_time(char *arg, int limited_digits);
 
 char * strjoin(char *left, char *right, char *delim);
 
+char **parse_cmdline(char *cmd, int *argc);
+void free_parsed_cmdline(char **argv);
+
 #endif /* __FTRACE_UTILS_H__ */


### PR DESCRIPTION
Hi, @namhyung.

I hope to add a feature to execute command when uftrace data received.
With this, user can see the output of their own script to analysis something immediately the trace ends.

Originally, I hope to create some remote interface that start/end the trace and do something after the trace.
It may be a first step to reach that.