### PR TITLE
test: Reorder 'expected' and 'result' in verbose mode

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -332,9 +332,9 @@ class TestBase:
                 return TestBase.TEST_ABNORMAL_EXIT
             return TestBase.TEST_NONZERO_RETURN
 
-        self.pr_debug("=========== %s =============\n%s" % ("expected", result_expect))
-        self.pr_debug("=========== %s =============\n%s" % ("original", result_origin))
-        self.pr_debug("=========== %s =============\n%s" % ("result", result_tested))
+        self.pr_debug("=========== %s ===========\n%s" % ("original", result_origin))
+        self.pr_debug("=========== %s ===========\n%s" % (" result ", result_tested))
+        self.pr_debug("=========== %s ===========\n%s" % ("expected", result_expect))
 
         if result_expect.strip() == '':
             return TestBase.TEST_DIFF_RESULT


### PR DESCRIPTION
It's easier to compare the 'result' and 'expected' in runtest.py output
when they are placed closely.

With this change, the 'result' and 'expected' are placed very closely so
they can be easily compared.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>