### PR TITLE
Makefile: Add LDFLAGS in export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 RM = rm -f
 INSTALL = install
 
-export ARCH CC AR LD RM srcdir objdir
+export ARCH CC AR LD RM srcdir objdir LDFLAGS
 
 COMMON_CFLAGS := -O2 -g -D_GNU_SOURCE $(CFLAGS) $(CPPFLAGS)
 COMMON_CFLAGS +=  -iquote $(srcdir) -iquote $(objdir) -iquote $(srcdir)/arch/$(ARCH)


### PR DESCRIPTION
To use build with musl, need to argp library.
So need to add LDFLAGS from outside.

Signed-off-by: Changhyeok Bae <changhyeok.bae@gmail.com>