### PR TITLE
dynamic tracing: small refactoring

### DIFF
--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -167,16 +167,16 @@ static int patch_fentry_func(struct mcount_dynamic_info *mdi, struct sym *sym)
 	unsigned char *insn = (void *)sym->addr;
 	unsigned int target_addr;
 
-	/* get the jump offset to the trampoline */
-	target_addr = get_target_addr(mdi, sym->addr);
-	if (target_addr == 0)
-		return -2;
-
 	/* only support calls to __fentry__ at the beginning */
 	if (memcmp(insn, nop, sizeof(nop))) {
 		pr_dbg2("skip non-applicable functions: %s\n", sym->name);
 		return -2;
 	}
+
+	/* get the jump offset to the trampoline */
+	target_addr = get_target_addr(mdi, sym->addr);
+	if (target_addr == 0)
+		return -2;
 
 	/* make a "call" insn with 4-byte offset */
 	insn[0] = 0xe8;

--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -148,11 +148,13 @@ out:
 	free(names);
 }
 
+#define CALL_INSN_SIZE 5
+
 static unsigned long get_target_addr(struct mcount_dynamic_info *mdi, unsigned long addr)
 {
 	while (mdi) {
 		if (mdi->addr <= addr && addr < mdi->addr + mdi->size)
-			return mdi->trampoline - (addr + 5);
+			return mdi->trampoline - (addr + CALL_INSN_SIZE);
 
 		mdi = mdi->next;
 	}


### PR DESCRIPTION
Hi @namhyung ,

I came up with little refactoring patches while reading the code for dynamic tracing.
If you give me some feedback, I'd appreciate it. 😄 

Additionally what do you think about renaming "target_addr" to "jump_offset" ? like below.

```
diff --git a/arch/x86_64/mcount-dynamic.c b/arch/x86_64/mcount-dynamic.c
index 2b660c7..771c789 100644
--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -150,7 +150,7 @@ out:
 
 #define NOP_INSN_SIZE 5
 
-static unsigned long get_target_addr(struct mcount_dynamic_info *mdi, unsigned long addr)
+static unsigned long get_jump_offset(struct mcount_dynamic_info *mdi, unsigned long addr)
 {
         while (mdi) {
                 if (mdi->addr <= addr && addr < mdi->addr + mdi->size)
@@ -165,7 +165,7 @@ static int patch_fentry_func(struct mcount_dynamic_info *mdi, struct sym *sym)
 {
         unsigned char nop[] = { 0x67, 0x0f, 0x1f, 0x04, 0x00 };
         unsigned char *insn = (void *)sym->addr;
-        unsigned int target_addr;
+        unsigned int jump_offset;
 
         /* only support calls to __fentry__ at the beginning */
         if (memcmp(insn, nop, sizeof(nop))) {
@@ -174,14 +174,14 @@ static int patch_fentry_func(struct mcount_dynamic_info *mdi, struct sym *sym)
         }
 
         /* get the jump offset to the trampoline */
-        target_addr = get_target_addr(mdi, sym->addr);
-        if (target_addr == 0)
+        jump_offset = get_jump_offset(mdi, sym->addr);
+        if (jump_offset == 0)
                 return -2;
 
         /* make a "call" insn with 4-byte offset */
         insn[0] = 0xe8;
         /* hopefully we're not patching 'memcpy' itself */
-        memcpy(&insn[1], &target_addr, sizeof(target_addr));
+        memcpy(&insn[1], &jump_offset, sizeof(jump_offset));
 
         pr_dbg3("update function '%s' dynamically to call __fentry__\n",
                 sym->name);

```
