### PR TITLE
kernel: Fix the problem about enabled "tracing_on" even after kernel tracing was done

### DIFF
--- a/cmd-record.c
+++ b/cmd-record.c
@@ -1579,8 +1579,10 @@ int command_record(int argc, char *argv[], struct opts *opts)
 	}
 
 	stop_all_writers();
-	if (opts->kernel)
-		stop_kernel_tracing(&kernel);
+	if (opts->kernel) {
+		if (stop_kernel_tracing(&kernel) == 0)
+			pr_dbg("kernel tracing stopped\n");
+	}
 
 	if (fill_file_header(opts, status, &usage) < 0)
 		pr_err("cannot generate data file");

--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -378,9 +378,6 @@ next:
 
 static int reset_tracing_files(void)
 {
-	if (write_tracing_file("tracing_on", "1") < 0)
-		return -1;
-
 	if (write_tracing_file("current_tracer", "nop") < 0)
 		return -1;
 


### PR DESCRIPTION
Hi @namhyung ,

I found this problem below case:

```
$ cat /sys/kernel/debug/tracing/tracing_on
0

$ sudo uftrace -k t-openclose 
# DURATION    TID     FUNCTION
   2.141 us [23687] | __monstartup();
   2.029 us [23687] | __cxa_atexit();
            [23687] | main() {
            [23687] |   open() {
  25.416 us [23687] |     sys_open();
...

$ cat /sys/kernel/debug/tracing/tracing_on
1
```
If it ordinarily works, "tracing_on" was disabled after kernel tracing, Right ?
So I fix it. Additionally I added a debug message for stop_kernel_tracing()

I'd appreciate some feedback on my patches. 😄 