### PR TITLE
build: Add 'make ctags' rule for ctags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,4 +243,8 @@ clean:
 	@$(MAKE) -sC $(srcdir)/doc clean
 	@$(MAKE) -sC $(srcdir)/libtraceevent clean
 
-.PHONY: all config clean test dist doc PHONY
+ctags:
+	@find . -name "*\.[chS]" -o -path ./tests -prune -o -path ./check-deps -prune \
+		| xargs ctags --regex-asm='/^(GLOBAL|ENTRY|END)\(([^)]*)\).*/\2/'
+
+.PHONY: all config clean test dist doc ctags PHONY


### PR DESCRIPTION
It'd be useful if 'make tags' can generate ctags file for useful source
files excluding tests and check-deps.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>