### PR TITLE
Support python script for function entry and exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ $(objdir)/.config: $(srcdir)/configure
 # updated dependency.  So just abort the current build.
 	$(error)
 
-config: $(srcdir)/configure
+config: $(srcdir)/configure $(srcdir)/check-deps/Makefile
 	$(QUIET_GEN)$(srcdir)/configure -o $(objdir)/.config $(MAKEOVERRIDES)
 
 $(LIBMCOUNT_UTILS_OBJS): $(objdir)/%.op: $(srcdir)/utils/%.c $(COMMON_DEPS)

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ LIBMCOUNT_FAST_SINGLE_OBJS := $(patsubst $(objdir)/%.op,$(objdir)/%-fast-single.
 LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/symbol.c $(srcdir)/utils/debug.c
 LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/rbtree.c $(srcdir)/utils/filter.c
 LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/demangle.c $(srcdir)/utils/utils.c
+LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/script.c $(srcdir)/utils/script-python.c
 LIBMCOUNT_UTILS_OBJS := $(patsubst $(srcdir)/utils/%.c,$(objdir)/%.op,$(LIBMCOUNT_UTILS_SRCS))
 
 LIBMCOUNT_NOP_SRCS := $(srcdir)/libmcount/mcount-nop.c

--- a/check-deps/Makefile
+++ b/check-deps/Makefile
@@ -3,6 +3,7 @@ CHECK_LIST += cc_has_mfentry
 CHECK_LIST += cxa_demangle
 CHECK_LIST += have_libelf
 CHECK_LIST += cc_has_mno_sse2
+CHECK_LIST += have_libpython2.7
 
 #
 # This is needed for checking build dependency
@@ -15,6 +16,7 @@ CFLAGS_cc_has_mfentry = -mfentry
 LDFLAGS_cxa_demangle = -lstdc++
 LDFLAGS_have_libelf = -lelf
 CFLAGS_cc_has_mno_sse2 = -mno-sse2
+LDFLAGS_have_libpython2.7 = -lpython2.7
 
 check-build: check-tstamp $(CHECK_LIST)
 

--- a/check-deps/Makefile.check
+++ b/check-deps/Makefile.check
@@ -14,3 +14,7 @@ endif
 ifneq ($(wildcard $(srcdir)/check-deps/cc_has_mno_sse2),)
   LIB_CFLAGS += -mno-sse2
 endif
+
+ifneq ($(wildcard $(srcdir)/check-deps/have_libpython2.7),)
+  COMMON_CFLAGS += -DHAVE_LIBPYTHON2
+endif

--- a/check-deps/__have_libpython2.7.c
+++ b/check-deps/__have_libpython2.7.c
@@ -1,0 +1,7 @@
+#include <python2.7/Python.h>
+
+int main(void)
+{
+       Py_Initialize();
+       return 0;
+}

--- a/cmd-record.c
+++ b/cmd-record.c
@@ -62,7 +62,7 @@ static bool can_use_fast_libmcount(struct opts *opts)
 		return false;
 	if (getenv("UFTRACE_FILTER") || getenv("UFTRACE_TRIGGER") ||
 	    getenv("UFTRACE_ARGUMENT") || getenv("UFTRACE_RETVAL") ||
-	    getenv("UFTRACE_PATCH"))
+	    getenv("UFTRACE_PATCH") || getenv("UFTRACE_SCRIPT"))
 		return false;
 	return true;
 }
@@ -228,6 +228,9 @@ static void setup_child_environ(struct opts *opts, int pfd)
 	if ((opts->kernel || has_kernel_event(opts->event)) &&
 	    check_kernel_pid_filter())
 		setenv("UFTRACE_KERNEL_PID_UPDATE", "1", 1);
+
+	if (opts->script_file)
+		setenv("UFTRACE_SCRIPT", opts->script_file, 1);
 
 	if (opts->lib_path)
 		snprintf(buf, sizeof(buf), "%s/libmcount/", opts->lib_path);

--- a/cmd-script.c
+++ b/cmd-script.c
@@ -1,0 +1,162 @@
+/*
+ * Python script binding for function entry and exit
+ *
+ * Copyright (C) 2017, LG Electronics, Honggyu Kim <hong.gyu.kim@lge.com>
+ *
+ * Released under the GPL v2.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdio_ext.h>
+
+#include "uftrace.h"
+#include "utils/utils.h"
+#include "utils/symbol.h"
+#include "utils/filter.h"
+#include "utils/fstack.h"
+#include "utils/script.h"
+
+#include "libtraceevent/event-parse.h"
+
+
+static int run_script_for_rstack(struct ftrace_file_handle *handle,
+				 struct ftrace_task_handle *task,
+				 struct opts *opts)
+{
+	struct uftrace_record *rstack = task->rstack;
+	struct uftrace_session_link *sessions = &handle->sessions;
+	struct sym *sym = NULL;
+	char *symname = NULL;
+
+	if (task == NULL)
+		return 0;
+
+	sym = task_find_sym(sessions, task, rstack);
+	symname = symbol_getname(sym, rstack->addr);
+
+	task->timestamp_last = task->timestamp;
+	task->timestamp = rstack->time;
+
+	if (rstack->type == UFTRACE_ENTRY) {
+		struct fstack *fstack;
+		int depth;
+		struct ftrace_trigger tr = {
+			.flags = 0,
+		};
+		int ret;
+
+		ret = fstack_entry(task, rstack, &tr);
+		if (ret < 0)
+			goto out;
+
+		/* display depth is set in fstack_entry() */
+		depth = task->display_depth;
+
+		fstack = &task->func_stack[task->stack_count - 1];
+		fstack_update(UFTRACE_ENTRY, task, fstack);
+
+		/* setup arguments for script execution */
+		struct script_args sc_args = {
+			.tid = task->tid,
+			.depth = depth,  /* display depth */
+			.timestamp = rstack->time,
+			.address = rstack->addr,
+			.symname = symname,
+		};
+
+		/* script hooking for function entry */
+		script_uftrace_entry(&sc_args);
+	}
+	else if (rstack->type == UFTRACE_EXIT) {
+		struct fstack *fstack;
+
+		/* function exit */
+		fstack = &task->func_stack[task->stack_count];
+
+		if (!(fstack->flags & FSTACK_FL_NORECORD) && fstack_enabled) {
+			int depth = fstack_update(UFTRACE_EXIT, task, fstack);
+
+			/* display depth is set before passing rstack */
+			rstack->depth = depth;
+		}
+
+		fstack_exit(task);
+
+		/* setup arguments for script execution */
+		struct script_args sc_args = {
+			.tid = task->tid,
+			.depth = rstack->depth,
+			.timestamp = rstack->time,
+			.duration = fstack->total_time,
+			.address = rstack->addr,
+			.symname = symname,
+		};
+
+		/* script hooking for function exit */
+		script_uftrace_exit(&sc_args);
+	}
+	else if (rstack->type == UFTRACE_LOST) {
+		/* Do nothing as of now */
+	}
+	else if (rstack->type == UFTRACE_EVENT) {
+		/* TODO: event handling */
+	}
+out:
+	symbol_putname(sym, symname);
+	return 0;
+}
+
+int command_script(int argc, char *argv[], struct opts *opts)
+{
+	int ret;
+	struct ftrace_file_handle handle;
+	struct ftrace_task_handle *task;
+
+	if (!SCRIPT_ENABLED) {
+		pr_warn("script command is not supported due to missing libpython2.7.so\n");
+		return -1;
+	}
+
+	if (!opts->script_file) {
+		pr_out("Usage: uftrace script [-S|--script] [<script_file>]\n");
+		return -1;
+	}
+
+	__fsetlocking(outfp, FSETLOCKING_BYCALLER);
+	__fsetlocking(logfp, FSETLOCKING_BYCALLER);
+
+	ret = open_data_file(opts, &handle);
+	if (ret < 0)
+		return -1;
+
+	fstack_setup_filters(opts, &handle);
+
+	/* initialize script */
+	if (script_init(opts->script_file) < 0)
+		return -1;
+
+	while (read_rstack(&handle, &task) == 0 && !uftrace_done) {
+		struct uftrace_record *rstack = task->rstack;
+
+		/* skip user functions if --kernel-only is set */
+		if (opts->kernel_only && !is_kernel_record(task, rstack))
+			continue;
+
+		if (opts->kernel_skip_out) {
+			/* skip kernel functions outside user functions */
+			if (!task->user_stack_count &&
+			    is_kernel_record(task, rstack))
+				continue;
+		}
+
+		ret = run_script_for_rstack(&handle, task, opts);
+
+		if (ret)
+			break;
+	}
+
+	close_data_file(opts, &handle);
+
+	return ret;
+}

--- a/cmd-script.c
+++ b/cmd-script.c
@@ -156,6 +156,9 @@ int command_script(int argc, char *argv[], struct opts *opts)
 			break;
 	}
 
+	/* dtor for script support */
+	script_uftrace_end();
+
 	close_data_file(opts, &handle);
 
 	return ret;

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,7 +7,7 @@ INSTALL = install
 
 include ../Makefile.include
 
-COMMANDS = record replay live report recv info dump graph
+COMMANDS = record replay live report recv info dump graph script
 MANPAGES = uftrace.1 $(patsubst %,uftrace-%.1,$(COMMANDS))
 
 ifeq ($(has_pandoc),yes)

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -124,6 +124,9 @@ OPTIONS
 \--keep-pid
 :   Retain same pid for traced program.  For some daemon processes, it is important to have same pid when forked.  Running under uftrace normally changes pid as it calls fork() again internally.  Note that it might corrupt terminal setting so it'd be better using it with `--no-pager` option.
 
+-S *SCRIPT_PATH*, \--script=*SCRIPT_PATH*
+:   Add a script to do addtional work at the entry and exit of function.  The type of script is detected by the postfix such as '.py' for python.
+
 
 FILTERS
 =======
@@ -404,6 +407,69 @@ For example, you can build the target program by clang with the below option and
        3.005 us [11098] | } /* main */
 
 
+SCRIPT EXECUTION
+================
+The uftrace tool supports script execution for each function entry and exit.  The supported script is only Python 2.7 as of now.
+
+The user can write four functions. 'uftrace_entry' and 'uftrace_exit' are executed whenever each function is executed at the entry and exit.  However 'uftrace_begin' and 'uftrace_end' are only executed once when the target program begins and ends.
+
+    $ cat scripts/simple.py
+    def uftrace_begin():
+        print("program begins...")
+
+    def uftrace_entry(args):
+        _symname = args["symname"]
+        print("entry : " + _symname + "()")
+
+    def uftrace_exit(args):
+        _symname = args["symname"]
+        print("exit  : " + _symname + "()")
+
+    def uftrace_end():
+        print("program is finished")
+
+The above script can be executed in record time as follows:
+
+    $ uftrace -S scripts/simple.py -F main tests/t-abc
+    program begins...
+    entry : main()
+    entry : a()
+    entry : b()
+    entry : c()
+    entry : getpid()
+    exit  : getpid()
+    exit  : c()
+    exit  : b()
+    exit  : a()
+    exit  : main()
+    program is finished
+    # DURATION    TID     FUNCTION
+                [25794] | main() {
+                [25794] |   a() {
+                [25794] |     b() {
+                [25794] |       c() {
+                [25794] |         getpid() {
+      11.037 us [25794] |         } /* getpid */
+      44.752 us [25794] |       } /* c */
+      70.924 us [25794] |     } /* b */
+      98.191 us [25794] |   } /* a */
+     124.329 us [25794] | } /* main */
+
+The 'args' variable is a dictionary type that contains the below information.
+
+    /* argument information passed to script */
+    struct script_args {
+        int        tid;
+        int        depth;
+        uint64_t   timestamp;
+        uint64_t   duration;    /* exit only */
+        unsigned   long address;
+        char       *symname;
+    };
+
+Each field in 'struct script_args' can be read inside the script.
+
+
 SEE ALSO
 ========
-`uftrace-record`(1), `uftrace-replay`(1), `uftrace-report`(1)
+`uftrace-record`(1), `uftrace-replay`(1), `uftrace-report`(1), `uftrace-script`(1)

--- a/doc/uftrace-script.md
+++ b/doc/uftrace-script.md
@@ -1,0 +1,118 @@
+% UFTRACE-SCRIPT(1) Uftrace User Manuals
+% Honggyu Kim <honggyu.kp@gmail.com>
+% July, 2017
+
+NAME
+====
+uftrace-script - Run a script for recorded function trace
+
+
+SYNOPSIS
+========
+uftrace script [*options*]
+
+
+DESCRIPTION
+===========
+This command runs a script for trace data recorded using the `uftrace-record`(1) command.
+
+
+OPTIONS
+=======
+-F *FUNC*, \--filter=*FUNC*
+:   Set filter to trace selected functions only.  This option can be used more than once.  See 'uftrace-replay' for details.
+
+-N *FUNC*, \--notrace=*FUNC*
+:   Set filter not to trace selected functions (or the functions called underneath them).  This option can be used more than once.  See 'uftrace-replay' for details.
+
+-T *TRG*, \--trigger=*TRG*
+:   Set trigger on selected functions.  This option can be used more than once.  See 'uftrace-replay' for details.
+
+-t *TIME*, \--time-filter=*TIME*
+:   Do not show functions which run under the time threshold.  If some functions explicitly have the 'trace' trigger applied, those are always traced regardless of execution time.
+
+\--tid=*TID*[,*TID*,...]
+:   Only print functions called by the given threads.  To see the list of threads in the data file, you can use `uftrace report --threads` or `uftrace info`.  This option can also be used more than once.
+
+-D *DEPTH*, \--depth *DEPTH*
+:   Set trace limit in nesting level.
+
+-r *RANGE*, \--time-range=*RANGE*
+:   Only show functions executed within the time RANGE.  The RANGE can be \<start\>~\<stop\> (separated by "~") and one of \<start\> and \<stop\> can be omitted.  The \<start\> and \<stop\> are timestamp or elapsed time if they have \<time_unit\> postfix, for example '100us'.  The timestamp or elapsed time can be shown with `-f time` or `-f elapsed` option respectively.
+
+-S *SCRIPT_PATH*, \--script=*SCRIPT_PATH*
+:   Add a script to do addtional work at the entry and exit of function.  The type of script is detected by the postfix such as '.py' for python.
+
+
+EXAMPLES
+========
+The uftrace tool supports script execution for each function entry and exit.  The supported script is only Python 2.7 as of now.
+
+The user can write four functions. 'uftrace_entry' and 'uftrace_exit' are executed whenever each function is executed at the entry and exit.  However 'uftrace_begin' and 'uftrace_end' are only executed once when the target program begins and ends.
+
+    $ cat scripts/simple.py
+    def uftrace_begin():
+        print("program begins...")
+
+    def uftrace_entry(args):
+        _symname = args["symname"]
+        print("entry : " + _symname + "()")
+
+    def uftrace_exit(args):
+        _symname = args["symname"]
+        print("exit  : " + _symname + "()")
+
+    def uftrace_end():
+        print("program is finished")
+
+The 'args' variable is a dictionary type that contains the below information.
+
+    /* argument information passed to script */
+    struct script_args {
+        int        tid;
+        int        depth;
+        uint64_t   timestamp;
+        uint64_t   duration;    /* exit only */
+        unsigned   long address;
+        char       *symname;
+    };
+
+The above script can be executed while reading the recorded data.  The usage is as follows:
+
+    $ uftrace record -F main tests/t-abc
+
+    $ uftrace scripts -S scripts/simple.py
+    program begins...
+    entry : main()
+    entry : a()
+    entry : b()
+    entry : c()
+    entry : getpid()
+    exit  : getpid()
+    exit  : c()
+    exit  : b()
+    exit  : a()
+    exit  : main()
+    program is finished
+
+The below is another example that shows the different output compared to previous one for the same recorded data.  The output looks similar to 'uftrace replay' this time.
+
+    $ uftrace script -S scripts/replay.py
+    # DURATION    TID     FUNCTION
+                [25794] | main() {
+                [25794] |   a() {
+                [25794] |     b() {
+                [25794] |       c() {
+                [25794] |         getpid() {
+      11.037 us [25794] |         } /* getpid */
+      44.752 us [25794] |       } /* c */
+      70.924 us [25794] |     } /* b */
+      98.191 us [25794] |   } /* a */
+     124.329 us [25794] | } /* main */
+
+The python script above can be modified to do more output customization.
+
+
+SEE ALSO
+========
+`uftrace`(1), `uftrace-record`(1), `uftrace-replay`(1), `uftrace-live`(1)

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -32,6 +32,7 @@
 #include "utils/symbol.h"
 #include "utils/filter.h"
 #include "utils/compiler.h"
+#include "utils/script.h"
 
 uint64_t mcount_threshold;  /* nsec */
 struct symtabs symtabs = {
@@ -1062,6 +1063,7 @@ static void mcount_startup(void)
 	plthook_str = getenv("UFTRACE_PLTHOOK");
 	patch_str = getenv("UFTRACE_PATCH");
 	event_str = getenv("UFTRACE_EVENT");
+	script_str = getenv("UFTRACE_SCRIPT");
 
 	if (logfd_str) {
 		int fd = strtol(logfd_str, NULL, 0);

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -252,6 +252,10 @@ static void mtd_dtor(void *arg)
 	tmsg.tid = gettid(mtdp),
 	tmsg.time = mcount_gettime();
 
+	/* dtor for script support */
+	if (SCRIPT_ENABLED && script_str)
+		script_uftrace_end();
+
 	uftrace_send_message(UFTRACE_MSG_TASK_END, &tmsg, sizeof(tmsg));
 }
 

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -14,6 +14,7 @@
 #include "mcount-arch.h"
 #include "utils/filter.h"
 #include "utils/compiler.h"
+#include "utils/script.h"
 
 extern struct symtabs symtabs;
 

--- a/misc/bash-completion.sh
+++ b/misc/bash-completion.sh
@@ -6,7 +6,7 @@ _uftrace () {
 
     COMPREPLY=()
 
-    subcmds='record replay report live dump graph info recv'
+    subcmds='record replay report live dump graph info recv script'
     options=$(uftrace -? | awk '$1 ~ /--[a-z]/ { split($1, r, "="); print r[1] } \
                                 $2 ~ /--[a-z]/ { split($2, r, "="); print r[1] }')
     demangle='full simple no'

--- a/scripts/count.py
+++ b/scripts/count.py
@@ -1,0 +1,14 @@
+count = 0
+
+def uftrace_begin():
+    pass
+
+def uftrace_entry(args):
+    global count
+    count += 1
+
+def uftrace_exit(args):
+    pass
+
+def uftrace_end():
+    print(count)

--- a/scripts/replay.py
+++ b/scripts/replay.py
@@ -1,4 +1,5 @@
-print("# DURATION    TID     FUNCTION")
+def uftrace_begin():
+    print("# DURATION    TID     FUNCTION")
 
 def uftrace_entry(args):
     # read arguments
@@ -26,6 +27,10 @@ def uftrace_exit(args):
     buf = " %7.3f %s [%5d] | %s}" % (time, unit, _tid, space)
     buf = "%s /* %s */" % (buf, _symname)
     print(buf)
+
+def uftrace_end():
+    # print an empty line
+    print("")
 
 def get_time_and_unit(duration):
     duration = float(duration)

--- a/scripts/replay.py
+++ b/scripts/replay.py
@@ -1,0 +1,47 @@
+print("# DURATION    TID     FUNCTION")
+
+def uftrace_entry(args):
+    # read arguments
+    _tid = args["tid"]
+    _depth = args["depth"]
+    _symname = args["symname"]
+
+    indent = _depth * 2
+    space = " " * indent
+
+    buf = " %10s [%5d] | %s%s() {" % ("", _tid, space, _symname)
+    print(buf)
+
+def uftrace_exit(args):
+    # read arguments
+    _tid = args["tid"]
+    _depth = args["depth"]
+    _symname = args["symname"]
+    _duration = args["duration"]
+
+    indent = _depth * 2
+    space = " " * indent
+
+    (time, unit) = get_time_and_unit(_duration)
+    buf = " %7.3f %s [%5d] | %s}" % (time, unit, _tid, space)
+    buf = "%s /* %s */" % (buf, _symname)
+    print(buf)
+
+def get_time_and_unit(duration):
+    duration = float(duration)
+    time_unit = ""
+
+    if duration < 100:
+        divider = 1
+        time_unit = "ns"
+    elif duration < 1000000:
+        divider = 1000
+        time_unit = "us"
+    elif duration < 1000000000:
+        divider = 1000000
+        time_unit = "ms"
+    else:
+        divider = 1000000000
+        time_unit = " s"
+
+    return (duration / divider, time_unit)

--- a/scripts/simple.py
+++ b/scripts/simple.py
@@ -1,0 +1,7 @@
+def uftrace_entry(args):
+    _symname = args["symname"]
+    print("entry : " + _symname + "()")
+
+def uftrace_exit(args):
+    _symname = args["symname"]
+    print("exit  : " + _symname + "()")

--- a/scripts/simple.py
+++ b/scripts/simple.py
@@ -1,3 +1,6 @@
+def uftrace_begin():
+    print("program begins...")
+
 def uftrace_entry(args):
     _symname = args["symname"]
     print("entry : " + _symname + "()")
@@ -5,3 +8,6 @@ def uftrace_entry(args):
 def uftrace_exit(args):
     _symname = args["symname"]
     print("exit  : " + _symname + "()")
+
+def uftrace_end():
+    print("program is finished")

--- a/tests/t157_script_python.py
+++ b/tests/t157_script_python.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+import subprocess as sp
+
+TDIR='xxx'
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'abc', '5')
+
+    def pre(self):
+        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-abc')
+        sp.call(record_cmd.split())
+        return TestBase.TEST_SUCCESS
+
+    def runcmd(self):
+        uftrace = TestBase.ftrace
+        options = '-F main -S ../scripts/count.py'
+        return '%s script -d %s %s' % (uftrace, TDIR, options)
+
+    def sort(self, output):
+        return output.strip()
+
+    def post(self, ret):
+        sp.call(['rm', '-rf', TDIR])
+        return ret

--- a/uftrace.c
+++ b/uftrace.c
@@ -150,6 +150,7 @@ static struct argp_option uftrace_options[] = {
 	{ "run-cmd", OPT_run_cmd, "CMDLINE", 0, "Command line that want to execute after tracing data received" },
 	{ "opt-file", OPT_opt_file, "FILE", 0, "Read command-line options from FILE" },
 	{ "keep-pid", OPT_keep_pid, 0, 0, "Keep same pid during execution of traced program" },
+	{ "script", 'S', "SCRIPT", 0, "Run a given SCRIPT in function entry and exit" },
 	{ 0 }
 };
 
@@ -409,6 +410,10 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 
 	case 's':
 		opts->sort_keys = opt_add_string(opts->sort_keys, arg);
+		break;
+
+	case 'S':
+		opts->script_file = arg;
 		break;
 
 	case 't':

--- a/uftrace.c
+++ b/uftrace.c
@@ -692,6 +692,8 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 			opts->mode = UFTRACE_MODE_DUMP;
 		else if (!strcmp("graph", arg))
 			opts->mode = UFTRACE_MODE_GRAPH;
+		else if (!strcmp("script", arg))
+			opts->mode = UFTRACE_MODE_SCRIPT;
 		else
 			return ARGP_ERR_UNKNOWN; /* almost same as fall through */
 		break;
@@ -744,7 +746,7 @@ static void parse_opt_file(int *argc, char ***argv, char *filename, struct opts 
 	struct argp file_argp = {
 		.options = uftrace_options,
 		.parser = parse_option,
-		.args_doc = "[record|replay|live|report|info|dump|recv|graph] [<program>]",
+		.args_doc = "[record|replay|live|report|info|dump|recv|graph|script] [<program>]",
 		.doc = "uftrace -- function (graph) tracer for userspace",
 	};
 
@@ -798,7 +800,7 @@ int main(int argc, char *argv[])
 	struct argp argp = {
 		.options = uftrace_options,
 		.parser = parse_option,
-		.args_doc = "[record|replay|live|report|info|dump|recv|graph] [<program>]",
+		.args_doc = "[record|replay|live|report|info|dump|recv|graph|script] [<program>]",
 		.doc = "uftrace -- function (graph) tracer for userspace",
 	};
 	int ret = -1;
@@ -870,6 +872,9 @@ int main(int argc, char *argv[])
 		break;
 	case UFTRACE_MODE_GRAPH:
 		ret = command_graph(argc, argv, &opts);
+		break;
+	case UFTRACE_MODE_SCRIPT:
+		ret = command_script(argc, argv, &opts);
 		break;
 	case UFTRACE_MODE_INVALID:
 		ret = 1;

--- a/uftrace.h
+++ b/uftrace.h
@@ -174,6 +174,7 @@ struct opts {
 	char *event;
 	char **run_cmd;
 	char *opt_file;
+	char *script_file;
 	int mode;
 	int idx;
 	int depth;

--- a/uftrace.h
+++ b/uftrace.h
@@ -153,6 +153,7 @@ struct ftrace_file_handle {
 #define UFTRACE_MODE_RECV    6
 #define UFTRACE_MODE_DUMP    7
 #define UFTRACE_MODE_GRAPH   8
+#define UFTRACE_MODE_SCRIPT  9
 
 #define UFTRACE_MODE_DEFAULT  UFTRACE_MODE_LIVE
 
@@ -233,6 +234,7 @@ int command_info(int argc, char *argv[], struct opts *opts);
 int command_recv(int argc, char *argv[], struct opts *opts);
 int command_dump(int argc, char *argv[], struct opts *opts);
 int command_graph(int argc, char *argv[], struct opts *opts);
+int command_script(int argc, char *argv[], struct opts *opts);
 
 extern volatile bool uftrace_done;
 extern struct ftrace_proc_maps *proc_maps;

--- a/utils/script-python.c
+++ b/utils/script-python.c
@@ -1,0 +1,268 @@
+/*
+ * Python script binding for function entry and exit
+ *
+ * Copyright (C) 2017, LG Electronics, Honggyu Kim <hong.gyu.kim@lge.com>
+ *
+ * Released under the GPL v2.
+ */
+
+#ifdef HAVE_LIBPYTHON2
+
+#include <dlfcn.h>
+#include "utils/symbol.h"
+#include "utils/fstack.h"
+#include "utils/script.h"
+#include "utils/script-python.h"
+
+/* python library name, it only supports python 2.7 as of now */
+static const char *libpython = "libpython2.7.so";
+
+/* python library handle returned by dlopen() */
+static void *python_handle;
+
+static PyAPI_FUNC(void) (*__Py_Initialize)(void);
+static PyAPI_FUNC(void) (*__PySys_SetPath)(char *);
+static PyAPI_FUNC(PyObject *) (*__PyImport_Import)(PyObject *name);
+
+static PyAPI_FUNC(PyObject *) (*__PyErr_Occurred)(void);
+static PyAPI_FUNC(void) (*__PyErr_Print)(void);
+
+static PyAPI_FUNC(PyObject *) (*__PyObject_GetAttrString)(PyObject *, const char *);
+static PyAPI_FUNC(int) (*__PyCallable_Check)(PyObject *);
+static PyAPI_FUNC(PyObject *) (*__PyObject_CallObject)(PyObject *callable_object, PyObject *args);
+
+static PyAPI_FUNC(PyObject *) (*__PyString_FromString)(const char *);
+static PyAPI_FUNC(PyObject *) (*__PyInt_FromLong)(long);
+static PyAPI_FUNC(PyObject *) (*__PyLong_FromLong)(long);
+static PyAPI_FUNC(PyObject *) (*__PyLong_FromUnsignedLongLong)(unsigned PY_LONG_LONG);
+
+static PyAPI_FUNC(char *) (*__PyString_AsString)(PyObject *);
+static PyAPI_FUNC(long) (*__PyLong_AsLong)(PyObject *);
+
+static PyAPI_FUNC(PyObject *) (*__PyTuple_New)(Py_ssize_t size);
+static PyAPI_FUNC(int) (*__PyTuple_SetItem)(PyObject *, Py_ssize_t, PyObject *);
+
+static PyAPI_FUNC(PyObject *) (*__PyDict_New)(void);
+static PyAPI_FUNC(int) (*__PyDict_SetItem)(PyObject *mp, PyObject *key, PyObject *item);
+static PyAPI_FUNC(int) (*__PyDict_SetItemString)(PyObject *dp, const char *key, PyObject *item);
+static PyAPI_FUNC(PyObject *) (*__PyDict_GetItem)(PyObject *mp, PyObject *key);
+
+static PyObject *pName, *pModule, *pFuncEntry, *pFuncExit;
+
+extern struct symtabs symtabs;
+
+enum py_args {
+	PY_ARG_TID = 0,
+	PY_ARG_DEPTH,
+	PY_ARG_TIMESTAMP,
+	PY_ARG_DURATION,
+	PY_ARG_ADDRESS,
+	PY_ARG_SYMNAME,
+};
+
+/* The order has to be aligned with enum py_args above. */
+static const char *py_args_table[] = {
+	"tid",
+	"depth",
+	"timestamp",
+	"duration",
+	"address",
+	"symname",
+};
+
+#define INIT_PY_API_FUNC(func) \
+	do { \
+		__##func = dlsym(python_handle, #func); \
+		if (!__##func) { \
+			pr_err("dlsym for \"" #func "\" is failed!\n"); \
+			return -1; \
+		} \
+	} while (0)
+
+static char *remove_py_suffix(char *py_name)
+{
+	char *ext = strrchr(py_name, '.');
+
+	if (!ext)
+		return NULL;
+
+	*ext = '\0';
+	return py_name;
+}
+
+/* Import python module that is given by -p option. */
+static int import_python_module(char *py_pathname)
+{
+	char py_sysdir[PATH_MAX];
+	if (absolute_dirname(py_pathname, py_sysdir) == NULL)
+		return -1;
+
+	/* Set path to import a python module. */
+	__PySys_SetPath(py_sysdir);
+	pr_dbg("PySys_SetPath(\"%s\") is done!\n", py_sysdir);
+
+	char *py_basename = basename(py_pathname);
+	remove_py_suffix(py_basename);
+
+	pName = __PyString_FromString(py_basename);
+	pModule = __PyImport_Import(pName);
+	if (pModule == NULL) {
+		__PyErr_Print();
+		pr_warn("%s.py cannot be imported!\n", py_pathname);
+		return -1;
+	}
+
+	return 0;
+}
+
+static void setup_common_args_in_dict(PyObject **pDict,
+				      struct script_args *sc_args)
+{
+	int tid = sc_args->tid;
+	int depth = sc_args->depth;
+	uint64_t timestamp = sc_args->timestamp;
+	unsigned long address = sc_args->address;
+	char *symname = sc_args->symname;
+
+	PyObject *pTid = __PyInt_FromLong(tid);
+	PyObject *pDepth = __PyInt_FromLong(depth);
+	PyObject *pTimeStamp = __PyLong_FromUnsignedLongLong(timestamp);
+	PyObject *pAddress = __PyInt_FromLong(address);
+	PyObject *pSym  = __PyString_FromString(symname);
+
+	__PyDict_SetItemString(*pDict, py_args_table[PY_ARG_TID], pTid);
+	__PyDict_SetItemString(*pDict, py_args_table[PY_ARG_DEPTH], pDepth);
+	__PyDict_SetItemString(*pDict, py_args_table[PY_ARG_TIMESTAMP], pTimeStamp);
+	__PyDict_SetItemString(*pDict, py_args_table[PY_ARG_ADDRESS], pAddress);
+	__PyDict_SetItemString(*pDict, py_args_table[PY_ARG_SYMNAME], pSym);
+
+	/* Py_XDECREF() frees the object when the count reaches zero. */
+	Py_XDECREF(pTid);
+	Py_XDECREF(pDepth);
+	Py_XDECREF(pTimeStamp);
+	Py_XDECREF(pAddress);
+	Py_XDECREF(pSym);
+}
+
+int python_uftrace_entry(struct script_args *sc_args)
+{
+	if (unlikely(!pFuncEntry))
+		return -1;
+
+	/* Entire arguments are passed into a single dictionary. */
+	PyObject *pDict = __PyDict_New();
+
+	/* Setup common arguments in both entry and exit into a dictionary */
+	setup_common_args_in_dict(&pDict, sc_args);
+
+	/* Argument list must be passed in a tuple. */
+	PyObject *pythonArgument = __PyTuple_New(1);
+	__PyTuple_SetItem(pythonArgument, 0, pDict);
+
+	/* Call python function "uftrace_entry". */
+	__PyObject_CallObject(pFuncEntry, pythonArgument);
+
+	/* Free PyTuple. */
+	Py_XDECREF(pythonArgument);
+
+	return 0;
+}
+
+int python_uftrace_exit(struct script_args *sc_args)
+{
+	if (unlikely(!pFuncExit))
+		return -1;
+
+	/* Entire arguments are passed into a single dictionary. */
+	PyObject *pDict = __PyDict_New();
+
+	/* Setup common arguments in both entry and exit into a dictionary */
+	setup_common_args_in_dict(&pDict, sc_args);
+
+	/* Add time duration info */
+	uint64_t duration = sc_args->duration;
+	PyObject *pDuration = __PyLong_FromUnsignedLongLong(duration);
+	__PyDict_SetItemString(pDict, py_args_table[PY_ARG_DURATION], pDuration);
+	Py_XDECREF(pDuration);
+
+	/* Argument list must be passed in a tuple. */
+	PyObject *pythonArgument = __PyTuple_New(1);
+	__PyTuple_SetItem(pythonArgument, 0, pDict);
+
+	/* Call python function "uftrace_exit". */
+	__PyObject_CallObject(pFuncExit, pythonArgument);
+
+	/* Free PyTuple. */
+	Py_XDECREF(pythonArgument);
+
+	return 0;
+}
+
+int script_init_for_python(char *py_pathname)
+{
+	pr_dbg("initialize python\n");
+
+	/* Bind script_uftrace functions to python's. */
+	script_uftrace_entry = python_uftrace_entry;
+	script_uftrace_exit = python_uftrace_exit;
+
+	python_handle = dlopen(libpython, RTLD_LAZY);
+	if (!python_handle) {
+		pr_warn("%s cannot be loaded!\n", libpython);
+		return -1;
+	}
+
+	INIT_PY_API_FUNC(Py_Initialize);
+	INIT_PY_API_FUNC(PySys_SetPath);
+	INIT_PY_API_FUNC(PyImport_Import);
+
+	INIT_PY_API_FUNC(PyErr_Occurred);
+	INIT_PY_API_FUNC(PyErr_Print);
+
+	INIT_PY_API_FUNC(PyObject_GetAttrString);
+	INIT_PY_API_FUNC(PyCallable_Check);
+	INIT_PY_API_FUNC(PyObject_CallObject);
+
+	INIT_PY_API_FUNC(PyString_FromString);
+	INIT_PY_API_FUNC(PyInt_FromLong);
+	INIT_PY_API_FUNC(PyLong_FromLong);
+	INIT_PY_API_FUNC(PyLong_FromUnsignedLongLong);
+
+	INIT_PY_API_FUNC(PyString_AsString);
+	INIT_PY_API_FUNC(PyLong_AsLong);
+
+	INIT_PY_API_FUNC(PyTuple_New);
+	INIT_PY_API_FUNC(PyTuple_SetItem);
+
+	INIT_PY_API_FUNC(PyDict_New);
+	INIT_PY_API_FUNC(PyDict_SetItem);
+	INIT_PY_API_FUNC(PyDict_SetItemString);
+	INIT_PY_API_FUNC(PyDict_GetItem);
+
+	__Py_Initialize();
+
+	/* Import python module that is passed by -p option. */
+	if (import_python_module(py_pathname) < 0)
+		return -1;
+
+	pFuncEntry = __PyObject_GetAttrString(pModule, "uftrace_entry");
+	if (!pFuncEntry || !__PyCallable_Check(pFuncEntry)) {
+		if (__PyErr_Occurred())
+			__PyErr_Print();
+		pr_dbg("uftrace_entry is not callable!\n");
+		pFuncEntry = NULL;
+	}
+	pFuncExit = __PyObject_GetAttrString(pModule, "uftrace_exit");
+	if (!pFuncExit || !__PyCallable_Check(pFuncExit)) {
+		if (__PyErr_Occurred())
+			__PyErr_Print();
+		pr_dbg("uftrace_exit is not callable!\n");
+		pFuncExit = NULL;
+	}
+
+	pr_dbg("script_init_for_python for \"%s.py\" is done!\n", py_pathname);
+
+	return 0;
+}
+
+#endif /* !HAVE_LIBPYTHON2 */

--- a/utils/script-python.h
+++ b/utils/script-python.h
@@ -1,0 +1,31 @@
+/*
+ * Python script binding for function entry and exit
+ *
+ * Copyright (C) 2017, LG Electronics, Honggyu Kim <hong.gyu.kim@lge.com>
+ *
+ * Released under the GPL v2.
+ */
+#ifndef __UFTRACE_SCRIPT_PYTHON_H__
+#define __UFTRACE_SCRIPT_PYTHON_H__
+
+#ifdef HAVE_LIBPYTHON2
+
+#include <python2.7/Python.h>
+
+#define SCRIPT_ENABLED 1
+int script_init_for_python(char *py_pathname);
+
+
+#else /* HAVE_LIBPYTHON2 */
+
+
+/* Do nothing if libpython2.7.so is not installed. */
+#define SCRIPT_ENABLED 0
+static inline int script_init_for_python(char *py_pathname)
+{
+	return -1;
+}
+
+#endif /* HAVE_LIBPYTHON2 */
+
+#endif /* __UFTRACE_SCRIPT_PYTHON_H__ */

--- a/utils/script.c
+++ b/utils/script.c
@@ -1,0 +1,51 @@
+/*
+ * Script binding for function entry and exit
+ *
+ * Copyright (C) 2017, LG Electronics, Honggyu Kim <hong.gyu.kim@lge.com>
+ *
+ * Released under the GPL v2.
+ */
+
+#include <unistd.h>
+#include "utils/script.h"
+
+
+/* This will be set by getenv("UFTRACE_SCRIPT"). */
+char *script_str;
+
+/* The below functions are used both in record time and script command. */
+script_uftrace_entry_t script_uftrace_entry;
+script_uftrace_exit_t script_uftrace_exit;
+
+static enum script_type_t get_script_type(const char *str)
+{
+	char *ext = strrchr(str, '.');
+
+	/*
+	 * The given script will be detected by the file suffix.
+	 * As of now, it only handles ".py" suffix for python.
+	 */
+	if (!strcmp(ext, ".py"))
+		return SCRIPT_PYTHON;
+
+	return SCRIPT_UNKNOWN;
+}
+
+int script_init(char *script_pathname)
+{
+	if (access(script_pathname, F_OK) < 0) {
+		perror(script_pathname);
+		return -1;
+	}
+
+	switch (get_script_type(script_pathname)) {
+	case SCRIPT_PYTHON:
+		if (script_init_for_python(script_pathname) < 0)
+			script_pathname = NULL;
+		break;
+	default:
+		script_pathname = NULL;
+	}
+
+	return 0;
+}

--- a/utils/script.c
+++ b/utils/script.c
@@ -16,6 +16,7 @@ char *script_str;
 /* The below functions are used both in record time and script command. */
 script_uftrace_entry_t script_uftrace_entry;
 script_uftrace_exit_t script_uftrace_exit;
+script_uftrace_end_t script_uftrace_end;
 
 static enum script_type_t get_script_type(const char *str)
 {

--- a/utils/script.h
+++ b/utils/script.h
@@ -1,0 +1,41 @@
+/*
+ * Script binding for function entry and exit
+ *
+ * Copyright (C) 2017, LG Electronics, Honggyu Kim <hong.gyu.kim@lge.com>
+ *
+ * Released under the GPL v2.
+ */
+#ifndef __UFTRACE_SCRIPT_H__
+#define __UFTRACE_SCRIPT_H__
+
+#include "libmcount/mcount.h"
+#include "utils/script-python.h"
+
+/* script type */
+enum script_type_t {
+	SCRIPT_UNKNOWN = 0,
+	SCRIPT_PYTHON
+};
+
+/* argument information passed to script */
+struct script_args {
+	int           tid;
+	int           depth;
+	uint64_t      timestamp;
+	uint64_t      duration;	/* exit only */
+	unsigned long address;
+	char          *symname;
+};
+
+extern char *script_str;
+
+typedef int (*script_uftrace_entry_t)(struct script_args *sc_args);
+typedef int (*script_uftrace_exit_t)(struct script_args *sc_args);
+
+/* The below functions are used both in record time and script command. */
+extern script_uftrace_entry_t script_uftrace_entry;
+extern script_uftrace_exit_t script_uftrace_exit;
+
+int script_init(char *script_pathname);
+
+#endif /* __UFTRACE_SCRIPT_H__ */

--- a/utils/script.h
+++ b/utils/script.h
@@ -31,10 +31,12 @@ extern char *script_str;
 
 typedef int (*script_uftrace_entry_t)(struct script_args *sc_args);
 typedef int (*script_uftrace_exit_t)(struct script_args *sc_args);
+typedef int (*script_uftrace_end_t)(void);
 
 /* The below functions are used both in record time and script command. */
 extern script_uftrace_entry_t script_uftrace_entry;
 extern script_uftrace_exit_t script_uftrace_exit;
+extern script_uftrace_end_t script_uftrace_end;
 
 int script_init(char *script_pathname);
 

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -7,6 +7,7 @@
 #include <sys/uio.h>
 #include <sys/stat.h>
 #include <limits.h>
+#include <libgen.h>
 
 #include "uftrace.h"
 #include "utils/utils.h"
@@ -567,6 +568,32 @@ char *get_event_name(struct ftrace_file_handle *handle, unsigned evt_id)
 
 out:
 	return evt_name;
+}
+
+/**
+ * absolute_dirname - return the canonicalized absolute dirname
+ *
+ * @path: pathname string that can be either absolute or relative path
+ * @resolved_path: input buffer that will store absolute dirname
+ *
+ * This function parses the @path and sets absolute dirname to @resolved_path.
+ *
+ * Given @path sets @resolved_path as follows:
+ *
+ *    @path                   | @resolved_path
+ *   -------------------------+----------------
+ *    mcount.py               | $PWD
+ *    tests/mcount.py         | $PWD/tests
+ *    ./tests/mcount.py       | $PWD/./tests
+ *    /root/uftrace/mcount.py | /root/uftrace
+ */
+char *absolute_dirname(const char *path, char *resolved_path)
+{
+	if (realpath(path, resolved_path) == NULL)
+		return NULL;
+	dirname(resolved_path);
+
+	return resolved_path;
 }
 
 #ifdef UNIT_TEST

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -253,4 +253,6 @@ struct ftrace_file_handle;
 
 char *get_event_name(struct ftrace_file_handle *handle, unsigned evt_id);
 
+char *absolute_dirname(const char *path, char *resolved_path);
+
 #endif /* __FTRACE_UTILS_H__ */


### PR DESCRIPTION
This PR supports python binding for C/C++ function entry and exit so that one can easily add a python script to hook function entry and exit and do whatever they want.

It includes `-S` / `--script` option for running a given script in record time and also includes `script` command to process with a given script for recorded data.

As an example, if `simple.py` script is written as follows:
```
  def uftrace_entry(args):
      _symname = args["symname"]
      print("entry : " + _symname + "()")

  def uftrace_exit(args):
      _symname = args["symname"]
      print("exit  : " + _symname + "()")
```
The `record` or `live` shows the following output in record time:
```
  $ uftrace -S scripts/simple.py -F main tests/t-abc
  entry : main()
  entry : a()
  entry : b()
  entry : c()
  entry : getpid()
  exit  : getpid()
  exit  : c()
  exit  : b()
  exit  : a()
  exit  : main()
  # DURATION    TID     FUNCTION
              [30960] | main() {
              [30960] |   a() {
              [30960] |     b() {
              [30960] |       c() {
     2.247 us [30960] |         getpid();
     8.948 us [30960] |       } /* c */
    13.011 us [30960] |     } /* b */
    18.580 us [30960] |   } /* a */
    41.977 us [30960] | } /* main */
```
The recorded data can be processed with `script` command as well:
```
  $ uftrace record -F main tests/t-abc

  $ uftrace script -S scripts/simple.py
  entry : main()
  entry : a()
  entry : b()
  entry : c()
  entry : getpid()
  exit  : getpid()
  exit  : c()
  exit  : b()
  exit  : a()
  exit  : main()
```

It implements two functions `uftrace_entry` and `uftrace_exit` and useful information is passed in a single `args` variable. The `args` variable is a dictionary type so some variables are passed into `args`.

The kernel functions can only be handle in `script` command.