### PR TITLE
mcount: Fix the size in proc statm event

### DIFF
--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -59,6 +59,8 @@ static enum filter_mode mcount_filter_mode = FILTER_MODE_NONE;
 static struct rb_root mcount_triggers = RB_ROOT;
 #endif /* DISABLE_MCOUNT_FILTER */
 
+int page_size_in_kb;
+
 uint64_t mcount_gettime(void)
 {
 	struct timespec ts;
@@ -1102,6 +1104,8 @@ static void mcount_startup(void)
 	patch_str = getenv("UFTRACE_PATCH");
 	event_str = getenv("UFTRACE_EVENT");
 	script_str = getenv("UFTRACE_SCRIPT");
+
+	page_size_in_kb = getpagesize() / KB;
 
 	if (logfd_str) {
 		int fd = strtol(logfd_str, NULL, 0);

--- a/libmcount/mcount.h
+++ b/libmcount/mcount.h
@@ -169,6 +169,8 @@ extern pthread_key_t mtd_key;
 extern int shmem_bufsize;
 extern unsigned long mcount_global_flags;
 
+extern int page_size_in_kb;
+
 enum mcount_global_flag {
 	MCOUNT_GFL_SETUP	= (1U << 0),
 	MCOUNT_GFL_FINISH	= (1U << 1),

--- a/libmcount/record.c
+++ b/libmcount/record.c
@@ -360,6 +360,12 @@ static void save_proc_statm(void *buf)
 		   &statm->vmsize, &statm->vmrss, &statm->shared) != 3)
 		pr_err("failed to scan /proc/self/statm");
 
+	/* Since /proc/[pid]/statm prints the number of pages for each field,
+	 * it'd be better to keep the memory size in KB. */
+	statm->vmsize *= page_size_in_kb;
+	statm->vmrss  *= page_size_in_kb;
+	statm->shared *= page_size_in_kb;
+
 	fclose(fp);
 }
 

--- a/uftrace.h
+++ b/uftrace.h
@@ -26,6 +26,9 @@
 #define OPT_DEPTH_MAX       OPT_RSTACK_MAX
 #define OPT_DEPTH_DEFAULT   OPT_RSTACK_DEFAULT
 
+#define KB 1024
+#define MB (KB * 1024)
+
 struct uftrace_file_header {
 	char magic[UFTRACE_MAGIC_LEN];
 	uint32_t version;

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -110,9 +110,9 @@ struct filter_module {
 
 /* please see man proc(5) for /proc/[pid]/statm */
 struct uftrace_proc_statm {
-	uint64_t		vmsize;  /* total program size */
-	uint64_t		vmrss;   /* resident set size */
-	uint64_t		shared;  /* shared rss (Rssfile + RssShmem) */
+	uint64_t		vmsize;  /* total program size in KB */
+	uint64_t		vmrss;   /* resident set size in KB */
+	uint64_t		shared;  /* shared rss in KB (Rssfile + RssShmem) */
 };
 
 struct uftrace_page_fault {


### PR DESCRIPTION
Since /proc/[pid]/statm prints the number of pages for each field, it'd
be better to keep the memory size in KB.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>