### PR TITLE
uftrace: Show the error message when info file can't be found

### DIFF
--- a/cmd-dump.c
+++ b/cmd-dump.c
@@ -1238,8 +1238,10 @@ int command_dump(int argc, char *argv[], struct opts *opts)
 	struct ftrace_file_handle handle;
 
 	ret = open_data_file(opts, &handle);
-	if (ret < 0)
-		pr_err("cannot open data: %s", opts->dirname);
+	if (ret < 0) {
+		pr_warn("cannot open data: %s: %m\n", opts->dirname);
+		return -1;
+	}
 
 	fstack_setup_filters(opts, &handle);
 

--- a/cmd-graph.c
+++ b/cmd-graph.c
@@ -651,8 +651,10 @@ int command_graph(int argc, char *argv[], struct opts *opts)
 		func = "main";
 
 	ret = open_data_file(opts, &handle);
-	if (ret < 0)
-		pr_err("cannot open data: %s", opts->dirname);
+	if (ret < 0) {
+		pr_warn("cannot open data: %s: %m\n", opts->dirname);
+		return -1;
+	}
 
 	if (opts->depth != OPT_DEPTH_DEFAULT) {
 		/*

--- a/cmd-info.c
+++ b/cmd-info.c
@@ -769,12 +769,17 @@ void clear_ftrace_info(struct uftrace_info *info)
 
 int command_info(int argc, char *argv[], struct opts *opts)
 {
+	int ret;
 	char buf[PATH_MAX];
 	struct stat statbuf;
 	struct ftrace_file_handle handle;
 	const char *fmt = "# %-20s: %s\n";
 
-	open_data_file(opts, &handle);
+	ret = open_data_file(opts, &handle);
+	if (ret < 0) {
+		pr_warn("cannot open data: %s: %m\n", opts->dirname);
+		return -1;
+	}
 
 	snprintf(buf, sizeof(buf), "%s/info", opts->dirname);
 

--- a/cmd-info.c
+++ b/cmd-info.c
@@ -783,6 +783,11 @@ int command_info(int argc, char *argv[], struct opts *opts)
 			.flags = SYMTAB_FL_DEMANGLE,
 		};
 
+		if (!opts->exename) {
+			pr_use("Usage: uftrace info --symbols [COMMAND]\n");
+			return -1;
+		}
+
 		load_symtabs(&symtabs, opts->dirname, opts->exename);
 		print_symtabs(&symtabs);
 		unload_symtabs(&symtabs);

--- a/cmd-info.c
+++ b/cmd-info.c
@@ -776,15 +776,6 @@ int command_info(int argc, char *argv[], struct opts *opts)
 	const char *fmt = "# %-20s: %s\n";
 
 	ret = open_data_file(opts, &handle);
-	if (ret < 0) {
-		pr_warn("cannot open data: %s: %m\n", opts->dirname);
-		return -1;
-	}
-
-	snprintf(buf, sizeof(buf), "%s/info", opts->dirname);
-
-	if (stat(buf, &statbuf) < 0)
-		return -1;
 
 	if (opts->print_symtab) {
 		struct symtabs symtabs = {
@@ -797,6 +788,16 @@ int command_info(int argc, char *argv[], struct opts *opts)
 		unload_symtabs(&symtabs);
 		goto out;
 	}
+
+	if (ret < 0) {
+		pr_warn("cannot open data: %s: %m\n", opts->dirname);
+		return -1;
+	}
+
+	snprintf(buf, sizeof(buf), "%s/info", opts->dirname);
+
+	if (stat(buf, &statbuf) < 0)
+		return -1;
 
 	pr_out("# system information\n");
 	pr_out("# ==================\n");

--- a/cmd-replay.c
+++ b/cmd-replay.c
@@ -930,8 +930,10 @@ int command_replay(int argc, char *argv[], struct opts *opts)
 	__fsetlocking(logfp, FSETLOCKING_BYCALLER);
 
 	ret = open_data_file(opts, &handle);
-	if (ret < 0)
-		pr_err("cannot open data: %s", opts->dirname);
+	if (ret < 0) {
+		pr_warn("cannot open data: %s: %m\n", opts->dirname);
+		return -1;
+	}
 
 	fstack_setup_filters(opts, &handle);
 	setup_field(opts);

--- a/cmd-report.c
+++ b/cmd-report.c
@@ -1129,8 +1129,10 @@ int command_report(int argc, char *argv[], struct opts *opts)
 		avg_mode = AVG_SELF;
 
 	ret = open_data_file(opts, &handle);
-	if (ret < 0)
-		pr_err("cannot open data: %s", opts->dirname);
+	if (ret < 0) {
+		pr_warn("cannot open data: %s: %m\n", opts->dirname);
+		return -1;
+	}
 
 	fstack_setup_filters(opts, &handle);
 

--- a/cmd-script.c
+++ b/cmd-script.c
@@ -124,8 +124,10 @@ int command_script(int argc, char *argv[], struct opts *opts)
 	__fsetlocking(logfp, FSETLOCKING_BYCALLER);
 
 	ret = open_data_file(opts, &handle);
-	if (ret < 0)
+	if (ret < 0) {
+		pr_warn("cannot open data: %s: %m\n", opts->dirname);
 		return -1;
+	}
 
 	fstack_setup_filters(opts, &handle);
 

--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -357,7 +357,7 @@ static void check_data_order(struct ftrace_file_handle *handle)
 }
 
 #define RECORD_MSG  "Was '%s' compiled with -pg or\n"		\
-"\t-finstrument-functions flag and ran with ftrace record?\n"
+"\t-finstrument-functions flag and ran with uftrace record?\n"
 
 int open_data_file(struct opts *opts, struct ftrace_file_handle *handle)
 {
@@ -389,7 +389,7 @@ retry:
 			pr_dbg("cannot find %s file!\n", buf);
 
 			if (opts->exename)
-				pr_err(RECORD_MSG, opts->exename);
+				pr_warn(RECORD_MSG, opts->exename);
 		} else {
 			pr_err("cannot open %s file", buf);
 		}


### PR DESCRIPTION
Currently if there isn't uftrace.data/info file,
print the error message with `pr_dbg()`.
But use `pr_err()` to let users know the error case, though
no using a debug -v option.

Fixes #127.

If you don't want to use `pr_err()`,
what about like below ?

```
diff --git a/cmd-info.c b/cmd-info.c
index 844ddfe..8d64fde 100644
--- a/cmd-info.c
+++ b/cmd-info.c
@@ -774,7 +774,10 @@ int command_info(int argc, char *argv[], struct opts *opts)
         struct ftrace_file_handle handle;
         const char *fmt = "# %-20s: %s\n";
 
-        open_data_file(opts, &handle);
+        if (open_data_file(opts, &handle) < 0) {
+                pr_warn("no trace data found\n");
+                return -1;
+        }
 
         snprintf(buf, sizeof(buf), "%s/info", opts->dirname);

```