### PR TITLE
Fix calc of message sizes in send_trace_metadata

### DIFF
--- a/cmd-recv.c
+++ b/cmd-recv.c
@@ -170,7 +170,7 @@ void send_trace_metadata(int sock, const char *dirname, char *filename)
 	struct uftrace_msg msg = {
 		.magic = htons(UFTRACE_MSG_MAGIC),
 		.type  = htons(UFTRACE_MSG_SEND_META_DATA),
-		.len   = htonl(sizeof(namelen) + namelen),
+		.len   = sizeof(namelen) + namelen,
 	};
 	struct iovec iov[4] = {
 		{ .iov_base = &msg,     .iov_len = sizeof(msg), },
@@ -191,7 +191,7 @@ void send_trace_metadata(int sock, const char *dirname, char *filename)
 	len = stbuf.st_size;
 	buf = xmalloc(len);
 
-	msg.len += htonl(len);
+	msg.len = htonl(msg.len + len);
 	iov[3].iov_base = buf;
 	iov[3].iov_len  = len;
 


### PR DESCRIPTION
It sometimes happens that (htonl(a) + htonl(b)) == htonl(a + b), but
sometimes (usually?) those are quite different.

This fixes t142_recv_multi.py so that it doesn't leave hung daemon
uftrace instances lying around when the memory maps file is of certain
sizes that happen to exercise this htonl bug.