### PR TITLE
replay: Fix a bug using abs() discarding upper 32-bit

### DIFF
--- a/utils/debug.c
+++ b/utils/debug.c
@@ -171,7 +171,7 @@ void __pr_color(char code, const char *fmt, ...)
 
 static void __print_time_unit(int64_t delta_nsec, bool needs_sign)
 {
-	uint64_t delta = abs(delta_nsec);
+	uint64_t delta = llabs(delta_nsec);
 	uint64_t delta_small = 0;
 	char *units[] = { "us", "ms", " s", " m", " h", };
 	char *color_units[] = {


### PR DESCRIPTION
When __print_time_unit() is called from print_diff_time_unit(),
an absolute value of delta_nsec is needed.
But it isn't needed at the print_time_unit() case,
so fix it.

Fixes #133.
Fixes: adf2763 ("report: Allow diff output as numbers")

Reported-by: @suapapa Homin Lee <homin.lee@suapapa.net>
Signed-off-by: Taeung Song <treeze.taeung@gmail.com>