### PR TITLE
test: Avoid -finstrument-functions bug in gcc

### DIFF
--- a/tests/s-alloca.c
+++ b/tests/s-alloca.c
@@ -5,7 +5,7 @@
 int foo(int c)
 {
 	char *ptr = alloca(c);
-	snprintf(ptr, c, "%s", "hello world\n");
+	strncpy(ptr, "hello world\n", c);
 	return c;
 }
 

--- a/tests/s-openclose.c
+++ b/tests/s-openclose.c
@@ -1,9 +1,7 @@
 #include <stdio.h>
-#include <unistd.h>
-#include <fcntl.h>
 
 int main(void)
 {
-	close(open("/dev/null", O_RDONLY));
+	fclose(fopen("/dev/null", "r"));
 	return 0;
 }

--- a/tests/t016_alloca.py
+++ b/tests/t016_alloca.py
@@ -9,14 +9,14 @@ class TestCase(TestBase):
   75.736 us [ 6681] | __cxa_atexit();
             [ 6681] | main() {
             [ 6681] |   foo() {
-   2.153 us [ 6681] |     snprintf();
+   2.153 us [ 6681] |     strncpy();
    3.073 us [ 6681] |   } /* foo */
             [ 6681] |   bar() {
             [ 6681] |     foo() {
-   0.593 us [ 6681] |       snprintf();
+   0.593 us [ 6681] |       strncpy();
    1.317 us [ 6681] |     } /* foo */
             [ 6681] |     foo() {
-   0.700 us [ 6681] |       snprintf();
+   0.700 us [ 6681] |       strncpy();
    1.336 us [ 6681] |     } /* foo */
    3.723 us [ 6681] |   } /* bar */
    8.063 us [ 6681] | } /* main */

--- a/tests/t079_replay_kernel_D.py
+++ b/tests/t079_replay_kernel_D.py
@@ -13,13 +13,13 @@ class TestCase(TestBase):
    1.088 us [18343] | __monstartup();
    0.640 us [18343] | __cxa_atexit();
             [18343] | main() {
-            [18343] |   open() {
+            [18343] |   fopen() {
   86.790 us [18343] |     sys_open();
-  89.018 us [18343] |   } /* open */
-            [18343] |   close() {
+  89.018 us [18343] |   } /* fopen */
+            [18343] |   fclose() {
   10.781 us [18343] |     sys_close();
   21.980 us [18343] |     exit_to_usermode_loop();
-  37.325 us [18343] |   } /* close */
+  37.325 us [18343] |   } /* fclose */
  128.387 us [18343] | } /* main */
 """)
 

--- a/tests/t080_replay_kernel_D2.py
+++ b/tests/t080_replay_kernel_D2.py
@@ -14,8 +14,8 @@ class TestCase(TestBase):
    1.088 us [18343] | __monstartup();
    0.640 us [18343] | __cxa_atexit();
             [18343] | main() {
-  89.018 us [18343] |   open();
-  37.325 us [18343] |   close();
+  89.018 us [18343] |   fopen();
+  37.325 us [18343] |   fclose();
  128.387 us [18343] | } /* main */
 """)
 

--- a/tests/t081_kernel_depth.py
+++ b/tests/t081_kernel_depth.py
@@ -10,16 +10,16 @@ class TestCase(TestBase):
    1.540 us [27711] | __monstartup();
    1.089 us [27711] | __cxa_atexit();
             [27711] | main() {
-            [27711] |   open() {
+            [27711] |   fopen() {
             [27711] |     sys_open() {
   12.732 us [27711] |       do_sys_open();
   14.039 us [27711] |     } /* sys_open */
-  17.193 us [27711] |   } /* open */
-            [27711] |   close() {
+  17.193 us [27711] |   } /* fopen */
+            [27711] |   fclose() {
             [27711] |     sys_close() {
    0.591 us [27711] |       __close_fd();
    1.429 us [27711] |     } /* sys_close */
-   8.028 us [27711] |   } /* close */
+   8.028 us [27711] |   } /* fclose */
   26.938 us [27711] | } /* main */
 """)
 

--- a/tests/t132_trigger_kernel.py
+++ b/tests/t132_trigger_kernel.py
@@ -11,12 +11,12 @@ class TestCase(TestBase):
    0.714 us [ 4435] | __monstartup();
    0.349 us [ 4435] | __cxa_atexit();
             [ 4435] | main() {
-            [ 4435] |   open() {
+            [ 4435] |   fopen() {
    6.413 us [ 4435] |     sys_open();
-   7.037 us [ 4435] |   } /* open */
-            [ 4435] |   close() {
+   7.037 us [ 4435] |   } /* fopen */
+            [ 4435] |   fclose() {
    8.389 us [ 4435] |     sys_close();
-   9.949 us [ 4435] |   } /* close */
+   9.949 us [ 4435] |   } /* fclose */
   17.632 us [ 4435] | } /* main */
 """)
 

--- a/tests/t138_kernel_dynamic.py
+++ b/tests/t138_kernel_dynamic.py
@@ -8,12 +8,12 @@ class TestCase(TestBase):
         TestBase.__init__(self, 'openclose', """
 # DURATION    TID     FUNCTION
             [ 9875] | main() {
-            [ 9875] |   open() {
+            [ 9875] |   fopen() {
   14.416 us [ 9875] |     sys_open();
-  19.099 us [ 9875] |   } /* open */
-            [ 9875] |   close() {
+  19.099 us [ 9875] |   } /* fopen */
+            [ 9875] |   fclose() {
    3.380 us [ 9875] |     sys_close();
-   9.720 us [ 9875] |   } /* close */
+   9.720 us [ 9875] |   } /* fclose */
   37.051 us [ 9875] | } /* main */
 """)
 

--- a/tests/t139_kernel_dynamic2.py
+++ b/tests/t139_kernel_dynamic2.py
@@ -8,10 +8,10 @@ class TestCase(TestBase):
         TestBase.__init__(self, 'openclose', """
 # DURATION    TID     FUNCTION
             [ 9875] | main() {
-            [ 9875] |   open() {
+            [ 9875] |   fopen() {
   14.416 us [ 9875] |     sys_open();
-  19.099 us [ 9875] |   } /* open */
-   9.720 us [ 9875] |   close();
+  19.099 us [ 9875] |   } /* fopen */
+   9.720 us [ 9875] |   fclose();
   37.051 us [ 9875] | } /* main */
 """)
 

--- a/tests/t143_recv_kernel.py
+++ b/tests/t143_recv_kernel.py
@@ -14,13 +14,13 @@ class TestCase(TestBase):
    1.088 us [18343] | __monstartup();
    0.640 us [18343] | __cxa_atexit();
             [18343] | main() {
-            [18343] |   open() {
+            [18343] |   fopen() {
   86.790 us [18343] |     sys_open();
-  89.018 us [18343] |   } /* open */
-            [18343] |   close() {
+  89.018 us [18343] |   } /* fopen */
+            [18343] |   fclose() {
   10.781 us [18343] |     sys_close();
   21.980 us [18343] |     exit_to_usermode_loop();
-  37.325 us [18343] |   } /* close */
+  37.325 us [18343] |   } /* fclose */
  128.387 us [18343] | } /* main */
 """)
 

--- a/tests/t161_pltbind_now.py
+++ b/tests/t161_pltbind_now.py
@@ -7,8 +7,8 @@ class TestCase(TestBase):
         TestBase.__init__(self, 'openclose', """
 # DURATION    TID     FUNCTION
             [15973] | main() {
-   5.903 us [15973] |   open();
-   4.374 us [15973] |   close();
+   5.903 us [15973] |   fopen();
+   4.374 us [15973] |   fclose();
   15.262 us [15973] | } /* main */
 """)
 

--- a/tests/t162_pltbind_now_pie.py
+++ b/tests/t162_pltbind_now_pie.py
@@ -7,8 +7,8 @@ class TestCase(TestBase):
         TestBase.__init__(self, 'openclose', """
 # DURATION    TID     FUNCTION
             [15973] | main() {
-   5.903 us [15973] |   open();
-   4.374 us [15973] |   close();
+   5.903 us [15973] |   fopen();
+   4.374 us [15973] |   fclose();
   15.262 us [15973] | } /* main */
 """)
 


### PR DESCRIPTION
Since older gcc such as gcc-4.xx and gcc-5.xx have a bug in
-finstrument-functions, some of tests are failed.

The problem is that gcc sometimes put '__cyg_profile_func_enter' and
'__cyg_profile_func_exit' for some library calls, which is not expected.

For example, the below example shows unexpected additional open call.

```
  $ gcc -finstrument-functions -O2 s-openclose.c
  $ uftrace a.out
  # DURATION    TID     FUNCTION
              [18948] | main() {
              [18948] |   open() {
     7.493 us [18948] |     open();
    19.570 us [18948] |   } /* open */
     4.143 us [18948] |   close();
    25.447 us [18948] | } /* main */
```

Unlike this, clang doesn't have such problem for the same example.

```
  $ clang -finstrument-functions -O2 s-openclose.c
  $ uftrace a.out
  # DURATION    TID     FUNCTION
              [18980] | main() {
    13.103 us [18980] |   open();
     4.433 us [18980] |   close();
    31.157 us [18980] | } /* main */
```

Since this bug has been fixed in recent gcc, so we better avoid in our
test framework to reduce confusion in old systems.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>