### PR TITLE
uftrace: Disable pager when using --nop option

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -862,6 +862,8 @@ int main(int argc, char *argv[])
 
 	if (opts.mode == UFTRACE_MODE_RECORD || opts.mode == UFTRACE_MODE_RECV)
 		opts.use_pager = false;
+	if (opts.nop)
+		opts.use_pager = false;
 
 	if (opts.use_pager)
 		start_pager();


### PR DESCRIPTION
--nop option is for performance testing so doesn't require to use pager
so it's better to disable it.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>