### PR TITLE
python: Fix to import matplotlib and numpy

### DIFF
--- a/utils/script-python.c
+++ b/utils/script-python.c
@@ -218,7 +218,7 @@ int script_init_for_python(char *py_pathname)
 	script_uftrace_exit = python_uftrace_exit;
 	script_uftrace_end = python_uftrace_end;
 
-	python_handle = dlopen(libpython, RTLD_LAZY);
+	python_handle = dlopen(libpython, RTLD_LAZY | RTLD_GLOBAL);
 	if (!python_handle) {
 		pr_warn("%s cannot be loaded!\n", libpython);
 		return -1;


### PR DESCRIPTION
Since sys.path is not properly set before, there was some import errors.
This patch first gets the correct sys.path by running python
interpreter, then generate .py_sys_path.def file so that it can be
included by utils/script-python.c.

This also adds RTLD_GLOBAL flag to dlopen to complete the symbol
resolution of subsequently loaded shared objects.

Now, it's ready to use matplotlib and numpy in uftrace python script.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>