### PR TITLE
doc: Add a item 'elapsed time'

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ The `info` command shows system and program information when recorded.
     # exe image           : /home/namhyung/project/uftrace/tests/t-abc
     # build id            : a3c50d25f7dd98dab68e94ef0f215edb06e98434
     # exit status         : exited with code: 0
+    # elapsed time        : 0.003219479 sec
     # cpu time            : 0.000 / 0.003 sec (sys / user)
     # context switch      : 1 / 1 (voluntary / involuntary)
     # max rss             : 3072 KB

--- a/doc/uftrace-info.md
+++ b/doc/uftrace-info.md
@@ -47,6 +47,7 @@ This command shows information like below:
     # exe image           : /home/namhyung/tmp/abc
     # build id            : a3c50d25f7dd98dab68e94ef0f215edb06e98434
     # exit status         : exited with code: 0
+    # elapsed time        : 0.003219479 sec
     # cpu time            : 0.003 / 0.000 sec (sys / user)
     # context switch      : 1 / 1 (voluntary / involuntary)
     # max rss             : 3104 KB


### PR DESCRIPTION
Hi @namhyung 

I send this patch because of a bit renewed info output with `elapsed time`.
But I didn't want to change all info output due to changed one thing,
so I just inserted one line with a elapsed time value from trace data recorded
with `t-abc` of tests/s-abc.c in my case.

What do you think about that ?