### PR TITLE
record: Add a comment for 'addr' of uftrace_record

### DIFF
--- a/uftrace.h
+++ b/uftrace.h
@@ -423,7 +423,7 @@ struct uftrace_record {
 	uint64_t more:   1;
 	uint64_t magic:  3;
 	uint64_t depth:  10;
-	uint64_t addr:   48;
+	uint64_t addr:   48; /* child ip or uftrace_event_id */
 };
 
 static inline bool is_v3_compat(struct uftrace_record *urec)


### PR DESCRIPTION
struct uftrace_record has a member 'addr'.
It can mean child ip or uftrace_event_id,
so add this comment.

Signed-off-by: Taeung Song <treeze.taeung@gmail.com>