### PR TITLE
script: Add a new --record option

### DIFF
--- a/cmd-record.c
+++ b/cmd-record.c
@@ -1843,11 +1843,11 @@ int command_record(int argc, char *argv[], struct opts *opts)
 	if (create_directory(opts->dirname) < 0)
 		return -1;
 
-	check_binary(opts);
-
 	/* apply script-provided options */
 	if (opts->script_file)
 		parse_script_opt(opts);
+
+	check_binary(opts);
 
 	has_perf_event = check_linux_perf_event(opts->event);
 

--- a/cmd-script.c
+++ b/cmd-script.c
@@ -140,6 +140,19 @@ int command_script(int argc, char *argv[], struct opts *opts)
 		return -1;
 	}
 
+	if (opts->record) {
+		/* parse in-script record option - "uftrace_options" */
+		parse_script_opt(opts);
+
+		char *script_file = opts->script_file;
+		opts->script_file = NULL;
+
+		pr_dbg("start recording before running a script\n");
+		ret = command_record(argc, argv, opts);
+
+		opts->script_file = script_file;
+	}
+
 	__fsetlocking(outfp, FSETLOCKING_BYCALLER);
 	__fsetlocking(logfp, FSETLOCKING_BYCALLER);
 

--- a/doc/uftrace-script.md
+++ b/doc/uftrace-script.md
@@ -43,6 +43,9 @@ OPTIONS
 -S *SCRIPT_PATH*, \--script=*SCRIPT_PATH*
 :   Add a script to do addtional work at the entry and exit of function.  The type of script is detected by the postfix such as '.py' for python.
 
+\--record COMMAND [*command-options*]
+:   Record a new trace before running a given script.
+
 
 EXAMPLES
 ========

--- a/uftrace.c
+++ b/uftrace.c
@@ -89,6 +89,7 @@ enum options {
 	OPT_diff_policy,
 	OPT_event_full,
 	OPT_nest_libcall,
+	OPT_record,
 };
 
 static struct argp_option uftrace_options[] = {
@@ -157,6 +158,7 @@ static struct argp_option uftrace_options[] = {
 	{ "diff-policy", OPT_diff_policy, "POLICY", 0, "Control diff report policy" },
 	{ "event-full", OPT_event_full, 0, 0, "Show all events outside of function" },
 	{ "nest-libcall", OPT_nest_libcall, 0, 0, "Show nested library calls" },
+	{ "record", OPT_record, 0, 0, "Record a new trace data before running command" },
 	{ 0 }
 };
 
@@ -683,6 +685,10 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 
 	case OPT_nest_libcall:
 		opts->nest_libcall = true;
+		break;
+
+	case OPT_record:
+		opts->record = true;
 		break;
 
 	case ARGP_KEY_ARG:

--- a/uftrace.h
+++ b/uftrace.h
@@ -233,6 +233,7 @@ struct opts {
 	bool keep_pid;
 	bool event_skip_out;
 	bool nest_libcall;
+	bool record;
 	struct uftrace_time_range range;
 };
 


### PR DESCRIPTION
It'd be better to have an option to record a new trace before running a
given script.  This patch adds --record option to do it in script
command.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>