### PR TITLE
uftrace: Make --nest-libcall imply --force option

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -682,6 +682,8 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 		break;
 
 	case OPT_nest_libcall:
+		/* --nest-libcall implies --force option */
+		opts->force = true;
 		opts->nest_libcall = true;
 		break;
 


### PR DESCRIPTION
Since --nest-libcall can be used for binaries that are not recompiled
with -pg or -finstrument-functions, it can often be used with --force
option.  So it'd be better to make --nest-libcall implies --force
option to make it simpler for general users.

Before:
  $ uftrace --nest-libcall --force /usr/bin/gcc hello.c

After:
  $ uftrace --nest-libcall /usr/bin/gcc hello.c

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>