### PR TITLE
event: Fix to enable timer-filter for events

### DIFF
--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -530,14 +530,6 @@ void mcount_entry_filter_record(struct mcount_thread_data *mtdp,
 				save_argument(mtdp, rstack, tr->pargs, regs);
 			if (tr->flags & TRIGGER_FL_READ)
 				save_trigger_read(mtdp, rstack, tr->read);
-
-			if (mtdp->nr_events) {
-				/*
-				 * Flush rstacks if event was recorded as it only has
-				 * limited space for the events.
-				 */
-				record_trace_data(mtdp, rstack, NULL);
-			}
 		}
 
 		/* script hooking for function entry */
@@ -634,6 +626,9 @@ void mcount_exit_filter_record(struct mcount_thread_data *mtdp,
 
 			if (record_trace_data(mtdp, rstack, retval) < 0)
 				pr_err("error during record");
+		} else {
+			/* invalidate events if filtered-out by time filter */
+			mtdp->nr_events = 0;
 		}
 
 		/* script hooking for function exit */

--- a/tests/s-time-to-sleep.c
+++ b/tests/s-time-to-sleep.c
@@ -1,0 +1,31 @@
+#include <stdlib.h>
+#include <unistd.h>
+
+void *mem_alloc(void)
+{
+	return malloc(0);
+}
+
+void mem_free(void *ptr)
+{
+	free(ptr);
+}
+
+void bar(int msec)
+{
+	usleep(msec);
+}
+
+void foo(void)
+{
+	void *p = mem_alloc();
+	bar(2000);
+	mem_free(p);
+}
+
+int main(void)
+{
+	foo();
+	bar(1000);
+	return 0;
+}

--- a/tests/t172_event_time_filter.py
+++ b/tests/t172_event_time_filter.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import re
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'time-to-sleep', result="""
+# DURATION    TID     FUNCTION
+            [48790] | main() {
+            [48790] |   foo() {
+            [48790] |     bar() {
+            [48790] |       /* read:proc/statm (size=27368KB, rss=3192KB, shared=2928KB) */
+   2.093 ms [48790] |       usleep();
+   2.124 ms [48790] |     } /* bar */
+   2.130 ms [48790] |   } /* foo */
+   3.257 ms [48790] | } /* main */
+""")
+
+    def runcmd(self):
+        uftrace = TestBase.ftrace
+        args    = '-F main -t 2ms -T bar@read=proc/statm'
+        prog    = 't-' + self.name
+        return '%s %s %s' % (uftrace, args, prog)
+
+    def sort(self, output):
+        result = []
+        for ln in output.split('\n'):
+            # ignore blank lines and comments
+            if ln.strip() == '' or ln.startswith('#'):
+                continue
+            func = ln.split('|', 1)[-1]
+            # remove actual numbers in proc.statm
+            if func.find('read:proc/statm') > 0:
+                func = '       /* read:proc/statm */'
+            result.append(func)
+
+        return '\n'.join(result)


### PR DESCRIPTION
Currently, time-filter doesn't work for events so this patch fixes the
problem.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>