### PR TITLE
record: Add -C/--caller-filter option

### DIFF
--- a/cmd-record.c
+++ b/cmd-record.c
@@ -66,7 +66,8 @@ static bool can_use_fast_libmcount(struct opts *opts)
 		return false;
 	if (getenv("UFTRACE_FILTER") || getenv("UFTRACE_TRIGGER") ||
 	    getenv("UFTRACE_ARGUMENT") || getenv("UFTRACE_RETVAL") ||
-	    getenv("UFTRACE_PATCH") || getenv("UFTRACE_SCRIPT"))
+	    getenv("UFTRACE_PATCH") || getenv("UFTRACE_SCRIPT") ||
+	    getenv("UFTRACE_CALLER_FILTER"))
 		return false;
 	return true;
 }
@@ -123,6 +124,15 @@ static void setup_child_environ(struct opts *opts, int pfd)
 		if (filter_str) {
 			setenv("UFTRACE_FILTER", filter_str, 1);
 			free(filter_str);
+		}
+	}
+
+	if (opts->caller_filter) {
+		char *caller_filter_str = uftrace_clear_kernel(opts->caller_filter);
+
+		if (caller_filter_str) {
+			setenv("UFTRACE_CALLER_FILTER", caller_filter_str, 1);
+			free(caller_filter_str);
 		}
 	}
 

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -1169,6 +1169,7 @@ static void mcount_startup(void)
 	char *color_str;
 	char *demangle_str;
 	char *filter_str;
+	char *caller_filter_str;
 	char *trigger_str;
 	char *argument_str;
 	char *retval_str;
@@ -1200,6 +1201,7 @@ static void mcount_startup(void)
 	threshold_str = getenv("UFTRACE_THRESHOLD");
 	demangle_str = getenv("UFTRACE_DEMANGLE");
 	filter_str = getenv("UFTRACE_FILTER");
+	caller_filter_str = getenv("UFTRACE_CALLER_FILTER");
 	trigger_str = getenv("UFTRACE_TRIGGER");
 	argument_str = getenv("UFTRACE_ARGUMENT");
 	retval_str = getenv("UFTRACE_RETVAL");
@@ -1260,7 +1262,8 @@ static void mcount_startup(void)
 
 	symtabs.dirname = dirname;
 
-	if (filter_str || trigger_str || argument_str || retval_str || patch_str)
+	if (filter_str || caller_filter_str || trigger_str || argument_str ||
+	    retval_str || patch_str)
 		symtabs.flags &= ~SYMTAB_FL_SKIP_NORMAL;
 	if (plthook_str)
 		symtabs.flags &= ~SYMTAB_FL_SKIP_DYNAMIC;
@@ -1280,6 +1283,8 @@ static void mcount_startup(void)
 
 	ftrace_setup_filter(filter_str, &symtabs, &mcount_triggers,
 			    &mcount_filter_mode);
+	ftrace_setup_caller_filter(caller_filter_str, &symtabs,
+				   &mcount_triggers, &mcount_filter_mode);
 	ftrace_setup_trigger(trigger_str, &symtabs, &mcount_triggers);
 	ftrace_setup_argument(argument_str, &symtabs, &mcount_triggers);
 	ftrace_setup_retval(retval_str, &symtabs, &mcount_triggers);

--- a/uftrace.c
+++ b/uftrace.c
@@ -96,6 +96,7 @@ static struct argp_option uftrace_options[] = {
 	{ "library-path", 'L', "PATH", 0, "Load libraries from this PATH" },
 	{ "filter", 'F', "FUNC", 0, "Only trace those FUNCs" },
 	{ "notrace", 'N', "FUNC", 0, "Don't trace those FUNCs" },
+	{ "caller-filter", 'C', "FUNC", 0, "Only trace callers of those FUNCs" },
 	{ "trigger", 'T', "FUNC@act[,act,...]", 0, "Trigger action on those FUNCs" },
 	{ "depth", 'D', "DEPTH", 0, "Trace functions within DEPTH" },
 	{ "debug", 'v', 0, 0, "Print debug messages" },
@@ -369,6 +370,11 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 
 	case 'N':
 		opts->filter = opt_add_prefix_string(opts->filter, "!", arg);
+		break;
+
+	case 'C':
+		opts->caller_filter = opt_add_string(opts->caller_filter, arg);
+		opts->threshold = ULONG_MAX;
 		break;
 
 	case 'T':

--- a/uftrace.h
+++ b/uftrace.h
@@ -173,6 +173,7 @@ struct ftrace_file_handle {
 struct opts {
 	char *lib_path;
 	char *filter;
+	char *caller_filter;
 	char *trigger;
 	char *tid;
 	char *exename;
@@ -239,8 +240,8 @@ struct opts {
 
 static inline bool opts_has_filter(struct opts *opts)
 {
-	return opts->filter || opts->trigger || opts->threshold ||
-		opts->depth != OPT_DEPTH_DEFAULT;
+	return opts->filter || opts->caller_filter || opts->trigger ||
+		opts->threshold || opts->depth != OPT_DEPTH_DEFAULT;
 }
 
 void parse_script_opt(struct opts *opts);

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -753,11 +753,13 @@ again:
 			goto again;
 		}
 
-		if (ret > 0 && fmode != NULL) {
-			if (tr.fmode == FILTER_MODE_IN)
-				*fmode = FILTER_MODE_IN;
-			else if (*fmode == FILTER_MODE_NONE)
-				*fmode = FILTER_MODE_OUT;
+		if (!(tr.flags & TRIGGER_FL_TRACE)) {
+			if (ret > 0 && fmode != NULL) {
+				if (tr.fmode == FILTER_MODE_IN)
+					*fmode = FILTER_MODE_IN;
+				else if (*fmode == FILTER_MODE_NONE)
+					*fmode = FILTER_MODE_OUT;
+			}
 		}
 next:
 		name = strtok(NULL, ";");
@@ -784,6 +786,20 @@ void ftrace_setup_filter(char *filter_str, struct symtabs *symtabs,
 			 struct rb_root *root, enum filter_mode *mode)
 {
 	setup_trigger(filter_str, symtabs, root, TRIGGER_FL_FILTER, mode);
+}
+
+/**
+ * ftrace_setup_caller_filter - construct rbtree of filters
+ * @caller_filter_str - CSV of filter string
+ * @symtabs           - symbol tables to find symbol address
+ * @root              - root of resulting rbtree
+ * @mode              - filter mode: opt-in (-F) or opt-out (-N)
+ */
+void ftrace_setup_caller_filter(char *caller_filter_str,
+				struct symtabs *symtabs, struct rb_root *root,
+				enum filter_mode *mode)
+{
+	setup_trigger(caller_filter_str, symtabs, root, TRIGGER_FL_TRACE, mode);
 }
 
 /**

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -124,6 +124,9 @@ typedef void (*trigger_fn_t)(struct ftrace_trigger *tr, void *arg);
 
 void ftrace_setup_filter(char *filter_str, struct symtabs *symtabs,
 			 struct rb_root *root, enum filter_mode *mode);
+void ftrace_setup_caller_filter(char *caller_filter_str,
+				struct symtabs *symtabs, struct rb_root *root,
+				enum filter_mode *mode);
 void ftrace_setup_trigger(char *trigger_str, struct symtabs *symtabs,
 			  struct rb_root *root);
 void ftrace_setup_argument(char *trigger_str, struct symtabs *symtabs,


### PR DESCRIPTION
-F/--filter option is useful when tracing the callee functions, but
sometime it's also useful to see its callers in a reverse way.

This patch adds -C/--caller-filter to show caller functions by tracing
the call path to the given function.

The same purpose could be acheived by time-filter with `trace` trigger
but it's a kind of weird combination to general users.  So this adds a
new option to provide the same feature.

The below shows the example to trace the call path to 'free' and its
callers.
```
  Before:
    $ uftrace -t 1000s -T free@trace <program>

  After:
    $ uftrace -C free <program>
```
The example output is as follows:
```
  # DURATION    TID     FUNCTION
              [32587] | main() {
              [32587] |   v8::Shell::Main() {
              [32587] |     v8::V8::InitializeICUDefaultLocation() {
              [32587] |       v8::internal::InitializeICUDefaultLocation() {
     1.380 us [32587] |         free();
     2.493 ms [32587] |       } /* v8::internal::InitializeICUDefaultLocation */
     2.496 ms [32587] |     } /* v8::V8::InitializeICUDefaultLocation */
              [32587] |     v8::V8::InitializeExternalStartupData() {
              [32587] |       v8::internal::InitializeExternalStartupData() {
     0.099 us [32587] |         free();
     0.049 us [32587] |         free();
   653.622 us [32587] |       } /* v8::internal::InitializeExternalStartupData */
   653.826 us [32587] |     } /* v8::V8::InitializeExternalStartupData */
                                ...
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>