### PR TITLE
replay: Add 's' postfix to std::string

### DIFF
--- a/cmd-replay.c
+++ b/cmd-replay.c
@@ -554,6 +554,10 @@ void get_argspec_string(struct ftrace_task_handle *task,
 				n += snprintf(args + n, len, "\"%.*s\"",
 					      slen + newline, str);
 
+			/* std::string can be represented as "TEXT"s from C++14 */
+			if (spec->fmt == ARG_FMT_STD_STRING)
+				args[n++] = 's';
+
 			free(str);
 			size = slen + 2;
 		}

--- a/tests/t146_arg_std_string.py
+++ b/tests/t146_arg_std_string.py
@@ -7,12 +7,12 @@ class TestCase(TestBase):
         TestBase.__init__(self, 'std-string', lang='C++', result="""
 # DURATION    TID     FUNCTION
             [71555] | main() {
-   7.549 us [71555] |   std_string_arg("Hello");
-   0.218 us [71555] |   std_string_arg("World!");
-   0.150 us [71555] |   std_string_arg("std::string support is done!");
-   0.240 us [71555] |   std_string_ret::cxx11() = "Hello";
-   0.124 us [71555] |   std_string_ret::cxx11() = "World!";
-   0.110 us [71555] |   std_string_ret::cxx11() = "std::string support is done!";
+   7.549 us [71555] |   std_string_arg("Hello"s);
+   0.218 us [71555] |   std_string_arg("World!"s);
+   0.150 us [71555] |   std_string_arg("std::string support is done!"s);
+   0.240 us [71555] |   std_string_ret::cxx11() = "Hello"s;
+   0.124 us [71555] |   std_string_ret::cxx11() = "World!"s;
+   0.110 us [71555] |   std_string_ret::cxx11() = "std::string support is done!"s;
   10.346 us [71555] | } /* main */
 """)
 


### PR DESCRIPTION
std::string can be directly represented with operator""s in C++14.
So it'd be better to display std::string in C++14 style.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>