### PR TITLE
test: Fix runtest.py to be able to run with -mtrace

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -409,7 +409,7 @@ def run_single_case(case, flags, opts, diff, dbg):
     result = []
 
     # for python3
-    _locals = locals()
+    _locals = {}
     exec("import %s; tc = %s.TestCase()" % (case, case), globals(), _locals)
     tc = _locals['tc']
     tc.set_debug(dbg)


### PR DESCRIPTION
runtest.py uses exec() inside and it accepts a dictionary contains local
variables.  But it makes a problem when tracing it using settrace(),
which is used in trace.py as follows:

```
  $ cd tests
  $ python runtest.py 136
  (... runs without a problem ...)

  $ python -mtrace --trace runtest.py 136
      ...
  runtest.py(414):     tc = _locals['tc']
   --- modulename: trace, funcname: _unsettrace
  trace.py(80):         sys.settrace(None)
  Traceback (most recent call last):
    File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
      "__main__", fname, loader, pkg_name)
    File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
      exec code in run_globals
    File "/usr/lib/python2.7/trace.py", line 819, in <module>
      main()
    File "/usr/lib/python2.7/trace.py", line 807, in main
      t.runctx(code, globs, globs)
    File "/usr/lib/python2.7/trace.py", line 513, in runctx
      exec cmd in globals, locals
    File "runtest.py", line 515, in <module>
      result = run_single_case(name, flags, opts.split(), arg.diff, arg.debug)
    File "runtest.py", line 414, in run_single_case
      tc = _locals['tc']
  KeyError: 'tc'
```

Current runtest.py doesn't use any local variables inside exec()
statment so we can just pass an empty dictionary to get a variable 'tc'
that is created inside exec().

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>