### PR TITLE
info: Fix --symbols problem in no executable file case

### DIFF
--- a/cmd-info.c
+++ b/cmd-info.c
@@ -834,7 +834,7 @@ int command_info(int argc, char *argv[], struct opts *opts)
 	if (opts->print_symtab) {
 		struct symtabs symtabs = {
 			.loaded = false,
-			.flags = SYMTAB_FL_DEMANGLE,
+			.flags = SYMTAB_FL_USE_SYMFILE | SYMTAB_FL_DEMANGLE,
 		};
 
 		if (!opts->exename) {


### PR DESCRIPTION
Even though there is uftrace.data/`<exename>`.sym,
if the executable file is removed,
uftrace --symbols shows nothing like below, so fix it.

```
  $ uftrace record tests/t-abc

  $ rm tests/t-abc

  $ uftrace info --symbols
  Normal symbols
  ==============

  Dynamic symbols
  ===============
```

Fixes #175.