### PR TITLE
kernel: Skip functions that seem to be rarely used

### DIFF
--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -467,6 +467,52 @@ out:
 	return -EINVAL;
 }
 
+static void skip_kernel_functions(struct uftrace_kernel_writer *kernel)
+{
+	unsigned int i;
+	struct kfilter *kfilter;
+	const char *skip_funcs[] = {
+		"syscall_trace_enter_phase1",
+		"smp_irq_work_interrupt",
+		"syscall_slow_exit_work",
+		/*
+		 * Some (old) kernel and architecture doesn't support VDSO
+		 * so there will be many sys_clock_gettime() in the output
+		 * due to internal call in libmcount.  It'd be better
+		 * ignoring them not to confuse users.  I think it does NOT
+		 * affect to the output when VDSO is enabled.
+		 */
+		"sys_clock_gettime",
+	};
+
+	for (i = 0; i < ARRAY_SIZE(skip_funcs); i++) {
+		bool add = true;
+		const char *name = skip_funcs[i];
+		struct kfilter *pos;
+
+		/* Don't skip it if user particularly want to see them*/
+		list_for_each_entry(pos, &kernel->filters, list) {
+			if (strcmp(pos->name, name)) {
+				add = false;
+				break;
+			}
+		}
+
+		list_for_each_entry(pos, &kernel->patches, list) {
+			if (strcmp(pos->name, name)) {
+				add = false;
+				break;
+			}
+		}
+
+		if (add) {
+			kfilter = xmalloc(sizeof(*kfilter) + strlen(name) + 1);
+			strcpy(kfilter->name, name);
+			list_add(&kfilter->list, &kernel->notrace);
+		}
+	}
+}
+
 /**
  * setup_kernel_tracing - prepare to record kernel ftrace data (binary)
  * @kernel : kernel ftrace handle
@@ -500,19 +546,8 @@ int setup_kernel_tracing(struct uftrace_kernel_writer *kernel, struct opts *opts
 	/* mark kernel tracing is enabled (for event tracing) */
 	opts->kernel = true;
 
-	if (opts->kernel_skip_out) {
-		/*
-		 * Some (old) kernel and architecture doesn't support VDSO
-		 * so there will be many sys_clock_gettime() in the output
-		 * due to internal call in libmcount.  It'd be better
-		 * ignoring them not to confuse users.  I think it does NOT
-		 * affect to the output when VDSO is enabled.
-		 *
-		 * If an user wants to see them, give --kernel-full option.
-		 */
-		build_kernel_filter(kernel, "!sys_clock_gettime@kernel",
-				    &kernel->filters, &kernel->notrace);
-	}
+	if (opts->kernel_skip_out)
+		skip_kernel_functions(kernel);
 
 	ret = __setup_kernel_tracing(kernel);
 	if (ret < 0)


### PR DESCRIPTION
Hi @namhyung , I send this PR.

Because we discussed the problem about the kernel functions
that seem needless (i.e. 'syscall_trace_enter_phase1', 'syscall_slow_exit_work',
'smp_irq_work_interrupt')

So, if users don't particularly want to see this functions,
it seems to be better to skip them.

If running simple hello example,
you can see the below kernel functions.

Before:
```
  $ sudo uftrace -k hello
  # DURATION    TID     FUNCTION
     0.730 us [24138] | __monstartup();
     0.773 us [24138] | __cxa_atexit();
              [24138] | main() {
              [24138] |   printf() {
     0.569 us [24138] |     syscall_trace_enter_phase1();
     1.700 us [24138] |     sys_newfstat();
     0.611 us [24138] |     syscall_slow_exit_work();
     4.927 us [24138] |     __do_page_fault();
     0.734 us [24138] |     smp_irq_work_interrupt();
    14.950 us [24138] |   } /* printf */
    ...
```

After:
```
  $ sudo ufrace -k hello

   0.533 us [24055] | __monstartup();
   0.515 us [24055] | __cxa_atexit();
            [24055] | main() {
            [24055] |   printf() {
   2.197 us [24055] |     sys_newfstat();
   3.389 us [24055] |     __do_page_fault();
   9.987 us [24055] |   } /* printf */
   ...
```