### PR TITLE
mcount: Remove a residue 'cmpq' after mcount_entry()

### DIFF
--- a/arch/x86_64/mcount.S
+++ b/arch/x86_64/mcount.S
@@ -61,7 +61,6 @@ GLOBAL(mcount)
 	lea 8(%rsp), %rdx
 
 	call mcount_entry
-	cmpq $0, %rax
 
 	movq 0(%rsp), %rax
 	movq 8(%rsp), %r9


### PR DESCRIPTION
The commit 666bdf3 ("mcount: Hijack the return address
in mcount_entry()") already eliminate the code hijacking
return addr based on a return value of mcount_entry()
    
But a 'cmpq' instruction that seems needless
still remains. So, remove it.
    
Signed-off-by: Taeung Song <treeze.taeung@gmail.com>
