### PR TITLE
info: Use dynamically allocated buffer for cmd-info.c

### DIFF
--- a/cmd-info.c
+++ b/cmd-info.c
@@ -506,11 +506,12 @@ static int read_taskinfo(void *arg)
 {
 	struct ftrace_file_handle *handle = arg;
 	struct uftrace_info *info = &handle->info;
-	char buf[4096];
 	int i, lines;
 	int ret = -1;
+	char *buf = NULL;
+	size_t len = 0;
 
-	if (fgets(buf, sizeof(buf), handle->fp) == NULL)
+	if (getline(&buf, &len, handle->fp) < 0)
 		goto out;
 
 	if (strncmp(buf, "taskinfo:", 9))
@@ -520,7 +521,7 @@ static int read_taskinfo(void *arg)
 		goto out;
 
 	for (i = 0; i < lines; i++) {
-		if (fgets(buf, sizeof(buf), handle->fp) == NULL)
+		if (getline(&buf, &len, handle->fp) < 0)
 			goto out;
 
 		if (strncmp(buf, "taskinfo:", 9))
@@ -552,6 +553,7 @@ static int read_taskinfo(void *arg)
 	}
 	ret = 0;
 out:
+	free(buf);
 	return ret;
 }
 
@@ -725,11 +727,12 @@ static int read_arg_spec(void *arg)
 {
 	struct ftrace_file_handle *handle = arg;
 	struct uftrace_info *info = &handle->info;
-	char buf[4096];
 	int i, lines;
 	int ret = -1;
+	char *buf = NULL;
+	size_t len = 0;
 
-	if (fgets(buf, sizeof(buf), handle->fp) == NULL)
+	if (getline(&buf, &len, handle->fp) < 0)
 		goto out;
 
 	if (strncmp(buf, "argspec:", 8))
@@ -746,7 +749,7 @@ static int read_arg_spec(void *arg)
 		goto out;
 
 	for (i = 0; i < lines; i++) {
-		if (fgets(buf, sizeof(buf), handle->fp) == NULL)
+		if (getline(&buf, &len, handle->fp) < 0)
 			goto out;
 
 		if (strncmp(&buf[3], "spec:", 5))
@@ -761,6 +764,7 @@ static int read_arg_spec(void *arg)
 	}
 	ret = 0;
 out:
+	free(buf);
 	return ret;
 }
 


### PR DESCRIPTION
Claudiu Balogh reported that uftrace cannot read data that has more than
1000 threads.  It's because the current implementation stores the
task list in a fixed size buffer (4096).

So this patch makes the buffer to be allocated dynamically to make it
work for any size of task list.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>