### PR TITLE
live: Add a new line after record before replay

### DIFF
--- a/cmd-live.c
+++ b/cmd-live.c
@@ -163,6 +163,7 @@ int command_live(int argc, char *argv[], struct opts *opts)
 	if (!can_skip_replay(opts, ret)) {
 		int ret2;
 
+		pr_out("\n");
 		reset_live_opts(opts);
 
 		pr_dbg("live-record finished.. \n");


### PR DESCRIPTION
Some programs do not provide a new line when the program finishes.
In this case, uftrace replay header is concatenated to the original
program output, which makes the output ugly as follows.

  $ uftrace hello
  Hello World!# DURATION    TID     FUNCTION
     0.243 us [32159] | __monstartup();
     0.090 us [32159] | __cxa_atexit();
              [32159] | main() {
     1.529 us [32159] |   printf();
     1.617 us [32159] |   fflush();
     3.445 us [32159] | } /* main */

This adds a new line between record and replay in live command.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>