### PR TITLE
graph: Make graph output header simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,17 +164,12 @@ The `graph` command shows function call graph of given function.  In the above
 example, function graph of function 'main' looks like below:
 
     $ uftrace graph  main
-    #
-    # function graph for 'main' (session: 8823ea321c31e531)
-    #
-    
-    backtrace
-    ================================
+    # Function Call Graph for 'main' (session: 073f1e84aa8b09d3)
+    =============== BACKTRACE ===============
      backtrace #0: hit 1, time  25.024 us
        [0] main (0x40066b)
     
-    calling functions
-    ================================
+    ========== FUNCTION CALL GRAPH ==========
       25.024 us : (1) main
        2.706 us :  +-(1) atoi
                 :  | 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The `info` command shows system and program information when recorded.
     $ uftrace info
     # system information
     # ==================
-    # program version     : uftrace v0.6
+    # program version     : uftrace v0.8.1
     # recorded on         : Tue May 24 11:21:59 2016
     # cmdline             : uftrace record tests/t-abc 
     # cpu info            : Intel(R) Core(TM) i7-3930K CPU @ 3.20GHz

--- a/cmd-graph.c
+++ b/cmd-graph.c
@@ -443,20 +443,16 @@ static int print_graph(struct uftrace_graph *graph, struct opts *opts)
 	    graph->root.nr_edges == 0)
 		return 0;
 
-	pr_out("#\n");
-	pr_out("# function graph for '%s' (session: %.16s)\n",
+	pr_out("# Function Call Graph for '%s' (session: %.16s)\n",
 	       graph->func, graph->sess->sid);
-	pr_out("#\n\n");
 
 	if (!list_empty(&graph->bt_list)) {
-		pr_out("backtrace\n");
-		pr_out("=====================================\n");
+		pr_out("=============== BACKTRACE ===============\n");
 		print_backtrace(graph);
 	}
 
 	if (graph->root.time || graph->root.nr_edges) {
-		pr_out("calling functions\n");
-		pr_out("=====================================\n");
+		pr_out("========== FUNCTION CALL GRAPH ==========\n");
 		indent_mask = xcalloc(opts->max_stack, sizeof(*indent_mask));
 		print_graph_node(graph, &graph->root, indent_mask, 0,
 				 graph->root.nr_edges > 1);

--- a/doc/uftrace-graph.md
+++ b/doc/uftrace-graph.md
@@ -86,17 +86,12 @@ This command show data like below:
 Running the `graph` command on the `main` function shows called functions like below:
 
     $ uftrace graph main
-    #
-    # function graph for 'main'
-    #
-    
-    backtrace
-    ================================
+    # Function Call Graph for 'main' (session: 073f1e84aa8b09d3)
+    =============== BACKTRACE ===============
      backtrace #0: hit 1, time  10.293 ms
        [0] main (0x4004f0)
     
-    calling functions
-    ================================
+    ========== FUNCTION CALL GRAPH ==========
       10.293 ms : (1) main
       46.626 us :  +-(2) foo
       44.360 us :  | (6) loop
@@ -111,19 +106,14 @@ It can also be seen that `main` called `bar` once and that `bar` then called `us
 Running graph command on a leaf function looks like below.
 
     $ uftrace graph loop
-    #
-    # function graph for 'loop'
-    #
-    
-    backtrace
-    ================================
+    # Function Call Graph for 'loop' (session: 073f1e84aa8b09d3)
+    =============== BACKTRACE ===============
      backtrace #0: hit 6, time  44.360 us
        [0] main (0x4004b0)
        [1] foo (0x400622)
        [2] loop (0x400f5f6)
     
-    calling functions
-    ================================
+    ========== FUNCTION CALL GRAPH ==========
       44.360 us : (6) loop
 
 The backtrace shows that loop is called from `foo` and that `foo` is called from `main`.  Since `loop` is a leaf function, it didn't call any other function.  In this case, `loop` was called only from a single path so backtrace #0 is hit 6 times.

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -214,13 +214,13 @@ class TestBase:
         result = []
         mode = 0
         for ln in output.split('\n'):
-            if ln.strip() == '' or ln.startswith('#') or ln.startswith('='):
+            if ln.strip() == '' or ln.startswith('#'):
                 continue
             # A graph result consists of backtrace and calling functions
-            if ln.startswith('backtrace'):
+            if ln.startswith('=============== BACKTRACE ==============='):
                 mode = 1
                 continue
-            if ln.startswith('calling'):
+            if ln.startswith('========== FUNCTION CALL GRAPH =========='):
                 mode = 2
                 continue
             if mode == 1:

--- a/tests/t069_graph.py
+++ b/tests/t069_graph.py
@@ -9,23 +9,18 @@ FUNC='main'
 class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'sort', result="""
-#
-# function graph for 'main'
-#
+# Function Call Graph for 'main' (session: baa921f86e22e0c9)
+=============== BACKTRACE ===============
+ backtrace #0: hit 1, time  11.460 ms
+   [0] main (0x40069e)
 
-backtrace
-================================
- backtrace #0: hit 1, time  10.293 ms
-   [0] main (0x4004f0)
-
-calling functions
-================================
-  10.293 ms : (1) main
-  46.626 us :  +-(2) foo
-  44.360 us :  | (6) loop
+========== FUNCTION CALL GRAPH ==========
+  11.460 ms : (1) main
+ 311.345 us :  +-(2) foo
+ 308.918 us :  | (6) loop
             :  | 
-  10.138 ms :  +-(1) bar
-  10.100 ms :    (1) usleep
+  10.362 ms :  +-(1) bar
+  10.091 ms :    (1) usleep
 """, sort='graph')
 
     def pre(self):

--- a/tests/t070_graph_backtrace.py
+++ b/tests/t070_graph_backtrace.py
@@ -9,22 +9,17 @@ FUNC='getpid'
 class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'abc', result="""
-#
-# function graph for 'getpid'
-#
+# Function Call Graph for 'getpid' (session: adff9f265b25c0d8)
+=============== BACKTRACE ===============
+ backtrace #0: hit 1, time   2.010 us
+   [0] main (0x400530)
+   [1] a (0x4006f1)
+   [2] b (0x4006c1)
+   [3] c (0x400686)
+   [4] getpid (0x4004d0)
 
-backtrace
-================================
- backtrace #0: hit 1, time   1.622 us
-   [0] main (0x4004f0)
-   [1] a (0x40069f)
-   [2] b (0x400674)
-   [3] c (0x400636)
-   [4] getpid (0x400490)
-
-calling functions
-================================
-   1.622 us : (1) getpid
+========== FUNCTION CALL GRAPH ==========
+   2.010 us : (1) getpid
 """, sort='graph')
 
     def pre(self):

--- a/tests/t071_graph_depth.py
+++ b/tests/t071_graph_depth.py
@@ -9,39 +9,34 @@ FUNC='main'
 class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'namespace', lang="C++", result="""
-#
-# function graph for 'main'
-#
+# Function Call Graph for 'main' (session: b508f628ffe7287f)
+=============== BACKTRACE ===============
+ backtrace #0: hit 1, time  17.931 us
+   [0] main (0x400790)
 
-backtrace
-================================
- backtrace #0: hit 1, time  17.930 us
-   [0] main (0x4004f0)
-
-calling functions
-================================
-  17.930 us : (1) main
-   2.472 us :  +-(2) operator new
+========== FUNCTION CALL GRAPH ==========
+  17.931 us : (1) main
+   2.087 us :  +-(2) operator new
             :  | 
-   1.106 us :  +-(1) ns::ns1::foo::foo
+   0.183 us :  +-(1) ns::ns1::foo::foo
             :  | 
-   4.968 us :  +-(1) ns::ns1::foo::bar
-   2.788 us :  |  +-(1) ns::ns1::foo::bar1
-   2.469 us :  |  | (1) ns::ns1::foo::bar2
-   2.117 us :  |  | (1) ns::ns1::foo::bar3
+   4.816 us :  +-(1) ns::ns1::foo::bar
+   2.810 us :  |  +-(1) ns::ns1::foo::bar1
+   2.536 us :  |  | (1) ns::ns1::foo::bar2
+   2.240 us :  |  | (1) ns::ns1::foo::bar3
             :  |  | 
-   1.565 us :  |  +-(1) free
+   1.356 us :  |  +-(1) free
             :  | 
-   3.924 us :  +-(2) operator delete
+   2.624 us :  +-(2) operator delete
             :  | 
-   0.092 us :  +-(1) ns::ns2::foo::foo
+   0.093 us :  +-(1) ns::ns2::foo::foo
             :  | 
-   1.917 us :  +-(1) ns::ns2::foo::bar
-   1.220 us :     +-(1) ns::ns2::foo::bar1
-   0.963 us :     | (1) ns::ns2::foo::bar2
-   0.714 us :     | (1) ns::ns2::foo::bar3
+   1.997 us :  +-(1) ns::ns2::foo::bar
+   1.286 us :     +-(1) ns::ns2::foo::bar1
+   1.017 us :     | (1) ns::ns2::foo::bar2
+   0.740 us :     | (1) ns::ns2::foo::bar3
             :     | 
-   0.240 us :     +-(1) free
+   0.187 us :     +-(1) free
 """, sort='graph')
 
     def pre(self):

--- a/tests/t088_graph_session.py
+++ b/tests/t088_graph_session.py
@@ -9,38 +9,28 @@ FUNC='main'
 class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'forkexec', result="""
-#
-# function graph for 'main' (session: ee242b9985a2975d)
-#
+# Function Call Graph for 'main' (session: 327202376e209585)
+=============== BACKTRACE ===============
+ backtrace #0: hit 1, time   5.824 us
+   [0] main (0x400530)
 
-backtrace
-================================
- backtrace #0: hit 1, time   7.865 us
-   [0] main (0x400510)
+========== FUNCTION CALL GRAPH ==========
+   5.824 us : (1) main
+   5.411 us : (1) a
+   5.141 us : (1) b
+   4.670 us : (1) c
+   0.967 us : (1) getpid
 
-calling functions
-================================
-   7.865 us : (1) main
-   2.988 us : (1) a
-   2.705 us : (1) b
-   2.271 us : (1) c
-   0.657 us : (1) getpid
+# Function Call Graph for 'main' (session: f34056bd485963b3)
+=============== BACKTRACE ===============
+ backtrace #0: hit 1, time   3.679 ms
+   [0] main (0x4005b0)
 
-#
-# function graph for 'main' (session: 1dc307633af856ad)
-#
-
-backtrace
-================================
- backtrace #0: hit 1, time   3.433 ms
-   [0] main (0x4007ed)
-
-calling functions
-================================
-   3.433 ms : (1) main
- 114.506 us :  +-(1) fork
+========== FUNCTION CALL GRAPH ==========
+   3.679 ms : (1) main
+ 127.172 us :  +-(1) fork
             :  | 
-   3.289 ms :  +-(1) waitpid
+   3.527 ms :  +-(1) waitpid
 """)
 
     def pre(self):
@@ -66,12 +56,12 @@ calling functions
         result = []
         mode = 0
         for ln in output.split('\n'):
-            if ln.strip() == '' or ln.startswith('#') or ln.startswith('='):
+            if ln.strip() == '' or ln.startswith('#'):
                 continue
-            if ln.startswith('backtrace'):
+            if ln.startswith('=============== BACKTRACE ==============='):
                 mode = 1  # it seems to be broken in this case
                 continue
-            if ln.startswith('calling'):
+            if ln.startswith('========== FUNCTION CALL GRAPH =========='):
                 mode = 2
                 continue
             if mode == 1:

--- a/tests/t089_graph_exit.py
+++ b/tests/t089_graph_exit.py
@@ -9,19 +9,14 @@ FUNC='main'
 class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'exit', result="""
-#
-# function graph for 'main' (session: 924133e5b1cd2228)
-#
+# Function Call Graph for 'main' (session: 095c3a95937bdbae)
+=============== BACKTRACE ===============
+ backtrace #0: hit 1, time   0.527 us
+   [0] main (0x400480)
 
-backtrace
-================================
- backtrace #0: hit 1, time           
-   [0] main (0x400644)
-
-calling functions
-================================
-            : (1) main
-            : (1) foo
+========== FUNCTION CALL GRAPH ==========
+   0.527 us : (1) main
+   0.387 us : (1) foo
             : (1) exit
 """, sort='graph')
 

--- a/tests/t095_graph_tid.py
+++ b/tests/t095_graph_tid.py
@@ -9,22 +9,17 @@ FUNC='a'
 class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'fork', result="""
-#
-# function graph for 'a' (session: de8436a173b22b1c)
-#
+# Function Call Graph for 'a' (session: 5eec64959f2b2e87)
+=============== BACKTRACE ===============
+ backtrace #0: hit 1, time   4.290 us
+   [0] main (0x4005c0)
+   [1] a (0x4007a1)
 
-backtrace
-================================
- backtrace #0: hit 1, time   6.602 us
-   [0] main (0x4005c5)
-   [1] a (0x400782)
-
-calling functions
-================================
-   6.602 us : (1) a
-   6.094 us : (1) b
-   5.680 us : (1) c
-   4.234 us : (1) getpid
+========== FUNCTION CALL GRAPH ==========
+   4.290 us : (1) a
+   3.970 us : (1) b
+   3.580 us : (1) c
+   2.616 us : (1) getpid
 """, sort='graph')
 
     def pre(self):

--- a/tests/t096_graph_filter.py
+++ b/tests/t096_graph_filter.py
@@ -9,21 +9,15 @@ FUNC='a'
 class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'fork', result="""
-#
-# function graph for 'a' (session: de8436a173b22b1c)
-#
+# Function Call Graph for 'a' (session: 93175b4bdd9d0ddf)
+=============== BACKTRACE ===============
+ backtrace #0: hit 1, time   4.217 us
+   [0] main (0x4005c0)
+   [1] a (0x4007a1)
 
-backtrace
-================================
- backtrace #0: hit 1, time   6.602 us
-   [0] main (0x4005c5)
-   [1] a (0x400782)
-
-calling functions
-================================
-   6.602 us : (1) a
-   6.094 us : (1) b
-
+========== FUNCTION CALL GRAPH ==========
+   4.217 us : (1) a
+   3.876 us : (1) b
 """, sort='graph')
 
     def pre(self):

--- a/tests/t104_graph_kernel.py
+++ b/tests/t104_graph_kernel.py
@@ -10,40 +10,35 @@ FUNC='main'
 class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'getids', result="""
-#
-# function graph for 'main' (session: 771f183fd824f3a3)
-#
+# Function Call Graph for 'main' (session: 59268c360e3c1bd6)
+=============== BACKTRACE ===============
+ backtrace #0: hit 1, time  24.837 us
+   [0] main (0x400893)
 
-backtrace
-================================
- backtrace #0: hit 1, time  17.436 us
-   [0] main (0x4006c0)
-
-calling functions
-================================
-  17.436 us : (1) main
-   1.123 us :  +-(1) getpid
+========== FUNCTION CALL GRAPH ==========
+  24.837 us : (1) main
+   0.860 us :  +-(1) getpid
             :  | 
-   1.838 us :  +-(1) getppid
-   0.738 us :  | (1) sys_getppid
+   3.130 us :  +-(1) getppid
+   1.080 us :  | (1) sys_getppid
             :  | 
-   1.919 us :  +-(1) getpgid
-   0.629 us :  | (1) sys_getpgid
+   2.926 us :  +-(1) getpgid
+   0.834 us :  | (1) sys_getpgid
             :  | 
-   1.711 us :  +-(1) getsid
-   0.496 us :  | (1) sys_getsid
+   2.393 us :  +-(1) getsid
+   0.750 us :  | (1) sys_getsid
             :  | 
-   1.353 us :  +-(1) getuid
-   0.361 us :  | (1) sys_getuid
+   2.030 us :  +-(1) getuid
+   0.660 us :  | (1) sys_getuid
             :  | 
-   1.451 us :  +-(1) geteuid
-   0.470 us :  | (1) sys_geteuid
+   2.074 us :  +-(1) geteuid
+   0.510 us :  | (1) sys_geteuid
             :  | 
-   1.456 us :  +-(1) getgid
-   0.401 us :  | (1) sys_getgid
+   4.391 us :  +-(1) getgid
+   0.696 us :  | (1) sys_getgid
             :  | 
-   1.360 us :  +-(1) getegid
-   0.346 us :    (1) sys_getegid
+   4.223 us :  +-(1) getegid
+   1.710 us :    (1) sys_getegid
 """, sort='graph')
 
     def pre(self):

--- a/tests/t108_graph_time.py
+++ b/tests/t108_graph_time.py
@@ -9,22 +9,16 @@ FUNC='main'
 class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'sleep', result="""
-#
-# function graph for 'main' (session: 0bc5da823389c319)
-#
+# Function Call Graph for 'main' (session: b78e9c27042adaa7)
+=============== BACKTRACE ===============
+ backtrace #0: hit 1, time   2.109 ms
+   [0] main (0x400570)
 
-backtrace
-================================
- backtrace #0: hit 1, time   2.103 ms
-   [0] main (0x400550)
-
-calling functions
-================================
-   2.103 ms : (1) main
-   2.102 ms : (1) foo
-   2.084 ms : (1) bar
-   2.080 ms : (1) usleep
-
+========== FUNCTION CALL GRAPH ==========
+   2.109 ms : (1) main
+   2.109 ms : (1) foo
+   2.098 ms : (1) bar
+   2.096 ms : (1) usleep
 """, sort='graph')
 
     def pre(self):

--- a/tests/t165_graph_sched.py
+++ b/tests/t165_graph_sched.py
@@ -9,24 +9,19 @@ FUNC='main'
 class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'sort', result="""
-#
-# function graph for 'main'
-#
+# Function Call Graph for 'main' (session: 54047ea45c46ad91)
+=============== BACKTRACE ===============
+ backtrace #0: hit 1, time  10.329 ms
+   [0] main (0x4004e0)
 
-backtrace
-================================
- backtrace #0: hit 1, time  10.293 ms
-   [0] main (0x4004f0)
-
-calling functions
-================================
-  10.293 ms : (1) main
-  46.626 us :  +-(2) foo
-  44.360 us :  | (6) loop
+========== FUNCTION CALL GRAPH ==========
+  10.329 ms : (1) main
+  53.100 us :  +-(2) foo
+  50.745 us :  | (6) loop
             :  | 
-  10.138 ms :  +-(1) bar
-  10.100 ms :    (1) usleep
-  10.098 ms :    (1) linux:schedule
+  10.150 ms :  +-(1) bar
+  10.102 ms :    (1) usleep
+  10.088 ms :    (1) linux:schedule
 """, sort='graph')
 
     def pre(self):


### PR DESCRIPTION
Since the header of graph output was very long, it'd be better to make
it simpler so that it can be shown as a compact form.

Before:
  \#
  \# function graph for 'main' (session: a4016e70192f5080)
  \#

  backtrace
  \=====================================
   backtrace #0: hit 1, time  13.013 us
     [0] main (0x400cc9)

  calling functions
  \=====================================
    13.013 us : (1) main
      ...

After:
  \# Function Call Graph for 'main' (session: a4016e70192f5080)

  \=============== BACKTRACE ===============
   backtrace #0: hit 1, time  13.013 us
     [0] main (0x400cc9)

  \========== FUNCTION CALL GRAPH ==========
    13.013 us : (1) main

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>