### PR TITLE
doc: Update man pages for funcptr arg type and live command

### DIFF
--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -286,15 +286,17 @@ The uftrace tool supports recording function arguments and/or return values usin
     <argument>    :=  <symbol> "@" <specs>
     <specs>       :=  <spec> | <spec> "," <spec>
     <spec>        :=  ( <int_spec> | <float_spec> | <ret_spec> )
-    <int_spec>    :=  "arg" N [ "/" <format> [ <size> ] ]
-    <float_spec>  :=  "fparg" N [ "/" ( <size> | "80" ) ]
+    <int_spec>    :=  "arg" N [ "/" <format> [ <size> ] ] [ "%" ( <reg> | <stack> ) ]
+    <float_spec>  :=  "fparg" N [ "/" ( <size> | "80" ) ] [ "%" ( <reg> | <stack> ) ]
     <ret_spec>    :=  "retval" [ "/" <format> [ <size> ] ]
-    <format>      :=  "i" | "u" | "x" | "s" | "c" | "f"
+    <format>      :=  "i" | "u" | "x" | "s" | "c" | "f" | "S"
     <size>        :=  "8" | "16" | "32" | "64"
+    <reg>         :=  <arch-specific register name>  # "rdi", "xmm0", "r0", ...
+    <stack>       :=  "stack" [ "+" ] <offset>
 
 The `-A`/`--argument` option takes argN where N is an index of the arguments.  The index starts from 1 and corresponds to the argument passing order of the calling convention on the system.  Note that the indexes of arguments are separately counted for integer (or pointer) and floating-point type, and they can interfere depending on the calling convention.  The argN is for integer arguments and fpargN is for floating-point arguments.
 
-Users can optionally specify a format and size for the arguments and/or return values.  Without this, uftrace treats them as 'long int' type for integers and 'double' for floating-point numbers.  The "i" format makes it signed integer type and "u" format is for unsigned type.  Both are printed as decimal while "x" format makes it printed as hexadecimal.  The "s" format is for string type and "c" format is for character type.  Finally, the "f" format is for floating-point type and is meaningful only for return value (generally).  Note that fpargN doesn't take the format field since it's always floating-point.
+Users can optionally specify a format and size for the arguments and/or return values.  Without this, uftrace treats them as 'long int' type for integers and 'double' for floating-point numbers.  The "i" format makes it signed integer type and "u" format is for unsigned type.  Both are printed as decimal while "x" format makes it printed as hexadecimal.  The "s" format is for null-terminated string type and "c" format is for character type.  The "f" format is for floating-point type and is meaningful only for return value (generally).  Note that fpargN doesn't take the format field since it's always floating-point.  Finally, the "S" format is for std::string, but it only supports libstdc++ library as of yet.
 
 Please beware when using string type arguments since it can crash the program if the (pointer) value is invalid.
 

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -289,14 +289,14 @@ The uftrace tool supports recording function arguments and/or return values usin
     <int_spec>    :=  "arg" N [ "/" <format> [ <size> ] ] [ "%" ( <reg> | <stack> ) ]
     <float_spec>  :=  "fparg" N [ "/" ( <size> | "80" ) ] [ "%" ( <reg> | <stack> ) ]
     <ret_spec>    :=  "retval" [ "/" <format> [ <size> ] ]
-    <format>      :=  "i" | "u" | "x" | "s" | "c" | "f" | "S"
+    <format>      :=  "i" | "u" | "x" | "s" | "c" | "f" | "S" | "p"
     <size>        :=  "8" | "16" | "32" | "64"
     <reg>         :=  <arch-specific register name>  # "rdi", "xmm0", "r0", ...
     <stack>       :=  "stack" [ "+" ] <offset>
 
 The `-A`/`--argument` option takes argN where N is an index of the arguments.  The index starts from 1 and corresponds to the argument passing order of the calling convention on the system.  Note that the indexes of arguments are separately counted for integer (or pointer) and floating-point type, and they can interfere depending on the calling convention.  The argN is for integer arguments and fpargN is for floating-point arguments.
 
-Users can optionally specify a format and size for the arguments and/or return values.  Without this, uftrace treats them as 'long int' type for integers and 'double' for floating-point numbers.  The "i" format makes it signed integer type and "u" format is for unsigned type.  Both are printed as decimal while "x" format makes it printed as hexadecimal.  The "s" format is for null-terminated string type and "c" format is for character type.  The "f" format is for floating-point type and is meaningful only for return value (generally).  Note that fpargN doesn't take the format field since it's always floating-point.  Finally, the "S" format is for std::string, but it only supports libstdc++ library as of yet.
+Users can optionally specify a format and size for the arguments and/or return values.  Without this, uftrace treats them as 'long int' type for integers and 'double' for floating-point numbers.  The "i" format makes it signed integer type and "u" format is for unsigned type.  Both are printed as decimal while "x" format makes it printed as hexadecimal.  The "s" format is for null-terminated string type and "c" format is for character type.  The "f" format is for floating-point type and is meaningful only for return value (generally).  Note that fpargN doesn't take the format field since it's always floating-point.  The "S" format is for std::string, but it only supports libstdc++ library as of yet.  Finally, the "p" format is for function pointer. Once the target address is recorded, it will be displayed as function name.
 
 Please beware when using string type arguments since it can crash the program if the (pointer) value is invalid.
 

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -287,14 +287,14 @@ The uftrace tool supports recording function arguments and/or return values usin
     <int_spec>    :=  "arg" N [ "/" <format> [ <size> ] ] [ "%" ( <reg> | <stack> ) ]
     <float_spec>  :=  "fparg" N [ "/" ( <size> | "80" ) ] [ "%" ( <reg> | <stack> ) ]
     <ret_spec>    :=  "retval" [ "/" <format> [ <size> ] ]
-    <format>      :=  "i" | "u" | "x" | "s" | "c" | "f" | "S"
+    <format>      :=  "i" | "u" | "x" | "s" | "c" | "f" | "S" | "p"
     <size>        :=  "8" | "16" | "32" | "64"
     <reg>         :=  <arch-specific register name>  # "rdi", "xmm0", "r0", ...
     <stack>       :=  "stack" [ "+" ] <offset>
 
 The `-A`/`--argument` option takes argN where N is an index of the arguments.  The index starts from 1 and corresponds to the argument passing order of the calling convention on the system.  Note that the indexes of arguments are separately counted for integer (or pointer) and floating-point type, and they can interfere depending on the calling convention.  The argN is for integer arguments and fpargN is for floating-point arguments.
 
-Users can optionally specify a format and size for the arguments and/or return values.  Without this, uftrace treats them as 'long int' type for integers and 'double' for floating-point numbers.  The "i" format makes it signed integer type and "u" format is for unsigned type.  Both are printed as decimal while "x" format makes it printed as hexadecimal.  The "s" format is for null-terminated string type and "c" format is for character type.  The "f" format is for floating-point type and is meaningful only for return value (generally).  Note that fpargN doesn't take the format field since it's always floating-point.  Finally, the "S" format is for std::string, but it only supports libstdc++ library as of yet.
+Users can optionally specify a format and size for the arguments and/or return values.  Without this, uftrace treats them as 'long int' type for integers and 'double' for floating-point numbers.  The "i" format makes it signed integer type and "u" format is for unsigned type.  Both are printed as decimal while "x" format makes it printed as hexadecimal.  The "s" format is for null-terminated string type and "c" format is for character type.  The "f" format is for floating-point type and is meaningful only for return value (generally).  Note that fpargN doesn't take the format field since it's always floating-point.  The "S" format is for std::string, but it only supports libstdc++ library as of yet.  Finally, the "p" format is for function pointer. Once the target address is recorded, it will be displayed as function name.
 
 Please beware when using string type arguments since it can crash the program if the (pointer) value is invalid.
 


### PR DESCRIPTION
This PR updates argspec in uftrace live man page and also update the man
page for newly added function pointer type in argspec.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>