### PR TITLE
doc:Fix script example command

### DIFF
--- a/doc/uftrace-script.md
+++ b/doc/uftrace-script.md
@@ -86,7 +86,7 @@ The above script can be executed while reading the recorded data.  The usage is 
 
     $ uftrace record -F main tests/t-abc
 
-    $ uftrace scripts -S scripts/simple.py
+    $ uftrace script -S scripts/simple.py
     program begins...
     entry : main()
     entry : a()


### PR DESCRIPTION
Hi, I think there is a typo in the script example.

line 58

Before
~~~
$ uftrace record -F main tests/t-abc

$ uftrace scripts -S scripts/simple.py
program begins...
entry : main()
entry : a()
entry : b()
entry : c()
entry : getpid()
exit  : getpid()
exit  : c()
exit  : b()
exit  : a()
exit  : main()
program is finished
~~~

After
~~~
$ uftrace record -F main tests/t-abc

$ uftrace script -S scripts/simple.py
program begins...
entry : main()
entry : a()
entry : b()
entry : c()
entry : getpid()
exit  : getpid()
exit  : c()
exit  : b()
exit  : a()
exit  : main()
program is finished
~~~

Thank you! :)

Signed-off-by: JangSoJin <wkdthwls3@naver.com>