### PR TITLE
doc:Fix -pg command

### DIFF
--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -160,7 +160,7 @@ For example, consider a simple program which calls `a()`, `b()` and `c()` in tur
         return 0;
     }
 
-    $ gcc -o abc abc.c
+    $ gcc -pg -o abc abc.c
 
 Normally uftrace will trace all the functions from `main()` to `c()`.
 


### PR DESCRIPTION
Sorry, but I found the wrong command. 
I think `-pg` option is missing by mistake. 
When i try to execute it(`uftrace ./abc`), I found out error message.(`It seems not to be compiled with -pg......`)

line 101
Before
~~~
$ cat abc.c
void c(void) {
    /* do nothing */
}

void b(void) {
    c();
}

void a(void) {
    b();
}

int main(void) {
    a();
    return 0;
}

$ gcc -o abc abc.c
~~~

After
~~~
$ cat abc.c
void c(void) {
    /* do nothing */
}

void b(void) {
    c();
}

void a(void) {
    b();
}

int main(void) {
    a();
    return 0;
}

$ gcc -pg -o abc abc.c
~~~

That's it, Thanks! :) 
Signed-off-by: JangSoJin <wkdthwls3@naver.com>