### PR TITLE
build: Add install-elfutils.sh to build elfutils manually

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -81,12 +81,23 @@ directories or build directory with this script.
     $ ./configure --help
     Usage: ./configure [<options>]
 
-      --help             print this message
-      --prefix=<DIR>     set install root dir as <DIR>        (default: /usr/local)
-      --bindir=<DIR>     set executable install dir as <DIR>  (default: ${prefix}/bin)
-      --libdir=<DIR>     set library install dir as <DIR>     (default: ${prefix}/lib)
-      --mandir=<DIR>     set manual doc install dir as <DIR>  (default: ${prefix}/share/man)
-      --objdir=<DIR>     set build dir as <DIR>               (default: ${PWD})
+      --help                print this message
+      --prefix=<DIR>        set install root dir as <DIR>        (default: /usr/local)
+      --bindir=<DIR>        set executable install dir as <DIR>  (default: ${prefix}/bin)
+      --libdir=<DIR>        set library install dir as <DIR>     (default: ${prefix}/lib)
+      --mandir=<DIR>        set manual doc install dir as <DIR>  (default: ${prefix}/share/man)
+      --objdir=<DIR>        set build dir as <DIR>               (default: ${PWD})
+      --sysconfdir=<DIR>    override the etc dir as <DIR>
+      --with-elfutils=<DIR> search for elfutils in <DIR>/include and <DIR>/lib
+
+      -p                    preserve old setting
+
+      Some influential environment variables:
+        ARCH           Target architecture    e.g. arm, aarch64, or x86_64
+        CROSS_COMPILE  Specify the compiler prefix during compilation
+                       e.g. CC is overridden by $(CROSS_COMPILE)gcc
+        CFLAGS         C compiler flags
+        LDFLAGS        linker flags
 
 Also you can set the target architecture and compiler options like CC, CFLAGS.
 
@@ -96,4 +107,27 @@ For cross compile, you may want to setup the toolchain something like below:
     $ ./configure ARCH=arm CFLAGS='--sysroot /path/to/sysroot'
 
 This assumes you already installed the cross-built `libelf` on the sysroot
-directory.
+directory.  Otherwise, you can also build it from source (please see below) or
+use it on a different path using `--with-elfutils=<PATH>`.
+
+BUILD WITH ELFUTILS (libelf)
+============================
+
+It may be useful to manually compile libelf for uftrace build if the target
+system doesn't have libelf installed.  `misc/install-elfutils.sh` provides a way
+to download and build libelf, which is one of the libraries in elfutils.
+
+The below is the way to compile uftrace together with libelf.
+
+    $ export CROSS_COMPILE=arm-linux-gnueabi-
+    $ export ARCH=arm
+    $ export CFLAGS="-march=armv7-a"
+    $ ./misc/install-elfutils.sh --prefix=/path/to/install
+    $ ./configure --prefix=/path/to/install --with-elfutils=/path/to/install
+
+    $ make
+    $ make install
+
+`misc/install-elfutils.sh` downloads and builds elfutils and install libelf to
+prefix directory.  The installed libelf can be found using `--with-elfutils` in
+`configure` script.

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,10 @@ COMMON_CFLAGS := -O2 -g -D_GNU_SOURCE $(CFLAGS) $(CPPFLAGS)
 COMMON_CFLAGS +=  -iquote $(srcdir) -iquote $(objdir) -iquote $(srcdir)/arch/$(ARCH)
 #CFLAGS-DEBUG = -g -D_GNU_SOURCE $(CFLAGS_$@)
 COMMON_LDFLAGS := -lelf -lrt -ldl -pthread $(LDFLAGS)
+ifneq ($(elfdir),)
+  COMMON_CFLAGS +=  -I$(elfdir)/include
+  COMMON_LDFLAGS += -L$(elfdir)/lib
+endif
 
 COMMON_CFLAGS += -W -Wall -Wno-unused-parameter -Wno-missing-field-initializers
 
@@ -205,6 +209,13 @@ install: all
 	$(Q)$(INSTALL) -d -m 755 $(DESTDIR)$(bindir)
 	$(Q)$(INSTALL) -d -m 755 $(DESTDIR)$(libdir)
 	$(Q)$(INSTALL) -d -m 755 $(DESTDIR)$(etcdir)/bash_completion.d
+ifneq ($(wildcard $(elfdir)/lib/libelf.so),)
+ifeq ($(wildcard $(prefix)/lib/libelf.so),)
+	# install libelf only when it's not in the install directory.
+	$(call QUIET_INSTALL, libelf)
+	$(Q)$(INSTALL) $(elfdir)/lib/libelf.so   $(DESTDIR)$(libdir)/libelf.so
+endif
+endif
 	$(call QUIET_INSTALL, uftrace)
 	$(Q)$(INSTALL) $(objdir)/uftrace         $(DESTDIR)$(bindir)/uftrace
 	$(call QUIET_INSTALL, libmcount)

--- a/check-deps/Makefile
+++ b/check-deps/Makefile
@@ -6,6 +6,7 @@ CHECK_LIST += cc_has_mno_sse2
 CHECK_LIST += have_libpython2.7
 CHECK_LIST += perf_clockid
 CHECK_LIST += perf_context_switch
+CHECK_LIST += arm_has_hardfp
 
 #
 # This is needed for checking build dependency

--- a/check-deps/Makefile.check
+++ b/check-deps/Makefile.check
@@ -26,3 +26,7 @@ endif
 ifneq ($(wildcard $(srcdir)/check-deps/perf_context_switch),)
   COMMON_CFLAGS += -DHAVE_PERF_CTXSW
 endif
+
+ifneq ($(wildcard $(srcdir)/check-deps/arm_has_hardfp),)
+  COMMON_CFLAGS += -DHAVE_ARM_HARDFP
+endif

--- a/check-deps/__arm_has_hardfp.c
+++ b/check-deps/__arm_has_hardfp.c
@@ -1,0 +1,7 @@
+int main(void)
+{
+	float f;
+
+	asm volatile ("vstr %%s0, %0\n" : "=m" (f));
+	return 0;
+}

--- a/configure
+++ b/configure
@@ -20,6 +20,13 @@ usage() {
   --with-elfutils=<DIR> search for elfutils in <DIR>/include and <DIR>/lib
 
   -p                    preserve old setting
+
+  Some influential environment variables:
+    ARCH           Target architecture    e.g. arm, aarch64, or x86_64
+    CROSS_COMPILE  Specify the compiler prefix during compilation
+                   e.g. CC is overridden by \$(CROSS_COMPILE)gcc
+    CFLAGS         C compiler flags
+    LDFLAGS        linker flags
 "
     exit 1
 }

--- a/configure
+++ b/configure
@@ -10,15 +10,16 @@ output=${output:-${objdir}/.config}
 usage() {
     echo "Usage: $0 [<options>]
 
-  --help             print this message
-  --prefix=<DIR>     set install root dir as <DIR>        (default: /usr/local)
-  --bindir=<DIR>     set executable install dir as <DIR>  (default: \${prefix}/bin)
-  --libdir=<DIR>     set library install dir as <DIR>     (default: \${prefix}/lib)
-  --mandir=<DIR>     set manual doc install dir as <DIR>  (default: \${prefix}/share/man)
-  --objdir=<DIR>     set build dir as <DIR>               (default: \${PWD})
-  --sysconfdir=<DIR> override the etc dir as <DIR>
+  --help                print this message
+  --prefix=<DIR>        set install root dir as <DIR>        (default: /usr/local)
+  --bindir=<DIR>        set executable install dir as <DIR>  (default: \${prefix}/bin)
+  --libdir=<DIR>        set library install dir as <DIR>     (default: \${prefix}/lib)
+  --mandir=<DIR>        set manual doc install dir as <DIR>  (default: \${prefix}/share/man)
+  --objdir=<DIR>        set build dir as <DIR>               (default: \${PWD})
+  --sysconfdir=<DIR>    override the etc dir as <DIR>
+  --with-elfutils=<DIR> search for elfutils in <DIR>/include and <DIR>/lib
 
-  -p                 preserve old setting
+  -p                    preserve old setting
 "
     exit 1
 }
@@ -105,8 +106,9 @@ export CC CFLAGS LD LDFLAGS
 make -siC ${srcdir}/check-deps check-clean
 make -siC ${srcdir}/check-deps check-build
 
-if [ ! -e ${srcdir}/check-deps/have_libelf ]; then
+if [ ! -e ${srcdir}/check-deps/have_libelf ] && [ ! -f ${with_elfutils}/lib/libelf.so ]; then
     echo "Error: cannot find 'libelf' (from elfutils): Please install it first."
+    echo "Otherwise, please install it using \"misc/install-elfutils.sh\" script."
     exit 1
 fi
 
@@ -117,6 +119,13 @@ override bindir := $bindir
 override libdir := $libdir
 override mandir := $mandir
 override etcdir := $etcdir
+EOF
+
+if [ ! -z $with_elfutils ]; then
+    echo "override elfdir := $with_elfutils" >> $output
+fi
+
+cat >>$output <<EOF
 
 override ARCH   := $ARCH
 override CC     := $CC

--- a/misc/install-elfutils.sh
+++ b/misc/install-elfutils.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#-*- mode: shell-script; -*-
+
+prefix=/usr/local
+
+objdir=$(readlink -f ${objdir:-${PWD}})
+builddir=${objdir}/.build
+
+n_cpus=$(cat /proc/cpuinfo | grep ^processor | wc -l)
+
+usage() {
+    echo "Usage: $0 [<options>]
+
+  --help             print this message
+  --prefix=<DIR>     set install root dir as <DIR>        (default: /usr/local)
+
+  Example usage for host compilation:
+    $ $0 --prefix=./build.host
+
+  Example usage for cross compilation:
+    $ CROSS_COMPILE=arm-linux-gnueabi- ARCH=arm CFLAGS=\"-march=armv7-a\" \\
+        $0 --prefix=./build.arm
+"
+    exit 1
+}
+
+while getopts ":ho:-:p" opt; do
+    case "$opt" in
+        -)
+	    # process --long-options
+	    case "$OPTARG" in
+                help)  usage ;;
+                *=*)   opt=${OPTARG%%=*}; val=${OPTARG#*=}
+                       eval "${opt/-/_}='$val'" ;;
+                *)     ;;
+            esac
+	    ;;
+        *)       usage ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+mkdir -p ${builddir} && cd ${builddir}
+
+ELFUTILS_VERSION=0.164
+ELFUTILS_NAME=elfutils-$ELFUTILS_VERSION
+ELFUTILS_TARBALL=$ELFUTILS_NAME.tar.bz2
+ELFUTILS_URL=https://sourceware.org/elfutils/ftp/$ELFUTILS_VERSION/$ELFUTILS_TARBALL
+
+if [ ! -d "$ELFUTILS_NAME" ]; then
+    wget -c $ELFUTILS_URL
+    tar xvfj $ELFUTILS_TARBALL
+    ln -sf $ELFUTILS_NAME elfutils
+fi
+cd elfutils
+
+opt_host_cc=""
+if [ ! -z $CROSS_COMPILE ]; then
+    HOST=$(basename $CROSS_COMPILE | sed 's/-$//g')
+    opt_host_cc="--host=$HOST CC=${CROSS_COMPILE}gcc"
+fi
+
+configure_cmd="./configure --prefix=$prefix $opt_host_cc"
+if [ ! -f configure.cmd ] || [ "$configure_cmd" != "$(cat configure.cmd)" ]; then
+    $configure_cmd && echo "$configure_cmd" > configure.cmd
+fi
+
+# build and install libelf only as of now
+make -j${n_cpus} -C libelf install
+
+# TODO: build and install libdw later on
+#       libdw requires to build libdwfl, libdwelf, and libebl
+#make -j${n_cpus} -C libdwfl
+#make -j${n_cpus} -C libdwelf
+#make -j${n_cpus} -C libebl CFLAGS="$CFLAGS -Wno-misleading-indentation"
+#make -j${n_cpus} -C libdw install
+
+cd ..


### PR DESCRIPTION
Sometimes it'd be better to provide full compilation method especially
in cross compile environment or in some systems that cannot install
libelf properly for some reasons.

This adds "misc/install-elfutils.sh" to download and compile elfutils.
The usage is as follows:

     $ export CROSS_COMPILE=arm-linux-gnueabi-
     $ export ARCH=arm
     $ export CFLAGS="-march=armv7-a"
     $ ./misc/install-elfutils.sh --prefix=`pwd`/build.arm
     $ ./configure --prefix=`pwd`/build.arm --with-elfutils=`pwd`/build.arm

     $ make
     $ make install

Some of environmental variables and prefix is better to be same both for
install-elfutils.sh and configure.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>