### PR TITLE
test: Add explicit function declaration.

### DIFF
--- a/tests/s-alloca.c
+++ b/tests/s-alloca.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <alloca.h>
+#include <string.h>
 
 int foo(int c)
 {

--- a/tests/s-fork.c
+++ b/tests/s-fork.c
@@ -3,6 +3,7 @@
  */
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/wait.h>
 
 static int a(void);
 static int b(void);

--- a/tests/s-fork2.c
+++ b/tests/s-fork2.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/wait.h>
 
 int main(void)
 {

--- a/tests/s-malloc-fork.c
+++ b/tests/s-malloc-fork.c
@@ -2,6 +2,7 @@
 #include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 void * (*real_malloc)(size_t sz);
 void (*real_free)(void *ptr);

--- a/tests/s-ucontext.c
+++ b/tests/s-ucontext.c
@@ -1,5 +1,6 @@
 #include <ucontext.h>
 #include <unistd.h>
+#include <stdlib.h>
 
 int foo(ucontext_t *old, ucontext_t *new)
 {


### PR DESCRIPTION
I think, maybe some users will be confused by the `warning message(implicit function declaration)` below during compilation for test.  

https://github.com/namhyung/uftrace/commit/04491ff880bd6592daca9be8d7397668bf848119  

```
$ gcc -o t-alloca -pg s-alloca.c  
s-alloca.c: In function ‘foo’:  
s-alloca.c:8:2: warning: implicit declaration of function ‘strncpy’ [-Wimplicit-function-declaration]  
  strncpy(ptr, "hello world\n", c);  
  ^  
```

https://github.com/namhyung/uftrace/commit/b1024b6905404b8709e0819f0f72f378d436c232

```
$ gcc -o t-fork -pg s-fork.c  
s-fork.c: In function ‘main’:  
s-fork.c:37:3: warning: implicit declaration of function ‘wait’ [-Wimplicit-function-declaration]  
   wait(NULL);  
   ^  
$ gcc -o t-fork2 -pg s-fork2.c  
s-fork2.c: In function ‘main’:  
s-fork2.c:11:3: warning: implicit declaration of function ‘wait’ [-Wimplicit-function-declaration]  
   wait(NULL);  
   ^  
```

https://github.com/namhyung/uftrace/commit/ec12bc07a0547e7f2aef37a46801ae028ef5abb1  

```
$ gcc -o t-malloc-fork -pg s-malloc-fork.c -ldl  
s-malloc-fork.c: In function ‘main’:  
s-malloc-fork.c:55:2: warning: implicit declaration of function ‘fork’ [-Wimplicit-function-declaration]  
  fork();  
  ^  
```

https://github.com/namhyung/uftrace/commit/ec12bc07a0547e7f2aef37a46801ae028ef5abb1  

```
$ gcc -o t-ucontext -pg s-ucontext.c 
s-ucontext.c: In function ‘main’:
s-ucontext.c:28:7: warning: implicit declaration of function ‘atoi’ [-Wimplicit-function-declaration]
   n = atoi(argv[1]);
       ^  
```

So I explicitly declared the functions. is it okay?