### PR TITLE
add supporting for i386 architecture.

### DIFF
--- a/arch/i386/Makefile
+++ b/arch/i386/Makefile
@@ -1,0 +1,34 @@
+LINKFLAGS := -r
+
+sdir := $(srcdir)/arch/i386
+odir := $(objdir)/arch/i386
+
+include $(srcdir)/Makefile.include
+
+ARCH_ENTRY_SRC = $(wildcard $(sdir)/*.S)
+ARCH_MCOUNT_SRC = $(wildcard $(sdir)/mcount-*.c) $(sdir)/regs.c 
+ARCH_UFTRACE_SRC = $(sdir)/cpuinfo.c $(sdir)/regs.c 
+
+ARCH_MCOUNT_OBJS  = $(patsubst $(sdir)/%.S,$(odir)/%.op,$(ARCH_ENTRY_SRC))
+ARCH_MCOUNT_OBJS += $(patsubst $(sdir)/%.c,$(odir)/%.op,$(ARCH_MCOUNT_SRC))
+ARCH_UFTRACE_OBJS = $(patsubst $(sdir)/%.c,$(odir)/%.o,$(ARCH_UFTRACE_SRC))
+
+all: $(odir)/entry.op
+
+$(odir)/mcount-entry.op: $(ARCH_MCOUNT_OBJS)
+	$(QUIET_LINK)$(LD) $(LINKFLAGS) -o $@ $^
+
+$(odir)/uftrace.o: $(ARCH_UFTRACE_OBJS)
+	$(QUIET_LINK)$(LD) $(LINKFLAGS) -o $@ $^
+
+$(odir)/%.op: $(sdir)/%.S
+	$(QUIET_ASM)$(CC) $(LIB_CFLAGS) -c -o $@ $<
+
+$(odir)/%.op: $(sdir)/%.c
+	$(QUIET_CC_FPIC)$(CC) $(LIB_CFLAGS) -c -o $@ $<
+
+$(odir)/%.o: $(sdir)/%.c
+	$(QUIET_CC)$(CC) $(UFTRACE_CFLAGS) -c -o $@ $<
+
+clean:
+	$(RM) $(odir)/*.op $(odir)/*.o

--- a/arch/i386/cpuinfo.c
+++ b/arch/i386/cpuinfo.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <string.h>
+
+int arch_fill_cpuinfo_model(int fd)
+{
+	char buf[1024];
+	FILE *fp;
+	int ret = -1;
+
+	fp = fopen("/proc/cpuinfo", "r");
+	if (fp == NULL)
+		return -1;
+
+	while (fgets(buf, sizeof(buf), fp) != NULL) {
+		if (!strncmp(buf, "model name\t:", 12)) {
+			dprintf(fd, "cpuinfo:desc=%s", &buf[13]);
+			ret = 0;
+			break;
+		}
+	}
+	fclose(fp);
+	return ret;
+}

--- a/arch/i386/fentry.S
+++ b/arch/i386/fentry.S
@@ -1,0 +1,50 @@
+#include "utils/asm.h"
+
+GLOBAL(__fentry__)
+	sub $32, %esp
+	movl %edx, 28(%esp)
+	movl %ecx, 24(%esp)
+	movl %eax, 20(%esp)
+	movl $0, 16(%esp)
+	/* parent location */
+	leal 36(%esp), %eax
+	movl %eax, 0(%esp)
+	/* child addr */
+	movl 32(%esp), %eax
+	movl %eax, 4(%esp)
+	/* mcount_args */
+	leal 16(%esp), %eax
+	movl %eax, 8(%esp)
+	call mcount_entry
+	cmpl $0, %eax
+	jne 1f
+
+	/* hijack return address */
+	call __x86.get_pc_thunk.ax
+	addl $_GLOBAL_OFFSET_TABLE_, %eax
+	addl $fentry_return@GOTOFF, %eax
+	movl %eax, 36(%esp)
+1:
+	movl 20(%esp), %eax
+	movl 24(%esp), %ecx
+	movl 28(%esp), %edx
+	add $32, %esp
+	ret
+END(__fentry__)
+
+
+ENTRY(fentry_return)
+	sub  $16, %esp
+	movl %edx, 8(%esp)
+	movl %eax, 4(%esp)
+	leal 4(%esp), %eax
+	movl %eax, 0(%esp)
+
+	call mcount_exit
+	movl %eax, 12(%esp)
+
+	movl 4(%esp), %eax
+	movl 8(%esp), %edx
+	add  $12, %esp
+	ret
+END(fentry_return)

--- a/arch/i386/mcount-arch.h
+++ b/arch/i386/mcount-arch.h
@@ -1,0 +1,50 @@
+#include "../../utils/symbol.h"
+#ifndef __MCOUNT_ARCH_H__
+#define __MCOUNT_ARCH_H__
+
+#define mcount_regs  mcount_regs
+
+struct mcount_regs {
+	unsigned long stack1;
+	unsigned long ecx;
+	unsigned long edx;
+};
+
+#define  ARG1(a)      ((a)->stack1)
+#define  ARG_REG1(a)  ((a)->ecx)
+#define  ARG_REG2(a)  ((a)->edx)
+
+#define ARCH_MAX_REG_ARGS  3
+#define ARCH_MAX_FLOAT_REGS  8
+
+enum x86_reg_index {
+	X86_REG_INT_BASE = 0,
+	/* integer registers */
+	X86_REG_ECX,
+	X86_REG_EDX,
+
+	X86_REG_FLOAT_BASE = 100,
+	/* floating-point registers */
+	X86_REG_XMM0,
+	X86_REG_XMM1,
+	X86_REG_XMM2,
+	X86_REG_XMM3,
+	X86_REG_XMM4,
+	X86_REG_XMM5,
+	X86_REG_XMM6,
+	X86_REG_XMM7,
+};
+
+#define HAVE_MCOUNT_ARCH_CONTEXT
+struct mcount_arch_context {
+	double xmm[ARCH_MAX_FLOAT_REGS];
+};
+
+#define FIX_PARENT_LOC
+unsigned long * mcount_arch_parent_location(struct symtabs *symtabs,
+					    unsigned long *parent_loc,
+					    unsigned long child_ip);
+#define ARCH_PLT0_SIZE  16
+#define ARCH_PLTHOOK_ADDR_OFFSET  6
+
+#endif /* __MCOUNT_ARCH_H__ */

--- a/arch/i386/mcount-dynamic.c
+++ b/arch/i386/mcount-dynamic.c
@@ -1,0 +1,202 @@
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+/* This should be defined before #include "utils.h" */
+#define PR_FMT     "dynamic"
+#define PR_DOMAIN  DBG_DYNAMIC
+
+#include "libmcount/internal.h"
+#include "utils/utils.h"
+#include "utils/symbol.h"
+
+#define PAGE_SIZE  4096
+#define XRAY_SECT  "xray_instr_map"
+
+/* target instrumentation function it needs to call */
+extern void __fentry__(void);
+
+struct xray_instr_map {
+	unsigned long addr;
+	unsigned long entry;
+	unsigned long type;
+	unsigned long count;
+};
+
+struct arch_dynamic_info {
+	struct xray_instr_map *xrmap;
+	unsigned xrmap_count;
+};
+
+int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
+{
+	/*
+	 * in i386, it is not possible to refer to eip.
+	 * so need a little trick. 
+	 * 
+	 * call 0x5
+	 * pop eax
+	 * jmp dword ptr [eax + 4]
+	 * 
+	 */
+	unsigned char trampoline[] = { 0xe8, 0x00, 0x00, 0x00, 0x00, 0x58, 0xff, 0x60, 0x04 };
+	unsigned long fentry_addr = (unsigned long)__fentry__;
+	struct arch_dynamic_info *adi = mdi->arch;
+	size_t trampoline_size = 16;
+
+	if (adi && adi->xrmap_count)
+		trampoline_size *= 2;
+
+	/* find unused 16-byte at the end of the code segment */
+	mdi->trampoline = ALIGN(mdi->addr + mdi->size, PAGE_SIZE) - trampoline_size;
+
+	if (unlikely(mdi->trampoline < mdi->addr + mdi->size)) {
+		mdi->trampoline += trampoline_size;
+		mdi->size += PAGE_SIZE;
+
+		pr_dbg2("adding a page for fentry trampoline at %#lx\n",
+			mdi->trampoline);
+
+		mmap((void *)mdi->trampoline, PAGE_SIZE, PROT_READ | PROT_WRITE,
+		     MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	}
+
+	if (mprotect((void *)mdi->addr, mdi->size, PROT_READ | PROT_WRITE)) {
+		pr_dbg("cannot setup trampoline due to protection: %m\n");
+		return -1;
+	}
+
+	/* jmpq  *0x2(%rip)     # <fentry_addr> */
+	memcpy((void *)mdi->trampoline, trampoline, sizeof(trampoline));
+	memcpy((void *)mdi->trampoline + sizeof(trampoline),
+	       &fentry_addr, sizeof(fentry_addr));
+	return 0;
+}
+
+void mcount_cleanup_trampoline(struct mcount_dynamic_info *mdi)
+{
+	if (mprotect((void *)mdi->addr, mdi->size, PROT_EXEC))
+		pr_err("cannot restore trampoline due to protection");
+}
+
+void mcount_arch_find_module(struct mcount_dynamic_info *mdi)
+{
+	Elf32_Ehdr ehdr;
+	Elf32_Shdr shdr;
+	char *mod_name = mdi->mod_name;
+	char *names = NULL;
+	int fd;
+	unsigned i;
+	off_t pos;
+
+	mdi->arch = NULL;
+
+	if (*mod_name == '\0')
+		mod_name = read_exename();
+
+	fd = open(mod_name, O_RDONLY);
+	if (fd < 0)
+		pr_err("cannot open %s", mod_name);
+
+	if (read_all(fd, &ehdr, sizeof(ehdr)) < 0)
+		goto out;
+	if (memcmp(ehdr.e_ident, ELFMAG, SELFMAG))
+		goto out;
+
+	/* read section header name */
+	if (pread_all(fd, &shdr, sizeof(shdr),
+		      ehdr.e_shoff + (ehdr.e_shstrndx * ehdr.e_shentsize)) < 0)
+		goto out;
+
+	names = xmalloc(shdr.sh_size);
+	if (pread_all(fd, names, shdr.sh_size, shdr.sh_offset) < 0)
+		goto out;
+
+	pos = ehdr.e_shoff;
+	for (i = 0; i < ehdr.e_shnum; i++, pos += ehdr.e_shentsize) {
+		struct arch_dynamic_info *adi;
+
+		if (pread_all(fd, &shdr, sizeof(shdr), pos) < 0)
+			goto out;
+
+		if (strcmp(&names[shdr.sh_name], XRAY_SECT))
+			continue;
+
+		adi = xmalloc(sizeof(*adi));
+		adi->xrmap_count = shdr.sh_size / sizeof(*adi->xrmap);
+		adi->xrmap = xmalloc(adi->xrmap_count * sizeof(*adi->xrmap));
+
+		if (pread_all(fd, adi->xrmap, shdr.sh_size, shdr.sh_offset) < 0) {
+			free(adi);
+			goto out;
+		}
+
+		/* handle position independent code */
+		if (ehdr.e_type == ET_DYN) {
+			struct xray_instr_map *xrmap;
+
+			for (i = 0; i < adi->xrmap_count; i++) {
+				xrmap = &adi->xrmap[i];
+
+				xrmap->addr  += mdi->addr;
+				xrmap->entry += mdi->addr;
+			}
+		}
+
+		mdi->arch = adi;
+		break;
+	}
+
+out:
+	close(fd);
+	free(names);
+}
+
+#define CALL_INSN_SIZE 5
+
+static unsigned long get_target_addr(struct mcount_dynamic_info *mdi, unsigned long addr)
+{
+	while (mdi) {
+		if (mdi->addr <= addr && addr < mdi->addr + mdi->size)
+			return mdi->trampoline - (addr + CALL_INSN_SIZE);
+
+		mdi = mdi->next;
+	}
+	return 0;
+}
+
+static int patch_fentry_func(struct mcount_dynamic_info *mdi, struct sym *sym)
+{
+	// In case of "gcc" which is not patched because of old version, 
+	// it may not create 5 byte nop.
+	unsigned char nop[] = { 0x0f, 0x1f, 0x44, 0x00, 0x00 };
+	unsigned char *insn = (void *)sym->addr;
+	unsigned int target_addr;
+
+	/* only support calls to __fentry__ at the beginning */
+	if (memcmp(insn, nop, sizeof(nop))) {
+		pr_dbg2("skip non-applicable functions: %s\n", sym->name);
+		return -2;
+	}
+
+	/* get the jump offset to the trampoline */
+	target_addr = get_target_addr(mdi, sym->addr);
+	if (target_addr == 0)
+		return -2;
+
+	/* make a "call" insn with 4-byte offset */
+	insn[0] = 0xe8;
+	/* hopefully we're not patching 'memcpy' itself */
+	memcpy(&insn[1], &target_addr, sizeof(target_addr));
+
+	pr_dbg3("update function '%s' dynamically to call __fentry__\n",
+		sym->name);
+
+	return 0;
+}
+
+int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym)
+{
+	return patch_fentry_func(mdi, sym);
+}
+

--- a/arch/i386/mcount-support.c
+++ b/arch/i386/mcount-support.c
@@ -234,3 +234,14 @@ unsigned long *mcount_arch_parent_location(struct symtabs *symtabs,
 	return parent_loc;
 }
 
+// in i386, the idx value is set to a multiple of 8 unlike other.
+unsigned long mcount_arch_child_idx(unsigned long child_idx)
+{
+	if (child_idx > 0) {
+                if (child_idx % 8) {
+                        pr_err_ns("the malformed child idx : %lx\n", child_idx);
+                }
+                child_idx = child_idx / 8;
+        }
+        return child_idx;
+}

--- a/arch/i386/mcount-support.c
+++ b/arch/i386/mcount-support.c
@@ -1,0 +1,236 @@
+/*
+ * basic i386 support for uftrace
+ *
+ * Copyright (C) 2014-2017. Hanbum Park <kese111@gmail.com>
+ *
+ * Released under the GPL v2.
+ */
+
+#include <assert.h>
+#include <string.h>
+#include <gelf.h>
+#include <sys/mman.h>
+
+/* This should be defined before #include "utils.h" */
+#define PR_FMT     "mcount"
+#define PR_DOMAIN  DBG_MCOUNT
+
+#include "libmcount/internal.h"
+#include "utils/filter.h"
+
+static bool search_main_ret = false;
+
+int mcount_get_register_arg(struct mcount_arg_context *ctx, 
+                            struct uftrace_arg_spec *spec)
+{
+	struct mcount_regs *regs = ctx->regs;
+	int reg_idx;
+
+	switch (spec->type) {
+	case ARG_TYPE_REG:
+		reg_idx = spec->reg_idx;
+		break;
+	default:
+		return -1; 
+	}
+
+	switch (reg_idx) {
+	case X86_REG_ECX:
+		ctx->val.i = ARG_REG1(regs);
+		break;
+	case X86_REG_EDX:
+		ctx->val.i = ARG_REG2(regs);
+		break;
+	case X86_REG_XMM0:
+		asm volatile ("movsd %%xmm0, %0\n" : "=m" (ctx->val.v));
+		break;
+	case X86_REG_XMM1:
+		asm volatile ("movsd %%xmm1, %0\n" : "=m" (ctx->val.v));
+		break;
+	case X86_REG_XMM2:
+		asm volatile ("movsd %%xmm2, %0\n" : "=m" (ctx->val.v));
+		break;
+	case X86_REG_XMM3:
+		asm volatile ("movsd %%xmm3, %0\n" : "=m" (ctx->val.v));
+		break;
+	case X86_REG_XMM4:
+		asm volatile ("movsd %%xmm4, %0\n" : "=m" (ctx->val.v));
+		break;
+	case X86_REG_XMM5:
+		asm volatile ("movsd %%xmm5, %0\n" : "=m" (ctx->val.v));
+		break;
+	case X86_REG_XMM6:
+		asm volatile ("movsd %%xmm6, %0\n" : "=m" (ctx->val.v));
+		break;
+	case X86_REG_XMM7:
+		asm volatile ("movsd %%xmm7, %0\n" : "=m" (ctx->val.v));
+		break;
+	default:
+		/* should not reach here */
+		pr_err_ns("invalid register access for arguments\n");
+		break;
+	}
+
+	return 0;
+}
+
+void mcount_get_stack_arg(struct mcount_arg_context *ctx,
+                        struct uftrace_arg_spec *spec)
+{
+	int offset;
+
+	switch (spec->type) {
+	case ARG_TYPE_STACK:
+		offset = spec->stack_ofs;
+		break;
+	case ARG_TYPE_INDEX:
+		offset = spec->idx;
+		break;
+	case ARG_TYPE_FLOAT:
+		offset = spec->idx;
+		break;
+	default:
+		/* should not reach here */
+		pr_err_ns("invalid stack access for arguments\n");
+		break;
+	}
+
+	if (offset < 1 || offset > 100)
+		pr_dbg("invalid stack offset: %d\n", offset);
+
+	memcpy(ctx->val.v, ctx->stack_base + offset, spec->size);
+}
+
+void mcount_arch_get_arg(struct mcount_arg_context *ctx,
+			 struct uftrace_arg_spec *spec)
+{
+	if (mcount_get_register_arg(ctx, spec) < 0)
+		mcount_get_stack_arg(ctx, spec);
+}
+
+void mcount_arch_get_retval(struct mcount_arg_context *ctx,
+			    struct uftrace_arg_spec *spec)
+{
+	/* type of return value cannot be FLOAT, so check format instead */
+	if (spec->fmt != ARG_FMT_FLOAT)
+		memcpy(ctx->val.v, ctx->retval, spec->size);
+	else if (spec->size == 4)  
+		asm volatile ("fstps %0\n\tflds %0" : "=m" (ctx->val.v));
+	else if (spec->size == 8)
+		asm volatile ("fstpl %0\n\tfldl %0" : "=m" (ctx->val.v));
+	else if (spec->size == 10)
+		asm volatile ("fstpt %0\n\tfldt %0" : "=m" (ctx->val.v));
+}
+
+void mcount_save_arch_context(struct mcount_arch_context *ctx)
+{
+	asm volatile ("movsd %%xmm0, %0\n" : "=m" (ctx->xmm[0]));
+	asm volatile ("movsd %%xmm1, %0\n" : "=m" (ctx->xmm[1]));
+	asm volatile ("movsd %%xmm2, %0\n" : "=m" (ctx->xmm[2]));
+	asm volatile ("movsd %%xmm3, %0\n" : "=m" (ctx->xmm[3]));
+	asm volatile ("movsd %%xmm4, %0\n" : "=m" (ctx->xmm[4]));
+	asm volatile ("movsd %%xmm5, %0\n" : "=m" (ctx->xmm[5]));
+	asm volatile ("movsd %%xmm6, %0\n" : "=m" (ctx->xmm[6]));
+	asm volatile ("movsd %%xmm7, %0\n" : "=m" (ctx->xmm[7]));
+}
+
+void mcount_restore_arch_context(struct mcount_arch_context *ctx)
+{
+	asm volatile ("movsd %0, %%xmm0\n" :: "m" (ctx->xmm[0]));
+	asm volatile ("movsd %0, %%xmm1\n" :: "m" (ctx->xmm[1]));
+	asm volatile ("movsd %0, %%xmm2\n" :: "m" (ctx->xmm[2]));
+	asm volatile ("movsd %0, %%xmm3\n" :: "m" (ctx->xmm[3]));
+	asm volatile ("movsd %0, %%xmm4\n" :: "m" (ctx->xmm[4]));
+	asm volatile ("movsd %0, %%xmm5\n" :: "m" (ctx->xmm[5]));
+	asm volatile ("movsd %0, %%xmm6\n" :: "m" (ctx->xmm[6]));
+	asm volatile ("movsd %0, %%xmm7\n" :: "m" (ctx->xmm[7]));
+}
+
+unsigned long mcount_arch_plthook_addr(struct plthook_data *pd, int idx)
+{
+	struct sym *sym;
+
+	sym = &pd->dsymtab.sym[idx];
+	return sym->addr + ARCH_PLTHOOK_ADDR_OFFSET;
+}
+
+
+/*
+	For 16-byte stack-alignment, 
+	the main function stores the return address in its stack scope at prologue.
+	When the time comes for the main function to return,
+	1. restore the saved return address from stack.
+	2. After cleaning up the stack.
+	3. Put the return address at the top of the stack and return.
+	4. will be returned.
+
+	080485f8 <main>:
+	80485f8: 8d 4c 24 04           lea    0x4(%esp),%ecx
+	80485fc: 83 e4 f0              and    $0xfffffff0,%esp
+	80485ff: ff 71 fc              pushl  -0x4(%ecx)
+	8048602: 55                    push   %ebp
+	8048603: 89 e5                 mov    %esp,%ebp
+	8048605: 51                    push   %ecx
+	8048606: 83 ec 14              sub    $0x14,%esp
+	8048609: e8 02 fe ff ff        call   8048410 <mcount@plt>
+
+	... ... 
+
+	8048645: 8b 4d fc              mov    -0x4(%ebp),%ecx
+	8048648: c9                    leave
+	8048649: 8d 61 fc              lea    -0x4(%ecx),%esp
+	804864c: c3                    ret
+
+	So, in this case. The return address we want to replace with 
+	mcount_exit is in the stack scope of the main function. 
+	Non a parent located. 
+
+	we search stack for that address. 
+	we will look for it.
+	we will find it, and we will replace it. 
+	GOOD LUCK!
+*/
+unsigned long *mcount_arch_parent_location(struct symtabs *symtabs,
+                                            unsigned long *parent_loc, 
+                                            unsigned long child_ip)
+{
+	if (!search_main_ret) {
+		struct sym *parent_sym, *child_sym;
+		char *parent_name, *child_name;
+
+		const char *find_main[] = {
+			"__libc_start_main",
+			"main"
+		};
+		unsigned long ret_addr;
+		unsigned long search_ret_addr;
+
+		ret_addr = *parent_loc;
+		parent_sym = find_symtabs(symtabs, ret_addr);
+		parent_name = symbol_getname(parent_sym, ret_addr);
+		child_sym = find_symtabs(symtabs, child_ip);
+		child_name = symbol_getname(child_sym, child_ip);
+
+		// Assuming that this happens only in main..			
+		bool found_main_ret = false;
+		if (!(strcmp(find_main[0], parent_name) || 
+		      strcmp(find_main[1], child_name))) {
+			ret_addr = *parent_loc;
+			for (int i = 1; i < 5; i++ ) {
+				search_ret_addr = *(unsigned long *)(parent_loc + i);
+				if (search_ret_addr == ret_addr) {
+					parent_loc = parent_loc+i;
+					found_main_ret = true;
+				}
+			}
+			// if we couldn't found correct position of return address,
+			// maybe this approach is not available anymore.
+			if (!found_main_ret) {
+				pr_dbg2("cannot find ret address of main\n");
+			}
+			search_main_ret = true;
+		}
+	}
+	return parent_loc;
+}
+

--- a/arch/i386/mcount.S
+++ b/arch/i386/mcount.S
@@ -1,0 +1,52 @@
+/* in i386, generally used stack for argument passing. */
+/* use register for return : %eax */
+/* no need save registers */
+/* stack frame (with -pg): parent addr = 4(%ebp) */
+/* child addr = (%esp) */
+
+#include "utils/asm.h"
+
+GLOBAL(mcount)
+	sub $32, %esp
+	/* save registers */
+	movl %edx, 28(%esp)
+	movl %ecx, 24(%esp)	
+	movl %eax, 20(%esp)
+	movl $0, 16(%esp)
+	/* parent location */
+	leal 4(%ebp), %eax
+	movl %eax, 0(%esp)
+	/* child addr */
+	movl 32(%esp), %eax
+	movl %eax, 4(%esp)
+	/*  mcount_regs */
+	leal 16(%esp), %eax
+	movl %eax, 8(%esp)
+
+	call mcount_entry
+
+	/* restore registers */
+	movl 20(%esp), %eax
+	movl 24(%esp), %ecx
+	movl 28(%esp), %edx
+	add $32, %esp
+	ret
+END(mcount)
+
+
+ENTRY(mcount_return)
+	sub $16, %esp
+	movl %edx, 8(%esp)
+	movl %eax, 4(%esp)
+	leal 4(%esp), %eax
+	movl %eax, 0(%esp)
+
+	/* returns original parent address */
+	call mcount_exit
+	movl %eax, 12(%esp)
+
+	movl 4(%esp), %eax
+	movl 8(%esp), %edx
+	add $12, %esp
+	ret
+END(mcount_return)

--- a/arch/i386/plthook.S
+++ b/arch/i386/plthook.S
@@ -1,0 +1,65 @@
+#include "utils/asm.h"
+
+.hidden plthook_resolver_addr
+
+ENTRY(plt_hooker)
+	sub $32, %esp
+	/* save registers */
+	movl %edx, 24(%esp)
+	movl %ecx, 20(%esp)
+	/* this is for ARG1 that using in jmp */
+	movl 44(%esp), %eax
+	movl %eax, 16(%esp)
+
+	/* stack address contain parent location */
+	leal 40(%esp), %eax
+	movl %eax, 0(%esp)
+
+	/* child_idx */
+	movl 36(%esp), %eax
+	movl %eax, 4(%esp)
+	
+	/* module_id */
+	movl 32(%esp), %eax
+	movl %eax, 8(%esp)
+
+	/* mcount_args */
+	leal 16(%esp), %eax
+	movl %eax, 12(%esp)
+
+	call plthook_entry
+
+	/* restore registers */
+	movl 20(%esp), %ecx
+	movl 24(%esp), %edx
+	add $32, %esp
+
+	cmpl $0, %eax
+	jnz 1f
+	/* get address of plthook_resolver_addr */
+	call __x86.get_pc_thunk.ax
+	addl $_GLOBAL_OFFSET_TABLE_, %eax
+	leal plthook_resolver_addr@GOTOFF(%eax), %eax
+	movl (%eax), %eax
+	jmp *%eax
+1:
+	add $8, %esp
+	jmp *%eax
+END(plt_hooker)
+
+
+ENTRY(plthook_return)
+	sub $16, %esp
+	movl %edx, 8(%esp)
+	movl %eax, 4(%esp)
+	leal 4(%esp), %eax
+	movl %eax, 0(%esp)
+
+	call plthook_exit
+	movl %eax, 12(%esp)
+
+	movl 4(%esp), %eax
+	movl 8(%esp), %edx
+	add $12, %esp
+	ret
+END(plthook_return)

--- a/arch/i386/regs.c
+++ b/arch/i386/regs.c
@@ -1,0 +1,29 @@
+#include "mcount-arch.h"
+#include "utils/utils.h"
+
+struct x86_reg_table {
+	const char		*name;
+	enum x86_reg_index	idx;
+} reg_table[] = {
+
+#define X86_REG(_r)  { #_r, X86_REG_##_r }
+
+	/* integer registers */
+	X86_REG(ECX), X86_REG(EDX),
+	/* floating-point registers */
+	X86_REG(XMM0), X86_REG(XMM1), X86_REG(XMM2), X86_REG(XMM3),
+	X86_REG(XMM4), X86_REG(XMM5), X86_REG(XMM6), X86_REG(XMM7),
+
+#undef X86_REG
+};
+
+int arch_register_index(char *reg_name)
+{
+	unsigned i;
+
+	for (i = 0; i < ARRAY_SIZE(reg_table); i++) {
+		if (!strcasecmp(reg_name, reg_table[i].name))
+			return reg_table[i].idx;
+	}
+	return -1;
+}

--- a/cmd-record.c
+++ b/cmd-record.c
@@ -1404,7 +1404,7 @@ static void check_binary(struct opts *opts)
 	uint16_t e_type;
 	uint16_t e_machine;
 	uint16_t supported_machines[] = {
-		EM_X86_64, EM_ARM, EM_AARCH64,
+		EM_X86_64, EM_ARM, EM_AARCH64, EM_386
 	};
 
 	pr_dbg3("checking binary %s\n", opts->exename);

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -701,6 +701,11 @@ static void update_pltgot(struct mcount_thread_data *mtdp,
 	}
 }
 
+__weak unsigned long mcount_arch_child_idx(unsigned long child_idx)
+{
+	return child_idx;
+}
+
 unsigned long plthook_entry(unsigned long *ret_addr, unsigned long child_idx,
 			    unsigned long module_id, struct mcount_regs *regs)
 {
@@ -744,6 +749,8 @@ unsigned long plthook_entry(unsigned long *ret_addr, unsigned long child_idx,
 
 	recursion = false;
 
+	// for i386 architecture.
+	child_idx = mcount_arch_child_idx(child_idx);
 	func = bsearch((void *)child_idx, pd->special_funcs, pd->nr_special,
 		       sizeof(*func), idxfind);
 	if (func)

--- a/utils/compiler.h
+++ b/utils/compiler.h
@@ -3,6 +3,13 @@
 
 #define compiler_barrier()	asm volatile("" :::"memory")
 
+#if defined(__i386__)
+# define cpu_relax()		asm volatile("rep; nop" ::: "memory")
+# define full_memory_barrier()	asm volatile("mfence" ::: "memory")
+# define read_memory_barrier()  asm volatile("lfence" ::: "memory")
+# define write_memory_barrier()	asm volatile("sfence" ::: "memory")
+#endif
+
 #if defined(__x86_64__)
 # define cpu_relax()		asm volatile("rep; nop" ::: "memory")
 # define full_memory_barrier()	asm volatile("mfence" ::: "memory")

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -112,8 +112,7 @@ struct uftrace_filter *uftrace_match_filter(uint64_t ip, struct rb_root *root,
 		iter = rb_entry(parent, struct uftrace_filter, node);
 
 		if (match_ip(iter, ip)) {
-			memcpy(tr, &iter->trigger, sizeof(*tr));
-
+			*tr = iter->trigger;
 			pr_dbg2("filter match: %s\n", iter->name);
 			if (dbg_domain[DBG_FILTER] >= 3)
 				print_trigger(tr);

--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -598,6 +598,9 @@ int load_elf_dynsymtab(struct symtab *dsymtab, Elf *elf,
 	else if (ehdr.e_machine == EM_AARCH64) {
 		plt_addr += 16;    /* AARCH64 PLT0 size is 32 */
 	}
+	else if (ehdr.e_machine == EM_386) {
+		plt_entsize += 12;
+	}
 
 	prev_addr = plt_addr;
 


### PR DESCRIPTION
m@ubuntu:~/uftrace/tests$ ./runtest.py
Test case                 pg             finstrument-fu
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
001 basic               : OK OK OK OK OK OK OK OK OK OK
002 argument            : OK OK OK OK OK OK OK OK OK OK
003 thread              : OK OK OK OK OK OK OK OK OK OK
004 filter_F            : OK OK OK OK OK OK OK OK OK OK
005 filter_N            : OK OK OK OK OK OK OK OK OK OK
006 filter_FN           : OK OK OK OK OK OK OK OK OK OK
007 library             : OK OK OK OK OK OK OK OK OK OK
008 daemon              : NG NG NG NG NG NG NG NG NG NG
009 fork                : OK OK OK OK OK OK OK OK OK OK
010 forkexec            : NG NG NG NG NG NG NG NG NG NG
011 vforkexec           : NG NG NG NG NG NG NG NG NG NG
012 demangle            : OK OK OK OK OK OK OK OK OK OK
013 signal              : OK OK OK OK OK OK OK OK OK OK
014 ucontext            : OK OK OK OK OK OK OK OK OK OK
015 longjmp             : OK OK OK OK OK OK OK OK OK OK
016 alloca              : OK OK OK OK OK OK NG NG NG NG
017 no_libcall          : OK OK OK OK OK OK OK OK OK OK
018 filter_regex        : OK OK OK OK OK OK OK OK OK OK
019 full_depth          : OK OK OK OK OK OK OK OK OK OK
020 filter_depth        : OK OK OK OK OK OK OK OK OK OK
021 filter_plt          : OK OK OK OK OK OK OK OK OK OK
022 filter_kernel       : SK SK SK SK SK SK SK SK SK SK
023 replay_filter       : OK OK OK OK OK OK OK OK OK OK
024 report_basic        : OK OK OK OK OK OK OK OK OK OK
025 report_s_call       : OK OK OK OK OK OK OK OK OK OK
026 filter_trigger      : OK OK OK OK OK OK OK OK OK OK
027 replay_filter_d     : OK OK OK OK OK OK OK OK OK OK
028 replay_backtrace    : OK OK OK OK OK OK OK OK OK OK
029 trigger_only        : OK OK OK OK OK OK OK OK OK OK
030 replay_trigger      : OK OK OK OK OK OK OK OK OK OK
031 filter_demangle1    : OK OK OK OK OK OK OK OK OK OK
032 filter_demangle2    : OK OK OK OK OK OK OK OK OK OK
033 filter_demangle3    : OK OK OK OK OK OK OK OK OK OK
034 filter_demangle4    : OK OK OK OK OK OK OK OK OK OK
035 filter_demangle5    : OK OK OK OK OK OK OK OK OK OK
036 replay_filter_N     : OK OK OK OK OK OK OK OK OK OK
037 trace_onoff         : OK OK OK OK OK OK OK OK OK OK
038 trace_disable       : OK OK OK OK OK OK OK OK OK OK
039 trace_onoff_F       : OK OK OK OK OK OK OK OK OK OK
040 replay_onoff        : OK OK OK OK OK OK OK OK OK OK
041 replay_onoff_N      : OK OK OK OK OK OK OK OK OK OK
042 live_disable        : OK OK OK OK OK OK OK OK OK OK
043 full_demangle       : OK OK OK OK OK OK OK OK OK OK
044 report_avg_total    : OK OK OK OK OK OK OK OK OK OK
045 report_avg_self     : OK OK OK OK OK OK OK OK OK OK
046 report_threads      : OK OK OK OK OK OK OK OK OK OK
047 signal2             : OK OK OK OK OK OK OK OK OK OK
048 malloc_impl         : OK OK OK OK OK OK OK OK OK OK
049 column_view         : OK OK OK OK OK OK OK OK OK OK
050 no_pltbind          : OK OK OK OK OK OK OK OK OK OK
051 return              : OK OK OK OK OK OK OK OK OK OK
052 nested_func         : OK OK OK OK OK NG NG NG NG NG
053 filter_time         : OK OK OK OK OK OK OK OK OK OK
054 filter_time_F       : OK OK OK OK OK OK OK OK OK OK
055 filter_time_N       : OK OK OK OK OK OK OK OK OK OK
056 filter_time_T       : OK OK OK OK OK OK OK OK OK OK
057 filter_time_D       : OK OK OK OK OK OK OK OK OK OK
058 arg_int             : OK OK OK OK OK SK SK SK SK SK
059 arg_str             : OK OK OK OK OK SK SK SK SK SK
060 arg_fmt             : OK OK OK OK OK SK SK SK SK SK
061 arg_plt             : OK OK OK OK OK OK OK OK OK OK
062 arg_char            : OK OK OK OK OK SK SK SK SK SK
063 retval              : OK OK OK OK OK SK SK SK SK SK
064 trigger_trace       : OK OK OK OK OK OK OK OK OK OK
065 arg_order           : OK OK OK OK OK SK SK SK SK SK
066 no_demangle         : OK OK OK OK OK OK OK OK OK OK
067 report_diff         : OK OK OK OK OK OK OK OK OK OK
068 filter_time_A       : OK OK OK OK OK SK SK SK SK SK
069 graph               : OK OK OK OK OK OK OK OK OK OK
070 graph_backtrace     : OK OK OK OK OK OK OK OK OK OK
071 graph_depth         : OK OK OK OK OK OK OK OK OK OK
072 no_comment          : OK OK OK OK OK OK OK OK OK OK
073 lib_filter          : OK OK OK OK OK OK OK OK OK OK
074 lib_trigger         : OK OK OK OK OK OK OK OK OK OK
075 lib_arg             : OK OK OK OK OK SK SK SK SK SK
076 lib_replay_F        : OK OK OK OK OK OK OK OK OK OK
077 lib_replay_T        : OK OK OK OK OK OK OK OK OK OK
078 max_stack           : OK OK OK OK OK OK OK OK OK OK
079 replay_kernel_D     : SK SK SK SK SK SK SK SK SK SK
080 replay_kernel_D2    : SK SK SK SK SK SK SK SK SK SK
081 kernel_depth        : SK SK SK SK SK SK SK SK SK SK
082 arg_many            : OK OK OK OK OK SK SK SK SK SK
083 arg_float           : OK OK OK OK OK SK SK SK SK SK
084 arg_mixed           : OK OK OK OK OK SK SK SK SK SK
085 arg_reg             : NG NG NG NG NG SK SK SK SK SK
086 arg_stack           : OK OK OK OK OK SK SK SK SK SK
087 arg_variadic        : OK OK OK OK OK SK SK SK SK SK
088 graph_session       : OK OK OK OK OK OK OK OK OK OK
089 graph_exit          : OK OK OK OK OK OK OK OK OK OK
090 report_recursive    : OK OK OK OK OK OK OK OK OK OK
091 replay_tid          : OK OK OK OK OK OK OK OK OK OK
092 report_tid          : OK OK OK OK OK OK OK OK OK OK
093 report_filter       : OK OK OK OK OK OK OK OK OK OK
094 report_depth        : OK OK OK OK OK OK OK OK OK OK
095 graph_tid           : OK OK OK OK OK OK OK OK OK OK
096 graph_filter        : OK OK OK OK OK OK OK OK OK OK
097 dump_basic          : OK OK OK OK OK OK OK OK OK OK
098 dump_tid            : OK OK OK OK OK OK OK OK OK OK
099 dump_filter         : OK OK OK OK OK OK OK OK OK OK
100 dump_depth          : OK OK OK OK OK OK OK OK OK OK
101 dump_chrome         : OK OK OK OK OK OK OK OK OK OK
102 dump_flamegraph     : OK OK OK OK OK OK OK OK OK OK
103 dump_kernel         : SK SK SK SK SK SK SK SK SK SK
104 graph_kernel        : SK SK SK SK SK SK SK SK SK SK
105 replay_time         : OK OK OK OK OK OK OK OK OK OK
106 report_time         : OK OK OK OK OK OK OK OK OK OK
107 dump_time           : OK OK OK OK OK OK OK OK OK OK
108 graph_time          : OK OK OK OK OK OK OK OK OK OK
109 replay_time_A       : OK OK OK OK OK SK SK SK SK SK
110 replay_time_T       : OK OK OK OK OK OK OK OK OK OK
111 kernel_tid          : SK SK SK SK SK SK SK SK SK SK
112 replay_skip         : OK OK OK OK OK OK OK OK OK OK
113 trigger_time        : OK OK OK OK OK OK OK OK OK OK
114 replay_trg_time     : OK OK OK OK OK OK OK OK OK OK
115 replay_field        : OK OK OK OK OK OK OK OK OK OK
116 field_none          : OK OK OK OK OK OK OK OK OK OK
117 time_range          : OK OK OK OK OK OK OK OK OK OK
118 thread_tsd          : OK OK OK OK OK OK OK OK OK OK
119 malloc_hook         : OK OK OK OK OK OK OK OK OK OK
120 malloc_tsd          : OK OK OK OK OK OK OK OK OK OK
121 malloc_fork         : OK OK OK OK OK OK OK OK OK OK
122 time_range2         : NG NG OK OK NG OK OK OK OK OK
123 backtrace           : OK OK OK OK OK OK OK OK OK OK
124 exception           : NG SG SG SG SG OK OK OK OK OK
125 report_range        : OK OK OK OK OK OK OK OK OK OK
126 arg_regex           : OK OK OK OK OK SK SK SK SK SK
127 arg_module          : OK OK OK OK OK SK SK SK SK SK
128 arg_module2         : OK OK OK OK OK SK SK SK SK SK
129 session_tid         : OK OK OK OK OK OK OK OK OK OK
130 thread_exec         : OK OK OK OK OK OK OK OK OK OK
131 lib_dlopen          : OK OK OK OK OK OK OK OK OK OK
132 trigger_kernel      : SK SK SK SK SK SK SK SK SK SK
133 long_string         : OK OK OK OK OK SK SK SK SK SK
134 pic_pie             : OK OK OK OK OK OK OK OK OK OK
135 trigger_time2       : OK OK OK OK OK OK OK OK OK OK
136 dynamic             : NG NG NG NG NG NG NG NG NG NG
137 kernel_tid_update   : SK SK SK SK SK SK SK SK SK SK
138 kernel_dynamic      : SK SK SK SK SK SK SK SK SK SK
139 kernel_dynamic2     : SK SK SK SK SK SK SK SK SK SK
140 dynamic_xray        : BI BI BI BI BI BI BI BI BI BI
141 recv_basic          : OK OK OK OK OK OK OK OK OK OK
142 recv_multi          : OK OK OK OK OK OK OK OK OK OK
143 recv_kernel         : SK SK SK SK SK SK SK SK SK SK
144 longjmp2            : OK OK OK OK OK OK OK OK OK OK
145 longjmp3            : OK OK OK OK OK OK OK OK OK OK
146 arg_std_string      : OK OK OK OK OK SK SK SK SK SK
147 event_sdt           : BI BI BI BI BI BI BI BI BI BI
148 event_kernel        : SK SK SK SK SK SK SK SK SK SK
149 event_kernel2       : SK SK SK SK SK SK SK SK SK SK
150 recv_event          : BI BI BI BI BI BI BI BI BI BI
151 recv_runcmd         : NG NG NG NG NG NG NG NG NG NG
152 read_proc_statm     : OK OK OK OK OK OK OK OK OK OK
153 read_page_fault     : OK OK OK OK OK OK OK OK OK OK
154 keep_pid            : NG NG NG NG NG NG NG NG NG NG
155 trigger_finish      : OK OK OK OK OK OK OK OK OK OK
156 trigger_finish2     : OK OK OK OK OK OK OK OK OK OK
157 script_python       : OK OK OK OK OK OK OK OK OK OK
158 report_diff_policy1 : OK OK OK NG OK OK OK OK OK OK
159 report_diff_policy2 : OK OK OK OK OK OK OK OK OK OK
160 report_diff_policy3 : OK OK OK OK OK OK OK OK OK OK
161 pltbind_now         : NG NG NG NG NG NG NG NG NG NG
162 pltbind_now_pie     : NG NG NG NG NG NG NG NG NG NG
163 event_sched         : NG NG NG NG NG NG NG NG NG NG
164 report_sched        : NG NG NG NG NG NG NG NG NG NG
165 graph_sched         : NG NG NG NG NG NG NG NG NG NG
166 dump_sched          : NG NG NG NG NG NG NG NG NG NG
167 recv_sched          : NG NG NG NG NG NG NG NG NG NG
168 lib_nested          : SG SG SG SG SG SG SG SG SG SG
169 script_args         : OK OK OK OK OK OK OK OK OK OK
170 script_filter       : OK OK OK OK OK OK OK OK OK OK
171 script_option       : OK OK OK OK OK OK OK OK OK OK
172 trigger_filter      : OK OK OK OK OK OK OK OK OK OK
173 trigger_args        : OK OK OK OK OK SK SK SK SK SK
174 replay_filter_kernel: SK SK SK SK SK SK SK SK SK SK
175 filter_time_read    : OK OK OK OK OK OK OK OK OK OK
176 arg_fptr            : OK OK OK OK OK OK OK OK OK OK
177 report_diff_policy4 : OK OK OK OK OK OK OK OK OK OK
178 arg_auto1           : OK OK OK OK OK OK OK OK OK OK
179 arg_auto2           : OK OK OK OK OK OK OK OK OK OK
180 arg_auto3           : OK OK OK OK OK OK OK OK OK OK

runtime test stats
====================
total  1800  Tests executed (success: 75.11%)
  OK:  1262  Test succeeded
  OK:    90  Test succeeded (with some fixup)
  NG:   149  Different test result
  NZ:     0  Non-zero return value
  SG:    14  Abnormal exit by signal
  TM:     0  Test ran too long
  BI:    30  Build failed
  LA:     0  Unsupported Language
  SK:   255  Skipped