### PR TITLE
doc:Fix example command

### DIFF
--- a/doc/uftrace-replay.md
+++ b/doc/uftrace-replay.md
@@ -195,7 +195,7 @@ The color trigger is to change the color of the function in replay output.  The 
 The following example shows how triggers work.  We set a filter on function `b()` with the `backtrace` action and change the maximum filter depth under `b()` to 2.
 
     $ uftrace record ./abc
-    $ uftrace replay -F 'b@backtrace,depth=2'
+    $ uftrace replay -T 'b@filter,backtrace,depth=2'
     # DURATION    TID     FUNCTION
       backtrace [ 1234] | /* [ 0] main */
       backtrace [ 1234] | /* [ 1] a */


### PR DESCRIPTION
backtrace trigger is not working with `-F` any more.
So it should be replaced by `-T` option.

Before
~~~
$ uftrace replay -F 'b@backtrace,depth=2'
~~~

After
~~~
$ uftrace replay -T 'b@filter,backtrace,depth=2'
~~~

Thanks !! :)

Signed-off-by: JangSoJin <wkdthwls3@naver.com>