### PR TITLE
Naming convention of the C++ language standard.

### DIFF
--- a/arch/aarch64/mcount-arch.h
+++ b/arch/aarch64/mcount-arch.h
@@ -1,5 +1,5 @@
-#ifndef __MCOUNT_ARCH_H__
-#define __MCOUNT_ARCH_H__
+#ifndef MCOUNT_ARCH_H
+#define MCOUNT_ARCH_H
 
 #define mcount_regs  mcount_regs
 
@@ -67,4 +67,4 @@ struct mcount_arch_context {
 #define ARCH_PLT0_SIZE  32
 #define ARCH_PLTHOOK_ADDR_OFFSET  0
 
-#endif /* __MCOUNT_ARCH_H__ */
+#endif /* MCOUNT_ARCH_H */

--- a/arch/arm/mcount-arch.h
+++ b/arch/arm/mcount-arch.h
@@ -1,5 +1,5 @@
-#ifndef __MCOUNT_ARCH_H__
-#define __MCOUNT_ARCH_H__
+#ifndef MCOUNT_ARCH_H
+#define MCOUNT_ARCH_H
 
 #define mcount_regs  mcount_regs
 
@@ -70,4 +70,4 @@ unsigned long * mcount_arch_parent_location(struct symtabs *symtabs,
 #define ARCH_PLT0_SIZE  20
 #define ARCH_PLTHOOK_ADDR_OFFSET  0
 
-#endif /* __MCOUNT_ARCH_H__ */
+#endif /* MCOUNT_ARCH_H */

--- a/arch/x86_64/mcount-arch.h
+++ b/arch/x86_64/mcount-arch.h
@@ -1,5 +1,5 @@
-#ifndef __MCOUNT_ARCH_H__
-#define __MCOUNT_ARCH_H__
+#ifndef MCOUNT_ARCH_H
+#define MCOUNT_ARCH_H
 
 #define mcount_regs  mcount_regs
 
@@ -52,4 +52,4 @@ struct mcount_arch_context {
 #define ARCH_PLT0_SIZE  16
 #define ARCH_PLTHOOK_ADDR_OFFSET  6
 
-#endif /* __MCOUNT_ARCH_H__ */
+#endif /* MCOUNT_ARCH_H */

--- a/tests/unittest.h
+++ b/tests/unittest.h
@@ -1,5 +1,5 @@
-#ifndef __UFTRACE_UNIT_TEST_H__
-#define __UFTRACE_UNIT_TEST_H__
+#ifndef UFTRACE_UNIT_TEST_H
+#define UFTRACE_UNIT_TEST_H
 
 #include <stdio.h>
 #include <string.h>
@@ -82,4 +82,4 @@ int func_ ## t(void)
 #define TERM_COLOR_GREEN	"\033[32m"
 #define TERM_COLOR_YELLOW	"\033[33m"
 
-#endif /* __UFTRACE_UNIT_TEST_H__ */
+#endif /* UFTRACE_UNIT_TEST_H */

--- a/uftrace.h
+++ b/uftrace.h
@@ -1,5 +1,5 @@
-#ifndef __UFTRACE_H__
-#define __UFTRACE_H__
+#ifndef UFTRACE_H
+#define UFTRACE_H
 
 #include <stdio.h>
 #include <stdint.h>
@@ -511,4 +511,4 @@ struct uftrace_event {
 	char			*event;
 };
 
-#endif /* __UFTRACE_H__ */
+#endif /* UFTRACE_H */

--- a/utils/asm.h
+++ b/utils/asm.h
@@ -1,5 +1,5 @@
-#ifndef __UFTRACE_ASM_H__
-#define __UFTRACE_ASM_H__
+#ifndef UFTRACE_ASM_H
+#define UFTRACE_ASM_H
 
 #define GLOBAL(sym)				\
 	.global sym;				\
@@ -19,4 +19,4 @@ sym:
 #define END(sym)				\
 	.size sym, .-sym;
 
-#endif /* __UFTRACE_ASM_H__ */
+#endif /* UFTRACE_ASM_H */

--- a/utils/compiler.h
+++ b/utils/compiler.h
@@ -1,5 +1,5 @@
-#ifndef __FTRACE_COMPILER_H__
-#define __FTRACE_COMPILER_H__
+#ifndef UFTRACE_COMPILER_H
+#define UFTRACE_COMPILER_H
 
 #define compiler_barrier()	asm volatile("" :::"memory")
 
@@ -34,4 +34,4 @@
 #define __alias(func)  __attribute__((alias(#func)))
 #define __maybe_unused  __attribute__((unused))
 
-#endif /* __FTRACE_COMPILER_H__ */
+#endif /* UFTRACE_COMPILER_H */

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -1,5 +1,5 @@
-#ifndef __FTRACE_FILTER_H__
-#define __FTRACE_FILTER_H__
+#ifndef UFTRACE_FILTER_H
+#define UFTRACE_FILTER_H
 
 #include <stdint.h>
 
@@ -148,4 +148,4 @@ char *get_auto_argspec_str(void);
 char *get_auto_retspec_str(void);
 int extract_trigger_args(char **pargs, char **prets, char *trigger);
 
-#endif /* __FTRACE_FILTER_H__ */
+#endif /* UFTRACE_FILTER_H */

--- a/utils/fstack.h
+++ b/utils/fstack.h
@@ -1,5 +1,5 @@
-#ifndef __FTRACE_FSTACK_H__
-#define __FTRACE_FSTACK_H__
+#ifndef UFTRACE_FSTACK_H
+#define UFTRACE_FSTACK_H
 
 #include <stdio.h>
 #include <stdint.h>
@@ -146,4 +146,4 @@ void get_argspec_string(struct ftrace_task_handle *task,
 		        char *args, size_t len,
 		        enum argspec_string_bits str_mode);
 
-#endif /* __FTRACE_FSTACK_H__ */
+#endif /* UFTRACE_FSTACK_H */

--- a/utils/kernel.h
+++ b/utils/kernel.h
@@ -1,5 +1,5 @@
-#ifndef __UFTRACE_KERNEL_H__
-#define __UFTRACE_KERNEL_H__
+#ifndef UFTRACE_KERNEL_H
+#define UFTRACE_KERNEL_H
 
 #include "libtraceevent/event-parse.h"
 
@@ -80,4 +80,4 @@ static inline bool has_kernel_event(char *events)
 
 bool check_kernel_pid_filter(void);
 
-#endif /* __UFTRACE_KERNEL_H__ */
+#endif /* UFTRACE_KERNEL_H */

--- a/utils/perf.h
+++ b/utils/perf.h
@@ -1,5 +1,5 @@
-#ifndef __UFTRACE_PERF_H__
-#define __UFTRACE_PERF_H__
+#ifndef UFTRACE_PERF_H
+#define UFTRACE_PERF_H
 
 #include <stdint.h>
 #include <stdbool.h>

--- a/utils/script-python.h
+++ b/utils/script-python.h
@@ -5,8 +5,8 @@
  *
  * Released under the GPL v2.
  */
-#ifndef __UFTRACE_SCRIPT_PYTHON_H__
-#define __UFTRACE_SCRIPT_PYTHON_H__
+#ifndef UFTRACE_SCRIPT_PYTHON_H
+#define UFTRACE_SCRIPT_PYTHON_H
 
 #ifdef HAVE_LIBPYTHON2
 
@@ -31,4 +31,4 @@ static inline void script_finish_for_python(void) {}
 
 #endif /* HAVE_LIBPYTHON2 */
 
-#endif /* __UFTRACE_SCRIPT_PYTHON_H__ */
+#endif /* UFTRACE_SCRIPT_PYTHON_H */

--- a/utils/script.h
+++ b/utils/script.h
@@ -5,8 +5,8 @@
  *
  * Released under the GPL v2.
  */
-#ifndef __UFTRACE_SCRIPT_H__
-#define __UFTRACE_SCRIPT_H__
+#ifndef UFTRACE_SCRIPT_H
+#define UFTRACE_SCRIPT_H
 
 #include "libmcount/mcount.h"
 #include "utils/script-python.h"
@@ -49,4 +49,4 @@ void script_add_filter(char *func);
 int script_match_filter(char *func);
 void script_finish_filter(void);
 
-#endif /* __UFTRACE_SCRIPT_H__ */
+#endif /* UFTRACE_SCRIPT_H */

--- a/utils/symbol.h
+++ b/utils/symbol.h
@@ -6,8 +6,8 @@
  * Released under the GPL v2.
  */
 
-#ifndef FTRACE_SYMBOL_H
-#define FTRACE_SYMBOL_H
+#ifndef UFTRACE_SYMBOL_H
+#define UFTRACE_SYMBOL_H
 
 #include <stdint.h>
 #include <limits.h>
@@ -175,4 +175,4 @@ static inline char *demangle_full(char *str)
 }
 #endif /* HAVE_CXA_DEMANGLE */
 
-#endif /* FTRACE_SYMBOL_H */
+#endif /* UFTRACE_SYMBOL_H */

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -6,8 +6,8 @@
  * Released under the GPL v2.
  */
 
-#ifndef __FTRACE_UTILS_H__
-#define __FTRACE_UTILS_H__
+#ifndef UFTRACE_UTILS_H
+#define UFTRACE_UTILS_H
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -260,4 +260,4 @@ char *get_event_name(struct ftrace_file_handle *handle, unsigned evt_id);
 
 char *absolute_dirname(const char *path, char *resolved_path);
 
-#endif /* __FTRACE_UTILS_H__ */
+#endif /* UFTRACE_UTILS_H */


### PR DESCRIPTION
I solved #187 a little bit.
I changed to naming convention of the C++ language standard in uftrace.h file and utils/utils.h file.