### PR TITLE
script: Flush python internal buffer at fork

### DIFF
--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -980,6 +980,10 @@ static void atfork_prepare_handler(void)
 		.pid = getpid(),
 	};
 
+	/* call script atfork preparation routine */
+	if (SCRIPT_ENABLED && script_str)
+		script_atfork_prepare();
+
 	uftrace_send_message(UFTRACE_MSG_FORK_START, &tmsg, sizeof(tmsg));
 }
 

--- a/scripts/replay.py
+++ b/scripts/replay.py
@@ -29,8 +29,7 @@ def uftrace_exit(ctx):
     print(buf)
 
 def uftrace_end():
-    # print an empty line
-    print("")
+    pass
 
 def get_time_and_unit(duration):
     duration = float(duration)

--- a/scripts/replay.py
+++ b/scripts/replay.py
@@ -17,7 +17,7 @@ def uftrace_exit(ctx):
     # read arguments
     _tid = ctx["tid"]
     _depth = ctx["depth"]
-    _symname = ctx["symname"]
+    _symname = ctx["name"]
     _duration = ctx["duration"]
 
     indent = _depth * 2

--- a/utils/script-python.c
+++ b/utils/script-python.c
@@ -146,6 +146,10 @@ static int import_python_module(char *py_pathname)
 	}
 
 	Py_XDECREF(pName);
+
+	/* import sys by default */
+	__PyRun_SimpleStringFlags("import sys", NULL);
+
 	return 0;
 }
 

--- a/utils/script-python.c
+++ b/utils/script-python.c
@@ -41,6 +41,7 @@ static PyAPI_FUNC(void) (*__PyErr_Clear)(void);
 static PyAPI_FUNC(PyObject *) (*__PyObject_GetAttrString)(PyObject *, const char *);
 static PyAPI_FUNC(int) (*__PyCallable_Check)(PyObject *);
 static PyAPI_FUNC(PyObject *) (*__PyObject_CallObject)(PyObject *callable_object, PyObject *args);
+static PyAPI_FUNC(int) (*__PyRun_SimpleStringFlags)(const char *, PyCompilerFlags *);
 
 static PyAPI_FUNC(PyObject *) (*__PyString_FromString)(const char *);
 static PyAPI_FUNC(PyObject *) (*__PyInt_FromLong)(long);
@@ -517,6 +518,7 @@ int script_init_for_python(char *py_pathname)
 	INIT_PY_API_FUNC(PyObject_GetAttrString);
 	INIT_PY_API_FUNC(PyCallable_Check);
 	INIT_PY_API_FUNC(PyObject_CallObject);
+	INIT_PY_API_FUNC(PyRun_SimpleStringFlags);
 
 	INIT_PY_API_FUNC(PyString_FromString);
 	INIT_PY_API_FUNC(PyInt_FromLong);

--- a/utils/script-python.c
+++ b/utils/script-python.c
@@ -495,6 +495,14 @@ int python_uftrace_end(void)
 	return 0;
 }
 
+int python_atfork_prepare(void)
+{
+	pr_dbg("flush python buffer");
+	__PyRun_SimpleStringFlags("sys.stdout.flush()", NULL);
+
+	return 0;
+}
+
 int script_init_for_python(char *py_pathname)
 {
 	pr_dbg("initialize python scripting engine for %s\n", py_pathname);
@@ -503,6 +511,7 @@ int script_init_for_python(char *py_pathname)
 	script_uftrace_entry = python_uftrace_entry;
 	script_uftrace_exit = python_uftrace_exit;
 	script_uftrace_end = python_uftrace_end;
+	script_atfork_prepare = python_atfork_prepare;
 
 	python_handle = dlopen(libpython, RTLD_LAZY | RTLD_GLOBAL);
 	if (!python_handle) {

--- a/utils/script.c
+++ b/utils/script.c
@@ -28,6 +28,7 @@ static enum script_type_t script_lang;
 script_uftrace_entry_t script_uftrace_entry;
 script_uftrace_exit_t script_uftrace_exit;
 script_uftrace_end_t script_uftrace_end;
+script_atfork_prepare_t script_atfork_prepare;
 
 struct script_filter_item {
 	struct list_head	list;

--- a/utils/script.h
+++ b/utils/script.h
@@ -36,11 +36,13 @@ extern char *script_str;
 typedef int (*script_uftrace_entry_t)(struct script_context *sc_ctx);
 typedef int (*script_uftrace_exit_t)(struct script_context *sc_ctx);
 typedef int (*script_uftrace_end_t)(void);
+typedef int (*script_atfork_prepare_t)(void);
 
 /* The below functions are used both in record time and script command. */
 extern script_uftrace_entry_t script_uftrace_entry;
 extern script_uftrace_exit_t script_uftrace_exit;
 extern script_uftrace_end_t script_uftrace_end;
+extern script_atfork_prepare_t script_atfork_prepare;
 
 int script_init(char *script_pathname);
 void script_finish(void);


### PR DESCRIPTION
Sometimes, when fork is called in the target program, python output is printed twice because its buffer is not flushed when creating a new process.

This PR makes python interpreter flush its internal buffer to avoid the problem by calling "sys.stdout.flush()".

```
Before:
  $ uftrace -S scripts/replay.py tests/t-fork
  # DURATION    TID     FUNCTION
              [15120] | main() {
              [15120] |   fork() {
   590.585 us [15132] |   } /* fork */
              [15132] |   a() {
              [15132] |     b() {
              [15132] |       c() {
              [15132] |         getpid() {
     9.400 us [15132] |         } /* getpid */
    39.670 us [15132] |       } /* c */
    59.414 us [15132] |     } /* b */
    93.723 us [15132] |   } /* a */
     1.078 ms [15132] | } /* main */
  # DURATION    TID     FUNCTION
              [15120] | main() {
              [15120] |   fork() {
   208.274 us [15120] |   } /* fork */
              [15120] |   wait() {
     6.277 ms [15120] |   } /* wait */
              [15120] |   a() {
              [15120] |     b() {
              [15120] |       c() {
              [15120] |         getpid() {
     9.203 us [15120] |         } /* getpid */
    32.964 us [15120] |       } /* c */
    52.163 us [15120] |     } /* b */
    77.881 us [15120] |   } /* a */
     6.921 ms [15120] | } /* main */
        ...

After:
  $ uftrace -S scripts/replay.py tests/t-fork
  # DURATION    TID     FUNCTION
              [14594] | main() {
              [14594] |   fork() {
   287.577 us [14594] |   } /* fork */
              [14594] |   wait() {
   530.621 us [14605] |   } /* fork */
              [14605] |   a() {
              [14605] |     b() {
              [14605] |       c() {
              [14605] |         getpid() {
    10.447 us [14605] |         } /* getpid */
    44.960 us [14605] |       } /* c */
    69.964 us [14605] |     } /* b */
   108.480 us [14605] |   } /* a */
     1.000 ms [14605] | } /* main */
     5.799 ms [14594] |   } /* wait */
              [14594] |   a() {
              [14594] |     b() {
              [14594] |       c() {
              [14594] |         getpid() {
    12.190 us [14594] |         } /* getpid */
    46.144 us [14594] |       } /* c */
    68.937 us [14594] |     } /* b */
    97.497 us [14594] |   } /* a */
     6.551 ms [14594] | } /* main */
        ...
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>