### PR TITLE
CONTRIBUTING: Change URL of the coding style of the Linux kernel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ readability.  For example:
 
 Please note that the position of the "else if" line.
 
-[1] https://www.kernel.org/doc/Documentation/CodingStyle
+[1] https://www.kernel.org/doc/Documentation/process/coding-style.rst 
 
 
 Include subject word in message header


### PR DESCRIPTION
The URL of the coding style of the Linux Kernel has been changed to
https://www.kernel.org/doc/Documentation/process/coding-style.rst