### PR TITLE
Update testcase for i386

### DIFF
--- a/tests/s-exp-int.c
+++ b/tests/s-exp-int.c
@@ -13,7 +13,7 @@ int int_mul(long long a, int b)
 	return a * b;
 }
 
-int int_div(unsigned a, long b)
+int int_div(int a, long b)
 {
 	return a / b;
 }

--- a/tests/t043_full_demangle.py
+++ b/tests/t043_full_demangle.py
@@ -29,9 +29,9 @@ class TestCase(TestBase):
         return '%s --demangle=full -N "ns2.*" %s' % (TestBase.ftrace, 't-namespace')
 
     def fixup(self, cflags, result):
-       import platform
-       if platform.machine().startswith('arm'):
-               return result.replace('unsigned long', 'unsigned int')
+        import platform
+        if platform.architecture()[0].startswith('32bit'):
+            return result.replace('unsigned long', 'unsigned int')
 
-       return result.replace('delete(void*);',
-                             'delete(void*, unsigned long);')
+        return result.replace('delete(void*);',
+                              'delete(void*, unsigned long);')

--- a/tests/t058_arg_int.py
+++ b/tests/t058_arg_int.py
@@ -25,7 +25,7 @@ class TestCase(TestBase):
         argopt = '-A "^int_@arg1,arg2"'
 
         import platform
-        if platform.machine().startswith('arm'):
+        if platform.architecture()[0].startswith('32bit'):
             # int_mul@arg1 is a 'long long', so we should skip arg2
             argopt = '-A "int_(add|sub|div)@arg1,arg2" -A "int_mul@arg1/i64,arg3"'
         return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)

--- a/tests/t063_retval.py
+++ b/tests/t063_retval.py
@@ -27,9 +27,9 @@ class TestCase(TestBase):
         argopt = '-A "^int_@arg1,arg2" -R "^int_@retval/i32"'
 
         import platform
-        if platform.machine().startswith('arm'):
+        if platform.architecture()[0].startswith('32bit'):
             # int_mul@arg1 is a 'long long', so we should skip arg2
             argopt  = '-A "int_(add|sub|div)@arg1,arg2" -A "int_mul@arg1/i64,arg3" '
             argopt += '-R "^int_@retval/i32"'
-
+      
         return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)

--- a/tests/t065_arg_order.py
+++ b/tests/t065_arg_order.py
@@ -25,7 +25,7 @@ class TestCase(TestBase):
         argopt = '-A "int_mul@arg2/x" -A "^int_@arg1,arg2" -A "int_add@arg1/i32"'
 
         import platform
-        if platform.machine().startswith('arm'):
+        if platform.architecture()[0].startswith('32bit'):
             # int_mul@arg1 is a 'long long', so we should skip arg2
             argopt  = '-A "int_mul@arg1/i64" -A "^int_@arg1" '
             argopt += '-A "int_(add|sub|div)@arg2" -A "int_mul@arg3/x" '

--- a/tests/t083_arg_float.py
+++ b/tests/t083_arg_float.py
@@ -33,4 +33,11 @@ class TestCase(TestBase):
             argopt = argopt.replace('float_mul@fparg1/64,fparg2/32',
                                     'float_mul@fparg1/64,fparg3/32')
 
+        elif platform.machine().startswith('i686'):
+            # argument count follows the size of type
+            argopt  = '-A "float_add@fparg1/32,fparg2/32" -R "float_add@retval/f32" '
+            argopt += '-A "float_sub@fparg1/32,fparg2"    -R "float_sub@retval/f32" '
+            argopt += '-A "float_mul@fparg1/64,fparg3/32" -R "float_mul@retval/f64" '
+            argopt += '-A "float_div@fparg1/64,fparg3/64" -R "float_div@retval/f64"'
+
         return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)

--- a/tests/t084_arg_mixed.py
+++ b/tests/t084_arg_mixed.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from runtest import TestBase
+import platform
 
 class TestCase(TestBase):
     def __init__(self):
@@ -32,5 +33,11 @@ class TestCase(TestBase):
         import platform
         if platform.machine().startswith('arm'):
             argopt = argopt.replace('fparg1/80%stack+1', 'fparg1/80')
+        elif platform.machine().startswith('i686'):
+            argopt  = '-A "mixed_add@arg1/i32,fparg2/32"         -R "mixed_add@retval/f64" '
+            argopt += '-A "mixed_sub@arg1/x,arg2"                -R "mixed_sub@retval" '
+            argopt += '-A "mixed_mul@fparg1,arg3/i64"            -R "mixed_mul@retval/i64" '
+            argopt += '-A "mixed_div@arg1/i64,fparg1/80%stack+3" -R "mixed_div@retval/f80" '
+            argopt += '-A "mixed_str@arg1/s,fparg1"              -R "mixed_str@retval/s"'
 
         return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)

--- a/tests/t086_arg_stack.py
+++ b/tests/t086_arg_stack.py
@@ -37,4 +37,11 @@ class TestCase(TestBase):
         argopt += '-A "many@arg3/i32%stack+3,arg4/i32%stack+4" '
         argopt += '-A "many@arg5/i32%stack5,arg6/i32%stack6,arg7/i32%stack7"'
 
+        import platform
+        if platform.machine().startswith('i686'):
+            # i386 use stack for passing argument. so, change order.
+            argopt  = '-A "many@arg1/i32%stack+7,arg2/i32%stack+8" '
+            argopt += '-A "many@arg3/i32%stack+9,arg4/i32%stack+10" '
+            argopt += '-A "many@arg5/i32%stack11,arg6/i32%stack12,arg7/i32%stack13"'
+
         return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)

--- a/tests/t087_arg_variadic.py
+++ b/tests/t087_arg_variadic.py
@@ -27,6 +27,11 @@ class TestCase(TestBase):
         argopt += '-A "vsnprintf@arg2,arg3/s" '
         argopt += '-A "__vsnprintf_chk@arg2,arg5/s"'
 
+        import platform
+        if platform.machine().startswith('i686'):
+            argopt  = '-A "variadic@arg1/s,arg2/c,arg3/s,arg4,arg5,arg6,arg7/i64,fparg9" '
+            argopt += '-A "vsnprintf@arg2,arg3/s" '
+            argopt += '-A "__vsnprintf_chk@arg2,arg5/s"'
         return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)
 
     def fixup(self, cflags, result):


### PR DESCRIPTION
hello. 
I changed some test cases for i386 support. 

first commit : 
```
    s-exp-int.c
    changed function int_div's first argument type to int from unsigned.
    because, when divide "unsigned type" to "long type",
    it will be unsigned operation during divide in 32bit system.
    we call this "automatic conversion".
    test does not intend unsigned divide, but instead a "signed" divide.

    t043_full_demangle.py,
    t058_arg_int.py, t063_retval.py, t065_arg_order.py
    extended argument option for arm to 32bit.
```

second commit:
```
    since i386 use stack for passing argument,
    previous argument size are affect to next argument position.
    for example when first argument's size are over 32bit,
    second argument have position must be 3.

    the following testcase have been changed to consider for these issue:
    t083_arg_float.py, t084_arg_mixed.py, t086_arg_stack.py
    t087_arg_variadic.py
```
