### PR TITLE
doc: Add two default values of options, `-f` and `--diff-policy=POLICY`

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -159,7 +159,7 @@ static struct argp_option uftrace_options[] = {
 	{ "opt-file", OPT_opt_file, "FILE", 0, "Read command-line options from FILE" },
 	{ "keep-pid", OPT_keep_pid, 0, 0, "Keep same pid during execution of traced program" },
 	{ "script", 'S', "SCRIPT", 0, "Run a given SCRIPT in function entry and exit" },
-	{ "diff-policy", OPT_diff_policy, "POLICY", 0, "Control diff report policy" },
+	{ "diff-policy", OPT_diff_policy, "POLICY", 0, "Control diff report policy (default: 'abs,compact,no-percent')" },
 	{ "event-full", OPT_event_full, 0, 0, "Show all events outside of function" },
 	{ "nest-libcall", OPT_nest_libcall, 0, 0, "Show nested library calls" },
 	{ "record", OPT_record, 0, 0, "Record a new trace data before running command" },

--- a/uftrace.c
+++ b/uftrace.c
@@ -150,7 +150,7 @@ static struct argp_option uftrace_options[] = {
 	{ "kernel-only", OPT_kernel_only, 0, 0, "Dump kernel data only" },
 	{ "flame-graph", OPT_flame_graph, 0, 0, "Dump recorded data in FlameGraph format" },
 	{ "sample-time", OPT_sample_time, "TIME", 0, "Show flame graph with this sampling time" },
-	{ "output-fields", 'f', "FIELD", 0, "Show FIELDs in the replay output" },
+	{ "output-fields", 'f', "FIELD", 0, "Show FIELDs in the replay output (default: 'duration,tid')" },
 	{ "time-range", 'r', "TIME~TIME", 0, "Show output within the TIME(timestamp or elapsed time) range only" },
 	{ "patch", 'P', "FUNC", 0, "Apply dynamic patching for FUNCs" },
 	{ "event", 'E', "EVENT", 0, "Enable EVENT to save more information" },


### PR DESCRIPTION
Like the `--column-offset=DEPTH` line of current `uftrace --help` results, add default values of options, `-f`(`--output-fields=FIELD`) and `--diff-policy`, respectively.
Following the written in `man uftrace-replay`, parenthesizing both default values with quote(`'`)s.

I think the users may infer that the `FIELD` and `POLICY` can be seperated by comma(`,`) from this.

Now we can see the followed results of `uftrace --help`:
```
$ uftrace --help
Usage: uftrace [OPTION...]
            [record|replay|live|report|info|dump|recv|graph|script]
            [<program>]
uftrace -- function (graph) tracer for userspace

...
      --column-offset=DEPTH  Offset of each column (default: 8)
...
      --diff-policy=POLICY   Control diff report policy (default:
                             'abs,compact,no-percent')
...
  -f, --output-fields=FIELD  Show FIELDs in the replay output (default:
                             'duration,tid')
...
```