### PR TITLE
doc: add usage method about dump --chrome option

### DIFF
--- a/doc/uftrace-dump.md
+++ b/doc/uftrace-dump.md
@@ -21,7 +21,7 @@ OPTIONS
 :   Show hex dump of data as well
 
 \--chrome
-:   Show JSON style output as used by the Google Chrome tracing facility.
+:   Show JSON style output as used by the Google Chrome tracing facility. Open chrome tracing tools (chrome://tracing) and load JSON file.
 
 \--flame-graph
 :   Show FlameGraph style output (svg) viewable by modern web browsers.


### PR DESCRIPTION
In doc/uftrace-dump.md file, there is no explain how to use the result JSON file from dump --chrome option. So, i add explain about way to use JSON file with chrome.

Open chrome tracing tools (chrome://tracing) and load JSON file.