### PR TITLE
some fix for uftrace

### DIFF
--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -701,6 +701,11 @@ static void update_pltgot(struct mcount_thread_data *mtdp,
 	}
 }
 
+__weak unsigned long mcount_arch_child_idx(unsigned long child_idx)
+{
+	return child_idx;
+}
+
 unsigned long plthook_entry(unsigned long *ret_addr, unsigned long child_idx,
 			    unsigned long module_id, struct mcount_regs *regs)
 {
@@ -719,6 +724,8 @@ unsigned long plthook_entry(unsigned long *ret_addr, unsigned long child_idx,
 	unsigned long special_flag = 0;
 	unsigned long real_addr = 0;
 
+	// if neccesary, implement it by architecture.
+	child_idx = mcount_arch_child_idx(child_idx);
 	list_for_each_entry(pd, &plthook_modules, list) {
 		if (module_id == pd->module_id)
 			break;

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -112,7 +112,7 @@ struct uftrace_filter *uftrace_match_filter(uint64_t ip, struct rb_root *root,
 		iter = rb_entry(parent, struct uftrace_filter, node);
 
 		if (match_ip(iter, ip)) {
-			memcpy(tr, &iter->trigger, sizeof(*tr));
+		  	*tr = iter->trigger;
 
 			pr_dbg2("filter match: %s\n", iter->name);
 			if (dbg_domain[DBG_FILTER] >= 3)


### PR DESCRIPTION
this "PR" is splitted part from "support-i386".
two fix for uftrace.

first commit:
```
trigger: do not use memcpy() for copying trigger

if we use memcpy to copy the &iter->trigger,
depending on the size of the uftrace_trigger *tr
we will ride optimization path to use SSE inside memcpy.
it will change status of SIMD register like mmx.
therefore we lose original value of register.
so, we decide not to use memcpy.
```

second commit:
```
mcount: add mcount_arch_child_idx()

The value of child idx may be different for each architecture.
For this reason, we added the part that calculates child_idx
to be implemented by each architecture.
```