### PR TITLE
Support i386 

### DIFF
--- a/arch/i386/Makefile
+++ b/arch/i386/Makefile
@@ -1,0 +1,34 @@
+LINKFLAGS := -r
+
+sdir := $(srcdir)/arch/i386
+odir := $(objdir)/arch/i386
+
+include $(srcdir)/Makefile.include
+
+ARCH_ENTRY_SRC = $(wildcard $(sdir)/*.S)
+ARCH_MCOUNT_SRC = $(wildcard $(sdir)/mcount-*.c) $(sdir)/regs.c 
+ARCH_UFTRACE_SRC = $(sdir)/cpuinfo.c $(sdir)/regs.c 
+
+ARCH_MCOUNT_OBJS  = $(patsubst $(sdir)/%.S,$(odir)/%.op,$(ARCH_ENTRY_SRC))
+ARCH_MCOUNT_OBJS += $(patsubst $(sdir)/%.c,$(odir)/%.op,$(ARCH_MCOUNT_SRC))
+ARCH_UFTRACE_OBJS = $(patsubst $(sdir)/%.c,$(odir)/%.o,$(ARCH_UFTRACE_SRC))
+
+all: $(odir)/entry.op
+
+$(odir)/mcount-entry.op: $(ARCH_MCOUNT_OBJS)
+	$(QUIET_LINK)$(LD) $(LINKFLAGS) -o $@ $^
+
+$(odir)/uftrace.o: $(ARCH_UFTRACE_OBJS)
+	$(QUIET_LINK)$(LD) $(LINKFLAGS) -o $@ $^
+
+$(odir)/%.op: $(sdir)/%.S
+	$(QUIET_ASM)$(CC) $(LIB_CFLAGS) -c -o $@ $<
+
+$(odir)/%.op: $(sdir)/%.c
+	$(QUIET_CC_FPIC)$(CC) $(LIB_CFLAGS) -c -o $@ $<
+
+$(odir)/%.o: $(sdir)/%.c
+	$(QUIET_CC)$(CC) $(UFTRACE_CFLAGS) -c -o $@ $<
+
+clean:
+	$(RM) $(odir)/*.op $(odir)/*.o

--- a/arch/i386/cpuinfo.c
+++ b/arch/i386/cpuinfo.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <string.h>
+
+int arch_fill_cpuinfo_model(int fd)
+{
+	char buf[1024];
+	FILE *fp;
+	int ret = -1;
+
+	fp = fopen("/proc/cpuinfo", "r");
+	if (fp == NULL)
+		return -1;
+
+	while (fgets(buf, sizeof(buf), fp) != NULL) {
+		if (!strncmp(buf, "model name\t:", 12)) {
+			dprintf(fd, "cpuinfo:desc=%s", &buf[13]);
+			ret = 0;
+			break;
+		}
+	}
+	fclose(fp);
+	return ret;
+}

--- a/arch/i386/fentry.S
+++ b/arch/i386/fentry.S
@@ -1,0 +1,50 @@
+#include "utils/asm.h"
+
+GLOBAL(__fentry__)
+	sub $32, %esp
+	movl %edx, 28(%esp)
+	movl %ecx, 24(%esp)
+	movl %eax, 20(%esp)
+	movl $0, 16(%esp)
+	/* parent location */
+	leal 36(%esp), %eax
+	movl %eax, 0(%esp)
+	/* child addr */
+	movl 32(%esp), %eax
+	movl %eax, 4(%esp)
+	/* mcount_args */
+	leal 16(%esp), %eax
+	movl %eax, 8(%esp)
+	call mcount_entry
+	cmpl $0, %eax
+	jne 1f
+
+	/* hijack return address */
+	call __x86.get_pc_thunk.ax
+	addl $_GLOBAL_OFFSET_TABLE_, %eax
+	addl $fentry_return@GOTOFF, %eax
+	movl %eax, 36(%esp)
+1:
+	movl 20(%esp), %eax
+	movl 24(%esp), %ecx
+	movl 28(%esp), %edx
+	add $32, %esp
+	ret
+END(__fentry__)
+
+
+ENTRY(fentry_return)
+	sub  $16, %esp
+	movl %edx, 8(%esp)
+	movl %eax, 4(%esp)
+	leal 4(%esp), %eax
+	movl %eax, 0(%esp)
+
+	call mcount_exit
+	movl %eax, 12(%esp)
+
+	movl 4(%esp), %eax
+	movl 8(%esp), %edx
+	add  $12, %esp
+	ret
+END(fentry_return)

--- a/arch/i386/mcount-arch.h
+++ b/arch/i386/mcount-arch.h
@@ -1,0 +1,50 @@
+#include "../../utils/symbol.h"
+#ifndef __MCOUNT_ARCH_H__
+#define __MCOUNT_ARCH_H__
+
+#define mcount_regs  mcount_regs
+
+struct mcount_regs {
+	unsigned long stack1;
+	unsigned long ecx;
+	unsigned long edx;
+};
+
+#define  ARG1(a)      ((a)->stack1)
+#define  ARG_REG1(a)  ((a)->ecx)
+#define  ARG_REG2(a)  ((a)->edx)
+
+#define ARCH_MAX_REG_ARGS  3
+#define ARCH_MAX_FLOAT_REGS  8
+
+enum x86_reg_index {
+	X86_REG_INT_BASE = 0,
+	/* integer registers */
+	X86_REG_ECX,
+	X86_REG_EDX,
+
+	X86_REG_FLOAT_BASE = 100,
+	/* floating-point registers */
+	X86_REG_XMM0,
+	X86_REG_XMM1,
+	X86_REG_XMM2,
+	X86_REG_XMM3,
+	X86_REG_XMM4,
+	X86_REG_XMM5,
+	X86_REG_XMM6,
+	X86_REG_XMM7,
+};
+
+#define HAVE_MCOUNT_ARCH_CONTEXT
+struct mcount_arch_context {
+	double xmm[ARCH_MAX_FLOAT_REGS];
+};
+
+#define FIX_PARENT_LOC
+unsigned long * mcount_arch_parent_location(struct symtabs *symtabs,
+					    unsigned long *parent_loc,
+					    unsigned long child_ip);
+#define ARCH_PLT0_SIZE  16
+#define ARCH_PLTHOOK_ADDR_OFFSET  6
+
+#endif /* __MCOUNT_ARCH_H__ */

--- a/arch/i386/mcount-dynamic.c
+++ b/arch/i386/mcount-dynamic.c
@@ -1,0 +1,104 @@
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+/* This should be defined before #include "utils.h" */
+#define PR_FMT     "dynamic"
+#define PR_DOMAIN  DBG_DYNAMIC
+
+#include "libmcount/internal.h"
+#include "utils/utils.h"
+#include "utils/symbol.h"
+
+#define PAGE_SIZE  4096
+
+/* target instrumentation function it needs to call */
+extern void __fentry__(void);
+
+int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
+{
+	unsigned char trampoline[] = { 0xe8, 0x00, 0x00, 0x00, 0x00, 0x58, 0xff, 0x60, 0x04 };
+	unsigned long fentry_addr = (unsigned long)__fentry__;
+	struct arch_dynamic_info *adi = mdi->arch;
+	size_t trampoline_size = 16;
+
+	/* find unused 16-byte at the end of the code segment */
+	mdi->trampoline = ALIGN(mdi->addr + mdi->size, PAGE_SIZE) - trampoline_size;
+
+	if (unlikely(mdi->trampoline < mdi->addr + mdi->size)) {
+		mdi->trampoline += trampoline_size;
+		mdi->size += PAGE_SIZE;
+
+		pr_dbg2("adding a page for fentry trampoline at %#lx\n",
+			mdi->trampoline);
+
+		mmap((void *)mdi->trampoline, PAGE_SIZE, PROT_READ | PROT_WRITE,
+		     MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	}
+
+	if (mprotect((void *)mdi->addr, mdi->size, PROT_READ | PROT_WRITE)) {
+		pr_dbg("cannot setup trampoline due to protection: %m\n");
+		return -1;
+	}
+
+	/* jmpq  *0x2(%rip)     # <fentry_addr> */
+	memcpy((void *)mdi->trampoline, trampoline, sizeof(trampoline));
+	memcpy((void *)mdi->trampoline + sizeof(trampoline),
+	       &fentry_addr, sizeof(fentry_addr));
+	return 0;
+}
+
+void mcount_cleanup_trampoline(struct mcount_dynamic_info *mdi)
+{
+	if (mprotect((void *)mdi->addr, mdi->size, PROT_EXEC))
+		pr_err("cannot restore trampoline due to protection");
+}
+
+#define CALL_INSN_SIZE 5
+
+static unsigned long get_target_addr(struct mcount_dynamic_info *mdi, unsigned long addr)
+{
+	while (mdi) {
+		if (mdi->addr <= addr && addr < mdi->addr + mdi->size)
+			return mdi->trampoline - (addr + CALL_INSN_SIZE);
+
+		mdi = mdi->next;
+	}
+	return 0;
+}
+
+static int patch_fentry_func(struct mcount_dynamic_info *mdi, struct sym *sym)
+{
+	// In case of "gcc" which is not patched because of old version, 
+	// it may not create 5 byte nop.
+	unsigned char nop[] = { 0x0f, 0x1f, 0x44, 0x00, 0x00 };
+	unsigned char *insn = (void *)sym->addr;
+	unsigned int target_addr;
+
+	/* only support calls to __fentry__ at the beginning */
+	if (memcmp(insn, nop, sizeof(nop))) {
+		pr_dbg2("skip non-applicable functions: %s\n", sym->name);
+		return -2;
+	}
+
+	/* get the jump offset to the trampoline */
+	target_addr = get_target_addr(mdi, sym->addr);
+	if (target_addr == 0)
+		return -2;
+
+	/* make a "call" insn with 4-byte offset */
+	insn[0] = 0xe8;
+	/* hopefully we're not patching 'memcpy' itself */
+	memcpy(&insn[1], &target_addr, sizeof(target_addr));
+
+	pr_dbg3("update function '%s' dynamically to call __fentry__\n",
+		sym->name);
+
+	return 0;
+}
+
+int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym)
+{
+	return patch_fentry_func(mdi, sym);
+}
+

--- a/arch/i386/mcount-support.c
+++ b/arch/i386/mcount-support.c
@@ -1,0 +1,242 @@
+/*
+ * basic i386 support for uftrace
+ *
+ * Copyright (C) 2017. Hanbum Park <kese111@gmail.com>
+ *
+ * Released under the GPL v2.
+ */
+
+#include <assert.h>
+#include <string.h>
+#include <gelf.h>
+#include <sys/mman.h>
+
+/* This should be defined before #include "utils.h" */
+#define PR_FMT     "mcount"
+#define PR_DOMAIN  DBG_MCOUNT
+
+// a max number that retrieves the stack to find the location of 
+// the real return address of the main function for i386.
+#define MAX_SEARCH_STACK 5
+
+#include "libmcount/internal.h"
+#include "utils/filter.h"
+
+static bool search_main_ret = false;
+
+int mcount_get_register_arg(struct mcount_arg_context *ctx, 
+                            struct uftrace_arg_spec *spec)
+{
+	struct mcount_regs *regs = ctx->regs;
+	int reg_idx;
+
+	switch (spec->type) {
+	case ARG_TYPE_REG:
+		reg_idx = spec->reg_idx;
+		break;
+	default:
+		return -1; 
+	}
+
+	switch (reg_idx) {
+	case X86_REG_ECX:
+		ctx->val.i = ARG_REG1(regs);
+		break;
+	case X86_REG_EDX:
+		ctx->val.i = ARG_REG2(regs);
+		break;
+	case X86_REG_XMM0:
+		asm volatile ("movsd %%xmm0, %0\n" : "=m" (ctx->val.v));
+		break;
+	case X86_REG_XMM1:
+		asm volatile ("movsd %%xmm1, %0\n" : "=m" (ctx->val.v));
+		break;
+	case X86_REG_XMM2:
+		asm volatile ("movsd %%xmm2, %0\n" : "=m" (ctx->val.v));
+		break;
+	case X86_REG_XMM3:
+		asm volatile ("movsd %%xmm3, %0\n" : "=m" (ctx->val.v));
+		break;
+	case X86_REG_XMM4:
+		asm volatile ("movsd %%xmm4, %0\n" : "=m" (ctx->val.v));
+		break;
+	case X86_REG_XMM5:
+		asm volatile ("movsd %%xmm5, %0\n" : "=m" (ctx->val.v));
+		break;
+	case X86_REG_XMM6:
+		asm volatile ("movsd %%xmm6, %0\n" : "=m" (ctx->val.v));
+		break;
+	case X86_REG_XMM7:
+		asm volatile ("movsd %%xmm7, %0\n" : "=m" (ctx->val.v));
+		break;
+	default:
+		/* should not reach here */
+		pr_err_ns("invalid register access for arguments\n");
+		break;
+	}
+
+	return 0;
+}
+
+void mcount_get_stack_arg(struct mcount_arg_context *ctx,
+                        struct uftrace_arg_spec *spec)
+{
+	int offset;
+
+	switch (spec->type) {
+	case ARG_TYPE_STACK:
+		offset = spec->stack_ofs;
+		break;
+	case ARG_TYPE_INDEX:
+		offset = spec->idx;
+		break;
+	case ARG_TYPE_FLOAT:
+		offset = spec->idx;
+		break;
+	default:
+		/* should not reach here */
+		pr_err_ns("invalid stack access for arguments\n");
+		break;
+	}
+
+	if (offset < 1 || offset > 100)
+		pr_dbg("invalid stack offset: %d\n", offset);
+
+	memcpy(ctx->val.v, ctx->stack_base + offset, spec->size);
+}
+
+void mcount_arch_get_arg(struct mcount_arg_context *ctx,
+			 struct uftrace_arg_spec *spec)
+{
+	if (mcount_get_register_arg(ctx, spec) < 0)
+		mcount_get_stack_arg(ctx, spec);
+}
+
+void mcount_arch_get_retval(struct mcount_arg_context *ctx,
+			    struct uftrace_arg_spec *spec)
+{
+	/* type of return value cannot be FLOAT, so check format instead */
+	if (spec->fmt != ARG_FMT_FLOAT)
+		memcpy(ctx->val.v, ctx->retval, spec->size);
+	else if (spec->size == 4)  
+		asm volatile ("fstps %0\n\tflds %0" : "=m" (ctx->val.v));
+	else if (spec->size == 8)
+		asm volatile ("fstpl %0\n\tfldl %0" : "=m" (ctx->val.v));
+	else if (spec->size == 10)
+		asm volatile ("fstpt %0\n\tfldt %0" : "=m" (ctx->val.v));
+}
+
+void mcount_save_arch_context(struct mcount_arch_context *ctx)
+{
+	asm volatile ("movsd %%xmm0, %0\n" : "=m" (ctx->xmm[0]));
+	asm volatile ("movsd %%xmm1, %0\n" : "=m" (ctx->xmm[1]));
+	asm volatile ("movsd %%xmm2, %0\n" : "=m" (ctx->xmm[2]));
+	asm volatile ("movsd %%xmm3, %0\n" : "=m" (ctx->xmm[3]));
+	asm volatile ("movsd %%xmm4, %0\n" : "=m" (ctx->xmm[4]));
+	asm volatile ("movsd %%xmm5, %0\n" : "=m" (ctx->xmm[5]));
+	asm volatile ("movsd %%xmm6, %0\n" : "=m" (ctx->xmm[6]));
+	asm volatile ("movsd %%xmm7, %0\n" : "=m" (ctx->xmm[7]));
+}
+
+void mcount_restore_arch_context(struct mcount_arch_context *ctx)
+{
+	asm volatile ("movsd %0, %%xmm0\n" :: "m" (ctx->xmm[0]));
+	asm volatile ("movsd %0, %%xmm1\n" :: "m" (ctx->xmm[1]));
+	asm volatile ("movsd %0, %%xmm2\n" :: "m" (ctx->xmm[2]));
+	asm volatile ("movsd %0, %%xmm3\n" :: "m" (ctx->xmm[3]));
+	asm volatile ("movsd %0, %%xmm4\n" :: "m" (ctx->xmm[4]));
+	asm volatile ("movsd %0, %%xmm5\n" :: "m" (ctx->xmm[5]));
+	asm volatile ("movsd %0, %%xmm6\n" :: "m" (ctx->xmm[6]));
+	asm volatile ("movsd %0, %%xmm7\n" :: "m" (ctx->xmm[7]));
+}
+
+/*
+	For 16-byte stack-alignment, 
+	the main function stores the return address in its stack scope at prologue.
+	When the time comes for the main function to return,
+	1. restore the saved return address from stack.
+	2. After cleaning up the stack.
+	3. Put the return address at the top of the stack and return.
+	4. will be returned.
+
+	080485f8 <main>:
+	80485f8: 8d 4c 24 04           lea    0x4(%esp),%ecx
+	80485fc: 83 e4 f0              and    $0xfffffff0,%esp
+	80485ff: ff 71 fc              pushl  -0x4(%ecx)
+	8048602: 55                    push   %ebp
+	8048603: 89 e5                 mov    %esp,%ebp
+	8048605: 51                    push   %ecx
+	8048606: 83 ec 14              sub    $0x14,%esp
+	8048609: e8 02 fe ff ff        call   8048410 <mcount@plt>
+
+	... ... 
+
+	8048645: 8b 4d fc              mov    -0x4(%ebp),%ecx
+	8048648: c9                    leave
+	8048649: 8d 61 fc              lea    -0x4(%ecx),%esp
+	804864c: c3                    ret
+
+	So, in this case. The return address we want to replace with 
+	mcount_exit is in the stack scope of the main function. 
+	Non a parent located. 
+
+	we search stack for that address. 
+	we will look for it.
+	we will find it, and we will replace it. 
+	GOOD LUCK!
+*/
+unsigned long *mcount_arch_parent_location(struct symtabs *symtabs,
+                                            unsigned long *parent_loc, 
+                                            unsigned long child_ip)
+{
+	if (!search_main_ret) {
+		struct sym *parent_sym, *child_sym;
+		char *parent_name, *child_name;
+
+		const char *find_main[] = {
+			"__libc_start_main",
+			"main"
+		};
+		unsigned long ret_addr;
+		unsigned long search_ret_addr;
+
+		ret_addr = *parent_loc;
+		parent_sym = find_symtabs(symtabs, ret_addr);
+		parent_name = symbol_getname(parent_sym, ret_addr);
+		child_sym = find_symtabs(symtabs, child_ip);
+		child_name = symbol_getname(child_sym, child_ip);
+
+		// Assuming that this happens only in main..			
+		bool found_main_ret = false;
+		if (!(strcmp(find_main[0], parent_name) || 
+		      strcmp(find_main[1], child_name))) {
+			ret_addr = *parent_loc;
+			for (int i = 1; i < MAX_SEARCH_STACK; i++ ) {
+				search_ret_addr = *(unsigned long *)(parent_loc + i);
+				if (search_ret_addr == ret_addr) {
+					parent_loc = parent_loc+i;
+					found_main_ret = true;
+				}
+			}
+			// if we couldn't found correct position of return address,
+			// maybe this approach is not available anymore.
+			if (!found_main_ret) {
+				pr_dbg2("cannot find ret address of main\n");
+			}
+			search_main_ret = true;
+		}
+	}
+	return parent_loc;
+}
+
+// in i386, the idx value is set to a multiple of 8 unlike other.
+unsigned long mcount_arch_child_idx(unsigned long child_idx)
+{
+	if (child_idx > 0) {
+		if (child_idx % 8) {
+			pr_err_ns("the malformed child idx : %lx\n", child_idx);
+		}
+		child_idx = child_idx / 8;
+	}
+	return child_idx;
+}

--- a/arch/i386/mcount.S
+++ b/arch/i386/mcount.S
@@ -1,0 +1,52 @@
+/* in i386, generally used stack for argument passing. */
+/* use register for return : %eax */
+/* no need save registers */
+/* stack frame (with -pg): parent addr = 4(%ebp) */
+/* child addr = (%esp) */
+
+#include "utils/asm.h"
+
+GLOBAL(mcount)
+	sub $32, %esp
+	/* save registers */
+	movl %edx, 28(%esp)
+	movl %ecx, 24(%esp)	
+	movl %eax, 20(%esp)
+	movl $0, 16(%esp)
+	/* parent location */
+	leal 4(%ebp), %eax
+	movl %eax, 0(%esp)
+	/* child addr */
+	movl 32(%esp), %eax
+	movl %eax, 4(%esp)
+	/*  mcount_regs */
+	leal 16(%esp), %eax
+	movl %eax, 8(%esp)
+
+	call mcount_entry
+
+	/* restore registers */
+	movl 20(%esp), %eax
+	movl 24(%esp), %ecx
+	movl 28(%esp), %edx
+	add $32, %esp
+	ret
+END(mcount)
+
+
+ENTRY(mcount_return)
+	sub $16, %esp
+	movl %edx, 8(%esp)
+	movl %eax, 4(%esp)
+	leal 4(%esp), %eax
+	movl %eax, 0(%esp)
+
+	/* returns original parent address */
+	call mcount_exit
+	movl %eax, 12(%esp)
+
+	movl 4(%esp), %eax
+	movl 8(%esp), %edx
+	add $12, %esp
+	ret
+END(mcount_return)

--- a/arch/i386/plthook.S
+++ b/arch/i386/plthook.S
@@ -1,0 +1,65 @@
+#include "utils/asm.h"
+
+.hidden plthook_resolver_addr
+
+ENTRY(plt_hooker)
+	sub $32, %esp
+	/* save registers */
+	movl %edx, 24(%esp)
+	movl %ecx, 20(%esp)
+	/* this is for ARG1 that using in jmp */
+	movl 44(%esp), %eax
+	movl %eax, 16(%esp)
+
+	/* stack address contain parent location */
+	leal 40(%esp), %eax
+	movl %eax, 0(%esp)
+
+	/* child_idx */
+	movl 36(%esp), %eax
+	movl %eax, 4(%esp)
+	
+	/* module_id */
+	movl 32(%esp), %eax
+	movl %eax, 8(%esp)
+
+	/* mcount_args */
+	leal 16(%esp), %eax
+	movl %eax, 12(%esp)
+
+	call plthook_entry
+
+	/* restore registers */
+	movl 20(%esp), %ecx
+	movl 24(%esp), %edx
+	add $32, %esp
+
+	cmpl $0, %eax
+	jnz 1f
+	/* get address of plthook_resolver_addr */
+	call __x86.get_pc_thunk.ax
+	addl $_GLOBAL_OFFSET_TABLE_, %eax
+	leal plthook_resolver_addr@GOTOFF(%eax), %eax
+	movl (%eax), %eax
+	jmp *%eax
+1:
+	add $8, %esp
+	jmp *%eax
+END(plt_hooker)
+
+
+ENTRY(plthook_return)
+	sub $16, %esp
+	movl %edx, 8(%esp)
+	movl %eax, 4(%esp)
+	leal 4(%esp), %eax
+	movl %eax, 0(%esp)
+
+	call plthook_exit
+	movl %eax, 12(%esp)
+
+	movl 4(%esp), %eax
+	movl 8(%esp), %edx
+	add $12, %esp
+	ret
+END(plthook_return)

--- a/arch/i386/regs.c
+++ b/arch/i386/regs.c
@@ -1,0 +1,29 @@
+#include "mcount-arch.h"
+#include "utils/utils.h"
+
+struct x86_reg_table {
+	const char		*name;
+	enum x86_reg_index	idx;
+} reg_table[] = {
+
+#define X86_REG(_r)  { #_r, X86_REG_##_r }
+
+	/* integer registers */
+	X86_REG(ECX), X86_REG(EDX),
+	/* floating-point registers */
+	X86_REG(XMM0), X86_REG(XMM1), X86_REG(XMM2), X86_REG(XMM3),
+	X86_REG(XMM4), X86_REG(XMM5), X86_REG(XMM6), X86_REG(XMM7),
+
+#undef X86_REG
+};
+
+int arch_register_index(char *reg_name)
+{
+	unsigned i;
+
+	for (i = 0; i < ARRAY_SIZE(reg_table); i++) {
+		if (!strcasecmp(reg_name, reg_table[i].name))
+			return reg_table[i].idx;
+	}
+	return -1;
+}

--- a/cmd-record.c
+++ b/cmd-record.c
@@ -1404,7 +1404,7 @@ static void check_binary(struct opts *opts)
 	uint16_t e_type;
 	uint16_t e_machine;
 	uint16_t supported_machines[] = {
-		EM_X86_64, EM_ARM, EM_AARCH64,
+		EM_X86_64, EM_ARM, EM_AARCH64, EM_386
 	};
 
 	pr_dbg3("checking binary %s\n", opts->exename);

--- a/utils/compiler.h
+++ b/utils/compiler.h
@@ -3,6 +3,13 @@
 
 #define compiler_barrier()	asm volatile("" :::"memory")
 
+#if defined(__i386__)
+# define cpu_relax()		asm volatile("rep; nop" ::: "memory")
+# define full_memory_barrier()	asm volatile("mfence" ::: "memory")
+# define read_memory_barrier()  asm volatile("lfence" ::: "memory")
+# define write_memory_barrier()	asm volatile("sfence" ::: "memory")
+#endif
+
 #if defined(__x86_64__)
 # define cpu_relax()		asm volatile("rep; nop" ::: "memory")
 # define full_memory_barrier()	asm volatile("mfence" ::: "memory")

--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -598,6 +598,9 @@ int load_elf_dynsymtab(struct symtab *dsymtab, Elf *elf,
 	else if (ehdr.e_machine == EM_AARCH64) {
 		plt_addr += 16;    /* AARCH64 PLT0 size is 32 */
 	}
+	else if (ehdr.e_machine == EM_386) {
+		plt_entsize += 12;
+	}
 
 	prev_addr = plt_addr;
 


### PR DESCRIPTION
this "PR" is splitted part from "support-i386".
this "PR" contain support i386 for uftrace.

first commit:
```
arch/i386: add basic support for i386 architecture

support fentry, mcount instrumentation feature for i386.
not support dynamic trace and xray yet.

add "mcount_arch_child_idx" function for i386 architecture.
in i386, child_idx is a multiple of 8 unlike other architecture.
therefore, child_idx must be divided by 8 to match the symbol order.
```
second commit:
```
arch/i386: support dynamic tracing.

support dynamic trace feature for i386.
In case of gcc which is not patched because of old version,
it may not create 5 byte nop.
however, when meet case like that,
dynamic trace does not proceed anymore.
so, there is no need to worry.

and in i386, it is not possible to refer to instruction pointer register.
therefore changed a trampoline to following:
=====================================
call 0x5
pop eax
jmp dword ptr [eax + 4]
=====================================
first call instruction point next line of assembly "pop eax".
it is work well.
```
