### PR TITLE
doc: Fix tabs to white spaces of `arg.py` example

### DIFF
--- a/doc/uftrace-script.md
+++ b/doc/uftrace-script.md
@@ -137,10 +137,10 @@ Also script can have options for record if it requires some form of data (i.e. f
     #
     def uftrace_entry(ctx):
         if "args" in ctx:
-	    print(ctx["name"] + " has args")
+            print(ctx["name"] + " has args")
     def uftrace_exit(ctx):
         if "retval" in ctx:
-	    print(ctx["name"] + " has retval")
+            print(ctx["name"] + " has retval")
 
     $ uftrace record -S arg.py abc
     a has args


### PR DESCRIPTION
Fix discussed on #240
 
### the commit message
The example python script, `arg.py`, in the EXAMPLES section was
written using tabs, not white spaces, to indent the code lines,
rendered a wrong man page. This may occur an error if who follow that
as it was.

Now we can see the correct man page like this:

    $ man uftrace-script
    ...
    EXAMPLES
    ...
            $ cat arg.py
            #
            # uftrace-option: -A a@arg1 -R b@retval
            #
            def uftrace_entry(ctx):
                if "args" in ctx:
                    print(ctx["name"] + " has args")
            def uftrace_exit(ctx):
                if "retval" in ctx:
                    print(ctx["name"] + " has retval")
    ...

Signed-off-by: Hansuk Hong <flavono123@gmail.com>