### PR TITLE
doc: Add more packages in quick install guide

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,9 @@ QUICK GUIDE
 On Ubuntu machines, following commands will build and install uftrace from
 source.
 
-    $ sudo apt-get install libelf-dev
+    $ sudo apt-get install libelf-dev           # mandatory
+    $ sudo apt-get install pandoc               # for man pages (optional)
+    $ sudo apt-get install libpython2.7-dev     # for python scripting (optional)
     $ make
     $ sudo make install
 


### PR DESCRIPTION
I think many people just want to read quick guide for installtion but
pandoc is not written there.  Some people may have problems finding
uftrace man pages.

So it'd be better to provide a very simple command for pandoc
installation in the quick install guide page.

Likewise, it also adds libpython2.7-dev installation command.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>