### PR TITLE
script: Add trace-memcpy.py script for memcpy info

### DIFF
--- a/scripts/trace-memcpy.py
+++ b/scripts/trace-memcpy.py
@@ -1,0 +1,30 @@
+#
+# trace-memcpy.py
+#
+# uftrace-option: --nest-libcall -T memcpy@filter,arg3
+#
+#   void *memcpy(void *dest, const void *src, size_t n);
+#
+
+# Only "memcpy" calls this script and other functions never.
+UFTRACE_FUNC = [ "memcpy" ]
+
+count = 0
+total_bytes = 0
+
+def uftrace_begin():
+    pass
+
+def uftrace_entry(ctx):
+    global count
+    global total_bytes
+    count += 1
+    total_bytes += ctx["args"][0]
+
+def uftrace_exit(ctx):
+    pass
+
+def uftrace_end():
+    global total_bytes
+    print("%d times memcpy called" % count)
+    print("%d bytes copied" % total_bytes)


### PR DESCRIPTION
trace-memcpy.py example traces only memcpy() call and calculate how
many times memcpy is called and how much bytes are copied in total.

The usage and output looks as follows:

    $ uftrace script -S scripts/trace-memcpy.py --record /bin/ls scripts/
    count.py
    trace-memcpy.py
    replay.py
    simple.py
    9 times memcpy called
    183 bytes copied

The last two lines are printed by trace-memcpy.py

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>