### PR TITLE
utils: Adjust the logic removing old directory

### DIFF
--- a/utils/utils.c
+++ b/utils/utils.c
@@ -176,16 +176,16 @@ int create_directory(char *dirname)
 
 	xasprintf(&oldname, "%s.old", dirname);
 
-	if (!access(oldname, F_OK)) {
-		if (remove_directory(oldname) < 0) {
+	if (!access(dirname, F_OK)) {
+		if (!access(oldname, F_OK) && remove_directory(oldname) < 0) {
 			pr_warn("removing old directory failed: %m\n");
 			goto out;
 		}
-	}
 
-	if (!access(dirname, F_OK) && rename(dirname, oldname) < 0) {
-		pr_warn("rename %s -> %s failed: %m\n", dirname, oldname);
-		goto out;
+		if (rename(dirname, oldname) < 0) {
+			pr_warn("rename %s -> %s failed: %m\n", dirname, oldname);
+			goto out;
+		}
 	}
 
 	ret = mkdir(dirname, 0755);


### PR DESCRIPTION
When there is only a 'uftrace.data.old',
```
  $ ls
  hello  uftrace.data.old
```
if recording, innocent old directory can be eliminated.

```
  $ uftrace record hello
  $ ls
  hello  uftrace.data
```
So I change the logic removing old directory.