### PR TITLE
graph: Add a 'graph-only' option

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -94,6 +94,7 @@ enum options {
 	OPT_nest_libcall,
 	OPT_record,
 	OPT_auto_args,
+	OPT_graph_only,
 };
 
 static struct argp_option uftrace_options[] = {
@@ -164,6 +165,7 @@ static struct argp_option uftrace_options[] = {
 	{ "nest-libcall", OPT_nest_libcall, 0, 0, "Show nested library calls" },
 	{ "record", OPT_record, 0, 0, "Record a new trace data before running command" },
 	{ "auto-args", OPT_auto_args, 0, 0, "Show arguments and return value of known functions" },
+	{ "graph-only", OPT_graph_only, 0, 0, "Show only function call graph" },
 	{ 0 }
 };
 
@@ -700,6 +702,10 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 
 	case OPT_auto_args:
 		opts->auto_args = true;
+		break;
+
+	case OPT_graph_only:
+		opts->graph_only = true;
 		break;
 
 	case ARGP_KEY_ARG:

--- a/uftrace.h
+++ b/uftrace.h
@@ -241,6 +241,7 @@ struct opts {
 	bool nest_libcall;
 	bool record;
 	bool auto_args;
+	bool graph_only;
 	struct uftrace_time_range range;
 };
 


### PR DESCRIPTION
This option show only function call graph
hiding time durations and backtrace like below:

```
  $ uftrace graph --graph-only main
  # Function Call Graph for 'main' (session: b2c29cdfe1d7387f)
  ========== FUNCTION CALL GRAPH ==========
  (1) main
   +-(1) printf
   |
   +-(1) fflush
```
It was mentioned in #185 