### PR TITLE
doc: Fix '[<function>]' that is invisible

### DIFF
--- a/doc/uftrace-graph.md
+++ b/doc/uftrace-graph.md
@@ -9,7 +9,7 @@ uftrace-graph - Show function call graph
 
 SYNOPSIS
 ========
-uftrace graph [*options*] [<function>]
+uftrace graph [*options*] [*FUNCTION*]
 
 
 DESCRIPTION


### PR DESCRIPTION
Change [\<function\>] -> [*FUNC*]

Because of '<>' on markdown, it disappears
on the 'graph' man page and github man page.

Here:
![screenshot from 2017-11-27 13-49-11](https://user-images.githubusercontent.com/3875235/33251417-ccbf5ef2-d379-11e7-94aa-2aaf3db58265.png)

Here:
```
$ man uftrace graph
...
UFTRACE-GRAPH(1)                                            UFTRACE-GRAPH(1)

NAME
       uftrace-graph - Show function call graph

SYNOPSIS
       uftrace graph [options] []
...
```
So, fix it.