### PR TITLE
script: Fix to add global keyword to count variable

### DIFF
--- a/scripts/trace-memcpy.py
+++ b/scripts/trace-memcpy.py
@@ -25,6 +25,7 @@ def uftrace_exit(ctx):
     pass
 
 def uftrace_end():
+    global count
     global total_bytes
     print("%d times memcpy called" % count)
     print("%d bytes copied" % total_bytes)


### PR DESCRIPTION
The keyword "global" was missing for "count" variable in uftrace_end
function so this patch fixes it.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>