### PR TITLE
replay: Adjust TID space for tid more than 6 digits

### DIFF
--- a/cmd-replay.c
+++ b/cmd-replay.c
@@ -59,7 +59,7 @@ static void print_duration(struct ftrace_task_handle *task,
 static void print_tid(struct ftrace_task_handle *task,
 		      struct fstack *fstack, void *arg)
 {
-	pr_out("[%5d]", task->tid);
+	pr_out("[%6d]", task->tid);
 }
 
 static void print_addr(struct ftrace_task_handle *task,
@@ -114,8 +114,8 @@ static struct replay_field field_duration = {
 static struct replay_field field_tid = {
 	.id      = REPLAY_F_TID,
 	.name    = "tid",
-	.header  = "  TID  ",
-	.length  = 7,
+	.header  = "   TID  ",
+	.length  = 8,
 	.print   = print_tid,
 	.list    = LIST_HEAD_INIT(field_tid.list),
 };


### PR DESCRIPTION
Some systems are running for a long time and it creates tid more than
6 digits.  In this case, the alignment is a bit broken so this fixes the
problem by giving more spaces for TID field.

Before:
```
  $ uftrace -D 2 tests/t-abc
  # DURATION    TID     FUNCTION
     1.627 us [142664] | __monstartup();
     0.913 us [142664] | __cxa_atexit();
              [142664] | main() {
     1.536 us [142664] |   a();
     2.670 us [142664] | } /* main */
```
After:
```
  $ uftrace -D 2 tests/t-abc
  # DURATION     TID     FUNCTION
     1.627 us [142664] | __monstartup();
     0.913 us [142664] | __cxa_atexit();
              [142664] | main() {
     1.536 us [142664] |   a();
     2.670 us [142664] | } /* main */
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>