### PR TITLE
script: Fix thread-safety issue in python interpreter execution

### DIFF
--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -761,8 +761,12 @@ unsigned long plthook_entry(unsigned long *ret_addr, unsigned long child_idx,
 		if (mtdp == NULL)
 			goto out;
 	}
-	else
+	else {
+		if (unlikely(mtdp->recursion_guard))
+			goto out;
+
 		mtdp->recursion_guard = true;
+	}
 
 	recursion = false;
 

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -873,7 +873,10 @@ unsigned long plthook_exit(long *retval)
 	mtdp->recursion_guard = true;
 
 again:
-	rstack = &mtdp->rstack[mtdp->idx - 1];
+	if (likely(mtdp->idx > 0))
+		rstack = &mtdp->rstack[mtdp->idx - 1];
+	else
+		rstack = restore_vfork(mtdp, NULL);  /* FIXME! */
 
 	if (unlikely(rstack->flags & (MCOUNT_FL_LONGJMP | MCOUNT_FL_VFORK))) {
 		if (rstack->flags & MCOUNT_FL_LONGJMP) {

--- a/scripts/replay.py
+++ b/scripts/replay.py
@@ -1,5 +1,5 @@
 def uftrace_begin():
-    print("# DURATION    TID     FUNCTION")
+    print("# DURATION     TID     FUNCTION")
 
 def uftrace_entry(ctx):
     # read arguments
@@ -10,7 +10,7 @@ def uftrace_entry(ctx):
     indent = _depth * 2
     space = " " * indent
 
-    buf = " %10s [%5d] | %s%s() {" % ("", _tid, space, _symname)
+    buf = " %10s [%6d] | %s%s() {" % ("", _tid, space, _symname)
     print(buf)
 
 def uftrace_exit(ctx):
@@ -24,7 +24,7 @@ def uftrace_exit(ctx):
     space = " " * indent
 
     (time, unit) = get_time_and_unit(_duration)
-    buf = " %7.3f %s [%5d] | %s}" % (time, unit, _tid, space)
+    buf = " %7.3f %s [%6d] | %s}" % (time, unit, _tid, space)
     buf = "%s /* %s */" % (buf, _symname)
     print(buf)
 

--- a/scripts/report-libcall.py
+++ b/scripts/report-libcall.py
@@ -1,0 +1,37 @@
+#
+# report-libcall.py
+#
+# uftrace-option: --nest-libcall -F .*@plt
+#
+
+import os
+
+libcall_map = {}
+
+def uftrace_begin():
+    pass
+
+def uftrace_entry(ctx):
+    _name = ctx["name"]
+    if libcall_map.has_key(_name):
+        libcall_map[_name] += 1
+    else:
+        libcall_map[_name] = 1
+
+def uftrace_exit(ctx):
+    pass
+
+def uftrace_end():
+    global libcall_map
+    sorted_dict = sorted(libcall_map.iteritems(), key=lambda (k, v): (v, k), reverse=True)
+
+    pid = os.getpid()
+    with open("/proc/%s/comm" % pid) as proc_comm:
+        comm = proc_comm.read()[:-1]
+        print("  # Library Function Call Report for '%s' (pid: %d)\n" % (comm, pid))
+
+    print("  %15s    %-#50s" % ("Call Count", "Library Functions"))
+    print("  ================  ================================================")
+    for item in sorted_dict:
+        print("  %15d    %-#50s" % (item[1], item[0]))
+    print("\n")

--- a/utils/script-python.c
+++ b/utils/script-python.c
@@ -139,11 +139,13 @@ static int set_python_path(char *py_pathname)
 static int import_python_module(char *py_pathname)
 {
 	PyObject *pName;
-	char *py_basename = basename(py_pathname);
+	char *py_basename = xstrdup(basename(py_pathname));
 
 	remove_py_suffix(py_basename);
 
 	pName = __PyString_FromString(py_basename);
+	free(py_basename);
+
 	pModule = __PyImport_Import(pName);
 	if (pModule == NULL) {
 		__PyErr_Print();

--- a/utils/script-python.c
+++ b/utils/script-python.c
@@ -115,6 +115,8 @@ static int set_python_path(char *py_pathname)
 	char *old_sysdir = getenv("PYTHONPATH");
 	char *new_sysdir = NULL;
 
+	pr_dbg2("%s(\"%s\")\n", __func__, py_pathname);
+
 	if (absolute_dirname(py_pathname, py_sysdir) == NULL)
 		return -1;
 
@@ -129,7 +131,7 @@ static int set_python_path(char *py_pathname)
 	return 0;
 }
 
-/* Import python module that is given by -p option. */
+/* Import python module that is given by -S option. */
 static int import_python_module(char *py_pathname)
 {
 	PyObject *pName;
@@ -141,7 +143,7 @@ static int import_python_module(char *py_pathname)
 	pModule = __PyImport_Import(pName);
 	if (pModule == NULL) {
 		__PyErr_Print();
-		pr_warn("%s.py cannot be imported!\n", py_pathname);
+		pr_warn("\"%s\" cannot be imported!\n", py_pathname);
 		return -1;
 	}
 
@@ -149,6 +151,8 @@ static int import_python_module(char *py_pathname)
 
 	/* import sys by default */
 	__PyRun_SimpleStringFlags("import sys", NULL);
+
+	pr_dbg("python module \"%s\" is imported.\n", py_pathname);
 
 	return 0;
 }
@@ -489,6 +493,8 @@ int python_uftrace_end(void)
 	if (unlikely(!pFuncEnd))
 		return -1;
 
+	pr_dbg("%s()\n", __func__);
+
 	/* Call python function "uftrace_end". */
 	__PyObject_CallObject(pFuncEnd, NULL);
 
@@ -497,7 +503,8 @@ int python_uftrace_end(void)
 
 int python_atfork_prepare(void)
 {
-	pr_dbg("flush python buffer");
+	pr_dbg("flush python buffer in %s()\n", __func__);
+
 	__PyRun_SimpleStringFlags("sys.stdout.flush()", NULL);
 
 	return 0;
@@ -505,7 +512,7 @@ int python_atfork_prepare(void)
 
 int script_init_for_python(char *py_pathname)
 {
-	pr_dbg("initialize python scripting engine for %s\n", py_pathname);
+	pr_dbg("%s(\"%s\")\n", __func__, py_pathname);
 
 	/* Bind script_uftrace functions to python's. */
 	script_uftrace_entry = python_uftrace_entry;
@@ -610,6 +617,8 @@ int script_init_for_python(char *py_pathname)
 
 void script_finish_for_python(void)
 {
+	pr_dbg("%s()\n", __func__);
+
 	__Py_Finalize();
 }
 

--- a/utils/script.c
+++ b/utils/script.c
@@ -107,6 +107,7 @@ void script_finish_filter(void)
 
 int script_init(char *script_pathname)
 {
+	pr_dbg2("%s(\"%s\")\n", __func__, script_pathname);
 	if (access(script_pathname, F_OK) < 0) {
 		perror(script_pathname);
 		return -1;
@@ -133,6 +134,7 @@ int script_init(char *script_pathname)
 
 void script_finish(void)
 {
+	pr_dbg2("%s()\n", __func__);
 	switch (script_lang) {
 	case SCRIPT_PYTHON:
 		script_finish_for_python();


### PR DESCRIPTION
This PR is to fix thread-safety problem running python script in record time.

Before:
```
$ uftrace record -S ./scripts/replay.py tests/t-thread
# DURATION    TID     FUNCTION
            [30186] | main() {
            [30186] |   pthread_create() {
  35.314 us [30186] |   } /* pthread_create */
            [30186] |   pthread_create() {
  19.590 us [30186] |   } /* pthread_create */
            [30186] |   pthread_create() {
  96.816 us [30186] |   } /* pthread_create */
            [30186] |   pthread_create() {
process crashed by signal 11: Segmentation fault (si_code: 1)
            [30189] | foo() {
child terminated by signal: 11: Segmentation fault
```
After:
```
$ uftrace record -S ./scripts/replay.py tests/t-thread
# DURATION     TID     FUNCTION
            [ 29732] | main() {
            [ 29732] |   pthread_create() {
  29.533 us [ 29732] |   } /* pthread_create */
            [ 29732] |   pthread_create() {
 156.904 us [ 29732] |   } /* pthread_create */
            [ 29732] |   pthread_create() {
  66.442 us [ 29732] |   } /* pthread_create */
            [ 29732] |   pthread_create() {
            [ 29735] | foo() {
            [ 29735] |   a() {
            [ 29735] |     b() {
            [ 29737] | foo() {
            [ 29737] |   a() {
            [ 29737] |     b() {
            [ 29737] |       c() {
   5.265 us [ 29737] |       } /* c */
  21.862 us [ 29737] |     } /* b */
  35.246 us [ 29737] |   } /* a */
  81.177 us [ 29737] | } /* foo */
            [ 29738] | foo() {
            [ 29738] |   a() {
            [ 29738] |     b() {
            [ 29738] |       c() {
   6.112 us [ 29738] |       } /* c */
  25.124 us [ 29738] |     } /* b */
  40.623 us [ 29738] |   } /* a */
 141.049 us [ 29738] | } /* foo */
            [ 29736] | foo() {
            [ 29736] |   a() {
            [ 29736] |     b() {
            [ 29736] |       c() {
   3.384 us [ 29736] |       } /* c */
  14.555 us [ 29736] |     } /* b */
  23.793 us [ 29736] |   } /* a */
 230.809 us [ 29736] | } /* foo */
  20.810 us [ 29732] |   } /* pthread_create */
            [ 29732] |   pthread_join() {
            [ 29735] |       c() {
 252.246 us [ 29735] |       } /* c */
 269.668 us [ 29735] |     } /* b */
 285.085 us [ 29735] |   } /* a */
 327.011 us [ 29735] | } /* foo */
  75.777 us [ 29732] |   } /* pthread_join */
            [ 29732] |   pthread_join() {
   3.518 us [ 29732] |   } /* pthread_join */
            [ 29732] |   pthread_join() {
   4.658 us [ 29732] |   } /* pthread_join */
            [ 29732] |   pthread_join() {
   4.206 us [ 29732] |   } /* pthread_join */
 696.298 us [ 29732] | } /* main */
```