### PR TITLE
graph: Use -f/--output-fields to customize its output

### DIFF
--- a/cmd-graph.c
+++ b/cmd-graph.c
@@ -107,6 +107,7 @@ static void print_addr(struct field_data *fd)
 static struct display_field field_total_time= {
 	.id      = GRAPH_F_TOTAL_TIME,
 	.name    = "total-time",
+	.alias   = "total",
 	.header  = "TOTAL TIME",
 	.length  = 10,
 	.print   = print_total_time,
@@ -116,6 +117,7 @@ static struct display_field field_total_time= {
 static struct display_field field_self_time= {
 	.id      = GRAPH_F_SELF_TIME,
 	.name    = "self-time",
+	.alias   = "self",
 	.header  = " SELF TIME",
 	.length  = 10,
 	.print   = print_self_time,
@@ -124,7 +126,8 @@ static struct display_field field_self_time= {
 
 static struct display_field field_addr = {
 	.id      = GRAPH_F_ADDR,
-	.name    = "addr",
+	.name    = "address",
+	.alias   = "addr",
 #if __SIZEOF_LONG == 4
 	.header  = "  ADDR  ",
 	.length  = 8,

--- a/cmd-graph.c
+++ b/cmd-graph.c
@@ -154,11 +154,8 @@ static void print_field(struct graph_node *node)
 		.arg = (struct graph_node*)node,
 	};
 
-	if (!list_empty(&output_fields))
-		pr_out("  ");
-
-	if (print_field_data(&output_fields, &fd))
-		pr_out(": ");
+	if (print_field_data(&output_fields, &fd, 2))
+		pr_out(" : ");
 }
 
 static int create_graph(struct uftrace_session *sess, void *func)
@@ -598,8 +595,8 @@ static void print_graph_node(struct uftrace_graph *graph,
 
 		if (&child->list != node->head.prev) {
 			/* print blank line between siblings */
-			if (print_empty_field(&output_fields))
-				pr_out(": ");
+			if (print_empty_field(&output_fields, 2))
+				pr_out(" : ");
 			pr_indent(indent_mask, indent, false);
 			pr_out("\n");
 		}
@@ -632,7 +629,7 @@ static int print_graph(struct uftrace_graph *graph, struct opts *opts)
 
 	if (graph->root.time || graph->root.nr_edges) {
 		pr_out("========== FUNCTION CALL GRAPH ==========\n");
-		print_header(&output_fields, "# ");
+		print_header(&output_fields, "# ", 2);
 		indent_mask = xcalloc(opts->max_stack, sizeof(*indent_mask));
 		print_graph_node(graph, &graph->root, indent_mask, 0,
 				 graph->root.nr_edges > 1);

--- a/cmd-graph.c
+++ b/cmd-graph.c
@@ -10,7 +10,10 @@
 #include "utils/symbol.h"
 #include "utils/filter.h"
 #include "utils/fstack.h"
+#include "utils/field.h"
 
+
+static LIST_HEAD(output_fields);
 
 struct graph_backtrace {
 	struct list_head list;
@@ -70,6 +73,93 @@ struct task_graph {
 static bool full_graph = false;
 static struct rb_root tasks = RB_ROOT;
 static struct uftrace_graph *graph_list = NULL;
+
+static void print_total_time(struct field_data *fd)
+{
+	struct graph_node *node = (struct graph_node*)fd->arg;
+	uint64_t d;
+
+	d = node->time;
+
+	print_time_unit(d);
+}
+
+static void print_self_time(struct field_data *fd)
+{
+	struct graph_node *node = (struct graph_node*)fd->arg;
+	uint64_t d;
+
+	d = node->time - node->child_time;
+
+	print_time_unit(d);
+}
+
+static void print_addr(struct field_data *fd)
+{
+	struct graph_node *node = (struct graph_node*)fd->arg;
+
+	/* uftrace records (truncated) 48-bit addresses */
+	int width = sizeof(long) == 4 ? 8 : 12;
+
+	pr_out("%*lx", width, node->addr);
+}
+
+static struct display_field field_total_time= {
+	.id      = GRAPH_F_TOTAL_TIME,
+	.name    = "total-time",
+	.header  = "TOTAL TIME",
+	.length  = 10,
+	.print   = print_total_time,
+	.list    = LIST_HEAD_INIT(field_total_time.list),
+};
+
+static struct display_field field_self_time= {
+	.id      = GRAPH_F_SELF_TIME,
+	.name    = "self-time",
+	.header  = " SELF TIME",
+	.length  = 10,
+	.print   = print_self_time,
+	.list    = LIST_HEAD_INIT(field_self_time.list),
+};
+
+static struct display_field field_addr = {
+	.id      = GRAPH_F_ADDR,
+	.name    = "addr",
+#if __SIZEOF_LONG == 4
+	.header  = "  ADDR  ",
+	.length  = 8,
+#else
+	.header  = "   ADDRESS  ",
+	.length  = 12,
+#endif
+	.print   = print_addr,
+	.list    = LIST_HEAD_INIT(field_addr.list),
+};
+
+/* index of this table should be matched to display_field_id */
+static struct display_field *field_table[] = {
+	&field_total_time,
+	&field_self_time,
+	&field_addr,
+};
+
+static void setup_default_field(struct list_head *fields, struct opts *opts)
+{
+	add_field(fields, field_table[GRAPH_F_TOTAL_TIME]);
+}
+
+static void print_field(struct graph_node *node)
+{
+	struct field_data fd = {
+		.arg = (struct graph_node*)node,
+	};
+
+	if (!list_empty(&output_fields))
+		pr_out("  ");
+
+	if (print_field_data(&output_fields, &fd))
+		pr_out(": ");
+}
 
 static int create_graph(struct uftrace_session *sess, void *func)
 {
@@ -484,9 +574,7 @@ static void print_graph_node(struct uftrace_graph *graph,
 
 	symname = symbol_getname(sym, node->addr);
 
-	pr_out(" ");
-	print_time_unit(node->time);
-	pr_out(" : ");
+	print_field(node);
 	pr_indent(indent_mask, indent, needs_line);
 
 	if (full_graph && node == &graph->root)
@@ -510,7 +598,8 @@ static void print_graph_node(struct uftrace_graph *graph,
 
 		if (&child->list != node->head.prev) {
 			/* print blank line between siblings */
-			pr_out("%*s: ", 12, "");
+			if (print_empty_field(&output_fields))
+				pr_out(": ");
 			pr_indent(indent_mask, indent, false);
 			pr_out("\n");
 		}
@@ -539,8 +628,11 @@ static int print_graph(struct uftrace_graph *graph, struct opts *opts)
 		print_backtrace(graph);
 	}
 
+	setup_field(&output_fields, opts, &setup_default_field, field_table, ARRAY_SIZE(field_table));
+
 	if (graph->root.time || graph->root.nr_edges) {
 		pr_out("========== FUNCTION CALL GRAPH ==========\n");
+		print_header(&output_fields, "# ");
 		indent_mask = xcalloc(opts->max_stack, sizeof(*indent_mask));
 		print_graph_node(graph, &graph->root, indent_mask, 0,
 				 graph->root.nr_edges > 1);

--- a/cmd-replay.c
+++ b/cmd-replay.c
@@ -162,8 +162,9 @@ static void print_field(struct ftrace_task_handle *task,
 		.fstack = fstack,
 		.arg = arg,
 	};
-	if (print_field_data(&output_fields, &fd))
-		pr_out("| ");
+
+	if (print_field_data(&output_fields, &fd, 1))
+		pr_out(" | ");
 }
 
 static void setup_default_field(struct list_head *fields, struct opts *opts)
@@ -315,8 +316,8 @@ static int print_flat_rstack(struct ftrace_file_handle *handle,
 static void print_task_newline(int current_tid)
 {
 	if (prev_tid != -1 && current_tid != prev_tid) {
-		if (print_empty_field(&output_fields))
-			pr_out("| ");
+		if (print_empty_field(&output_fields, 1))
+			pr_out(" | ");
 		pr_out("\n");
 	}
 
@@ -783,8 +784,8 @@ out:
 
 static void print_warning(struct ftrace_task_handle *task)
 {
-	if (print_empty_field(&output_fields))
-		pr_out("| ");
+	if (print_empty_field(&output_fields, 1))
+		pr_out(" | ");
 	pr_red(" %*s/* inverted time: broken data? */\n",
 	       (task->display_depth + 1) * 2, "");
 }
@@ -902,7 +903,7 @@ int command_replay(int argc, char *argv[], struct opts *opts)
 		    field_table, ARRAY_SIZE(field_table));
 
 	if (!opts->flat && peek_rstack(&handle, &task) == 0)
-		print_header(&output_fields, "#");
+		print_header(&output_fields, "#", 1);
 
 	while (read_rstack(&handle, &task) == 0 && !uftrace_done) {
 		struct uftrace_record *rstack = task->rstack;

--- a/cmd-replay.c
+++ b/cmd-replay.c
@@ -902,7 +902,7 @@ int command_replay(int argc, char *argv[], struct opts *opts)
 		    field_table, ARRAY_SIZE(field_table));
 
 	if (!opts->flat && peek_rstack(&handle, &task) == 0)
-		print_header(&output_fields);
+		print_header(&output_fields, "#");
 
 	while (read_rstack(&handle, &task) == 0 && !uftrace_done) {
 		struct uftrace_record *rstack = task->rstack;

--- a/cmd-replay.c
+++ b/cmd-replay.c
@@ -163,7 +163,7 @@ static void print_field(struct ftrace_task_handle *task,
 		.arg = arg,
 	};
 	if (print_field_data(&output_fields, &fd))
-		pr_out("|");
+		pr_out("| ");
 }
 
 static void setup_field(struct opts *opts)
@@ -264,10 +264,10 @@ static void print_backtrace(struct ftrace_task_handle *task)
 			pr_out(" ");
 		}
 		if (!list_empty(&output_fields))
-			pr_out("|");
+			pr_out("| ");
 
 		name = symbol_getname(sym, fstack->addr);
-		pr_gray(" /* [%2d] %s */\n", i, name);
+		pr_gray("/* [%2d] %s */\n", i, name);
 		symbol_putname(sym, name);
 	}
 }
@@ -364,7 +364,7 @@ static void print_task_newline(int current_tid)
 {
 	if (prev_tid != -1 && current_tid != prev_tid) {
 		if (print_empty_field(&output_fields))
-			pr_out("|");
+			pr_out("| ");
 		pr_out("\n");
 	}
 
@@ -692,7 +692,7 @@ static int print_graph_rstack(struct ftrace_file_handle *handle,
 			get_argspec_string(task, retval, sizeof(retval), str_mode);
 
 			print_field(task, fstack, NULL);
-			pr_out(" %*s", depth * 2, "");
+			pr_out("%*s", depth * 2, "");
 			if (tr.flags & TRIGGER_FL_COLOR) {
 				pr_color(tr.color, "%s", symname);
 				pr_out("%s%s\n", args, retval);
@@ -707,7 +707,7 @@ static int print_graph_rstack(struct ftrace_file_handle *handle,
 		else {
 			/* function entry */
 			print_field(task, fstack, NO_TIME);
-			pr_out(" %*s", depth * 2, "");
+			pr_out("%*s", depth * 2, "");
 			if (tr.flags & TRIGGER_FL_COLOR) {
 				pr_color(tr.color, "%s", symname);
 				pr_out("%s {\n", args);
@@ -743,7 +743,7 @@ static int print_graph_rstack(struct ftrace_file_handle *handle,
 				print_task_newline(task->tid);
 
 			print_field(task, fstack, NULL);
-			pr_out(" %*s}%s", depth * 2, "", retval);
+			pr_out("%*s}%s", depth * 2, "", retval);
 			if (opts->comment)
 				pr_gray(" /* %s */\n", symname);
 			else
@@ -769,10 +769,10 @@ lost:
 		print_field(task, NULL, NO_TIME);
 
 		if (losts > 0)
-			pr_red(" %*s/* LOST %d records!! */\n",
+			pr_red("%*s/* LOST %d records!! */\n",
 			       depth * 2, "", losts);
 		else /* kernel sometimes have unknown count */
-			pr_red(" %*s/* LOST some records!! */\n",
+			pr_red("%*s/* LOST some records!! */\n",
 			       depth * 2, "");
 	}
 	else if (rstack->type == UFTRACE_EVENT) {
@@ -820,7 +820,7 @@ lost:
 		else
 			print_field(task, NULL, NO_TIME);
 
-		pr_color(task->event_color, " %*s/* ", depth * 2, "");
+		pr_color(task->event_color, "%*s/* ", depth * 2, "");
 		print_event(task, &rec, task->event_color);
 		pr_color(task->event_color, " */\n");
 	}
@@ -832,7 +832,7 @@ out:
 static void print_warning(struct ftrace_task_handle *task)
 {
 	if (print_empty_field(&output_fields))
-		pr_out("|");
+		pr_out("| ");
 	pr_red(" %*s/* inverted time: broken data? */\n",
 	       (task->display_depth + 1) * 2, "");
 }

--- a/cmd-replay.c
+++ b/cmd-replay.c
@@ -173,14 +173,15 @@ static void print_header(void)
 {
 	struct replay_field *field;
 
+	/* do not print anything if not needed */
+	if (list_empty(&output_fields))
+		return;
+
 	pr_out("#");
 	list_for_each_entry(field, &output_fields, list)
 		pr_out("%s ", field->header);
 
-	if (!list_empty(&output_fields))
-		pr_out(" ");
-
-	pr_out(" FUNCTION\n");
+	pr_out("  FUNCTION\n");
 }
 
 /* index of this table should be matched to replay_field_id */

--- a/cmd-replay.c
+++ b/cmd-replay.c
@@ -85,7 +85,7 @@ static void print_elapsed(struct field_data *fd)
 	print_time_unit(elapsed);
 }
 
-static struct replay_field field_duration = {
+static struct display_field field_duration = {
 	.id      = REPLAY_F_DURATION,
 	.name    = "duration",
 	.header  = " DURATION ",
@@ -94,7 +94,7 @@ static struct replay_field field_duration = {
 	.list    = LIST_HEAD_INIT(field_duration.list),
 };
 
-static struct replay_field field_tid = {
+static struct display_field field_tid = {
 	.id      = REPLAY_F_TID,
 	.name    = "tid",
 	.header  = "   TID  ",
@@ -103,7 +103,7 @@ static struct replay_field field_tid = {
 	.list    = LIST_HEAD_INIT(field_tid.list),
 };
 
-static struct replay_field field_addr = {
+static struct display_field field_addr = {
 	.id      = REPLAY_F_ADDR,
 	.name    = "addr",
 #if __SIZEOF_LONG == 4
@@ -117,7 +117,7 @@ static struct replay_field field_addr = {
 	.list    = LIST_HEAD_INIT(field_addr.list),
 };
 
-static struct replay_field field_time = {
+static struct display_field field_time = {
 	.id      = REPLAY_F_TIMESTAMP,
 	.name    = "time",
 	.header  = "     TIMESTAMP    ",
@@ -126,7 +126,7 @@ static struct replay_field field_time = {
 	.list    = LIST_HEAD_INIT(field_time.list),
 };
 
-static struct replay_field field_delta = {
+static struct display_field field_delta = {
 	.id      = REPLAY_F_TIMEDELTA,
 	.name    = "delta",
 	.header  = " TIMEDELTA",
@@ -135,7 +135,7 @@ static struct replay_field field_delta = {
 	.list    = LIST_HEAD_INIT(field_delta.list),
 };
 
-static struct replay_field field_elapsed = {
+static struct display_field field_elapsed = {
 	.id      = REPLAY_F_ELAPSED,
 	.name    = "elapsed",
 	.header  = "  ELAPSED ",
@@ -145,7 +145,7 @@ static struct replay_field field_elapsed = {
 };
 
 /* index of this table should be matched to replay_field_id */
-static struct replay_field *field_table[] = {
+static struct display_field *field_table[] = {
 	&field_duration,
 	&field_tid,
 	&field_addr,
@@ -168,7 +168,7 @@ static void print_field(struct ftrace_task_handle *task,
 
 static void setup_field(struct opts *opts)
 {
-	struct replay_field *field;
+	struct display_field *field;
 	unsigned i;
 	char *str, *p, *s;
 
@@ -243,7 +243,7 @@ static void print_backtrace(struct ftrace_task_handle *task)
 	int i;
 
 	for (i = 0; i < task->stack_count - 1; i++) {
-		struct replay_field *field;
+		struct display_field *field;
 		struct sym *sym;
 		char *name;
 		struct fstack *fstack = &task->func_stack[i];

--- a/doc/uftrace-graph.md
+++ b/doc/uftrace-graph.md
@@ -37,6 +37,9 @@ OPTIONS
 -D *DEPTH*, \--depth *DEPTH*
 :   Set trace limit in nesting level.
 
+-f *FIELD*, \--output-fields=*FIELD*
+:   Customize field in the output.  Possible values are: total, self and addr.  Multiple fields can be set by using comma.  Special field of 'none' can be used (solely) to hide all fields.  Default is 'total'.  See *FIELDS*.
+
 -r *RANGE*, \--time-range=*RANGE*
 :   Only show functions executed within the time RANGE.  The RANGE can be \<start\>~\<stop\> (separated by "~") and one of \<start\> and \<stop\> can be omitted.  The \<start\> and \<stop\> are timestamp or elapsed time if they have \<time_unit\> postfix, for example '100us'.  The timestamp or elapsed time can be shown with `-f time` or `-f elapsed` option respectively in `uftrace replay`(1).
 
@@ -95,12 +98,13 @@ Running the `graph` command on the `main` function shows called functions like b
        [0] main (0x4004f0)
     
     ========== FUNCTION CALL GRAPH ==========
-      10.293 ms : (1) main
-      46.626 us :  +-(2) foo
-      44.360 us :  | (6) loop
-                :  | 
-      10.138 ms :  +-(1) bar
-      10.100 ms :    (1) usleep
+    # TOTAL TIME   FUNCTION
+       10.293 ms : (1) main
+       46.626 us :  +-(2) foo
+       44.360 us :  | (6) loop
+                 :  | 
+       10.138 ms :  +-(1) bar
+       10.100 ms :    (1) usleep
 
 The left side shows total time running the function on the right side.  The number in parentheses before the function name is the invocation count.  As you can see, `main` was called once and ran around 10 msec.  It called `foo` twice and then `foo` called `loop` 6 times in total.  The time is the sum of all execution time of the function.
 
@@ -117,9 +121,49 @@ Running graph command on a leaf function looks like below.
        [2] loop (0x400f5f6)
     
     ========== FUNCTION CALL GRAPH ==========
-      44.360 us : (6) loop
+    # TOTAL TIME   FUNCTION
+       44.360 us : (6) loop
 
 The backtrace shows that loop is called from `foo` and that `foo` is called from `main`.  Since `loop` is a leaf function, it didn't call any other function.  In this case, `loop` was called only from a single path so backtrace #0 is hit 6 times.
+
+
+FIELDS
+======
+The uftrace allows for user to customize the graph output with some of fields.  Here the field means info on the left side of the colon (:) character.  By default it uses time only, but you can use other fields in any order like:
+
+    $ uftrace record tests/t-abc
+    $ uftrace graph -f total,self,addr
+    # Function Call Graph for 't-sort' (session: b007f4b7cf792878)
+    ========== FUNCTION CALL GRAPH ==========
+    # TOTAL TIME  SELF TIME      ADDRESS     FUNCTION
+       10.145 ms              561f652cd610 : (1) t-sort
+       10.145 ms   39.890 us  561f652cd610 : (1) main
+       16.773 us    0.734 us  561f652cd7ce :  +-(2) foo
+       16.039 us   16.039 us  561f652cd7a0 :  | (6) loop
+                                           :  |
+       10.088 ms   14.740 us  561f652cd802 :  +-(1) bar
+       10.073 ms   10.073 ms  561f652cd608 :    (1) usleep
+
+Each field has following meaning:
+
+ * total: function execution time in total
+ * self : function execution time excluding its children's
+ * addr : address of the function
+
+The default value is 'total'.  If given field name starts with "+", then it'll be appended to the default fields.  So "-f +addr" is as same as "-f total,addr".  And it also accepts a special field name of 'none' which disables the field display and shows function output only.
+
+    $ uftrace graph -f none
+    # Function Call Graph for 't-sort' (session: b007f4b7cf792878)
+    ========== FUNCTION CALL GRAPH ==========
+    (1) t-sort
+    (1) main
+     +-(2) foo
+     | (6) loop
+     |
+     +-(1) bar
+       (1) usleep
+
+This output can be useful when comparing two different call graph outputs using diff tool.
 
 
 SEE ALSO

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -229,7 +229,10 @@ class TestBase:
                 if ln.startswith('   ['):
                     result.append(ln.split('(')[0])  # remove '(addr)' part
             if mode == 2:
-                result.append(ln.split(':')[1])      # remove time part
+                if " : " in ln:
+                    result.append(ln.split(':')[1])  # remove time part
+                else:
+                    result.append(ln)
 
         return '\n'.join(result)
 

--- a/tests/t097_dump_basic.py
+++ b/tests/t097_dump_basic.py
@@ -52,5 +52,5 @@ reading 5231.dat
             result = result.replace("2 (64 bit)", "1 (32 bit)")
         p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
         if 'BuildID' not in p.communicate()[0].decode(errors='ignore'):
-            result = result.replace("0x3ff", "0x3fd")
+            result = result.replace("0xbff", "0xbfd")
         return result

--- a/tests/t098_dump_tid.py
+++ b/tests/t098_dump_tid.py
@@ -64,5 +64,5 @@ reading 5188.dat
             result = result.replace("2 (64 bit)", "1 (32 bit)")
         p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
         if 'BuildID' not in p.communicate()[0].decode(errors='ignore'):
-            result = result.replace("0x3ff", "0x3fd")
+            result = result.replace("0xbff", "0xbfd")
         return result

--- a/tests/t099_dump_filter.py
+++ b/tests/t099_dump_filter.py
@@ -44,5 +44,5 @@ reading 5231.dat
             result = result.replace("2 (64 bit)", "1 (32 bit)")
         p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
         if 'BuildID' not in p.communicate()[0].decode(errors='ignore'):
-            result = result.replace("0x3ff", "0x3fd")
+            result = result.replace("0xbff", "0xbfd")
         return result

--- a/tests/t100_dump_depth.py
+++ b/tests/t100_dump_depth.py
@@ -44,5 +44,5 @@ reading 5231.dat
             result = result.replace("2 (64 bit)", "1 (32 bit)")
         p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
         if 'BuildID' not in p.communicate()[0].decode(errors='ignore'):
-            result = result.replace("0x3ff", "0x3fd")
+            result = result.replace("0xbff", "0xbfd")
         return result

--- a/tests/t116_field_none.py
+++ b/tests/t116_field_none.py
@@ -5,8 +5,7 @@ from runtest import TestBase
 class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'abc',
-"""# FUNCTION
- main() {
+""" main() {
    a() {
      b() {
        c() {

--- a/tests/t116_field_none.py
+++ b/tests/t116_field_none.py
@@ -5,15 +5,15 @@ from runtest import TestBase
 class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'abc',
-""" main() {
-   a() {
-     b() {
-       c() {
-         getpid();
-       } /* c */
-     } /* b */
-   } /* a */
- } /* main */
+"""main() {
+  a() {
+    b() {
+      c() {
+        getpid();
+      } /* c */
+    } /* b */
+  } /* a */
+} /* main */
 """)
 
     def runcmd(self):

--- a/tests/t181_graph_full.py
+++ b/tests/t181_graph_full.py
@@ -4,6 +4,7 @@ from runtest import TestBase
 import subprocess as sp
 
 TDIR='xxx'
+NOFILTERS='-N __monstartup -N __cxa_atexit'
 
 class TestCase(TestBase):
     def __init__(self):
@@ -29,7 +30,7 @@ class TestCase(TestBase):
 """, sort='graph')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record %s -d %s %s' % (TestBase.ftrace, NOFILTERS, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t187_graph_field.py
+++ b/tests/t187_graph_field.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+import subprocess as sp
+
+TDIR='xxx'
+FUNC='main'
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'sort', """
+# Function Call Graph for 'main' (session: 67af3e650b051216)
+=============== BACKTRACE ===============
+ backtrace #0: hit 1, time  10.148 ms
+   [0] main (0x560e956bd610)
+
+========== FUNCTION CALL GRAPH ==========
+# TOTAL TIME  SELF TIME      ADDRESS     FUNCTION
+   10.148 ms   37.889 us  560e956bd610 : (1) main
+   15.991 us    0.765 us  560e956bd7ce :  +-(2) foo
+   15.226 us   15.226 us  560e956bd7a0 :  | (6) loop
+                                       :  | 
+   10.094 ms   13.365 us  560e956bd802 :  +-(1) bar
+   10.081 ms   10.081 ms  560e956bd608 :    (1) usleep
+""", sort='graph')
+
+    def pre(self):
+        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        sp.call(record_cmd.split())
+        return TestBase.TEST_SUCCESS
+
+    def runcmd(self):
+        return '%s graph -f +self,addr -d %s %s' % (TestBase.ftrace, TDIR, FUNC)
+
+    def post(self, ret):
+        sp.call(['rm', '-rf', TDIR])
+        return ret

--- a/tests/t188_graph_field_none.py
+++ b/tests/t188_graph_field_none.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+import subprocess as sp
+
+TDIR='xxx'
+FUNC='main'
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'sort', """
+# Function Call Graph for 'main' (session: 6085c5f021e501d0)
+=============== BACKTRACE ===============
+ backtrace #0: hit 1, time  10.321 ms
+   [0] main (0x4004a0)
+
+========== FUNCTION CALL GRAPH ==========
+(1) main
+ +-(2) foo
+ | (6) loop
+ | 
+ +-(1) bar
+   (1) usleep
+
+""", sort='graph')
+
+    def pre(self):
+        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        sp.call(record_cmd.split())
+        return TestBase.TEST_SUCCESS
+
+    def runcmd(self):
+        return '%s graph -f none -d %s %s' % (TestBase.ftrace, TDIR, FUNC)
+
+    def post(self, ret):
+        sp.call(['rm', '-rf', TDIR])
+        return ret

--- a/uftrace.c
+++ b/uftrace.c
@@ -150,7 +150,7 @@ static struct argp_option uftrace_options[] = {
 	{ "kernel-only", OPT_kernel_only, 0, 0, "Dump kernel data only" },
 	{ "flame-graph", OPT_flame_graph, 0, 0, "Dump recorded data in FlameGraph format" },
 	{ "sample-time", OPT_sample_time, "TIME", 0, "Show flame graph with this sampling time" },
-	{ "output-fields", 'f', "FIELD", 0, "Show FIELDs in the replay output (default: 'duration,tid')" },
+	{ "output-fields", 'f', "FIELD", 0, "Show FIELDs in the replay or graph output" },
 	{ "time-range", 'r', "TIME~TIME", 0, "Show output within the TIME(timestamp or elapsed time) range only" },
 	{ "patch", 'P', "FUNC", 0, "Apply dynamic patching for FUNCs" },
 	{ "event", 'E', "EVENT", 0, "Enable EVENT to save more information" },

--- a/utils/field.c
+++ b/utils/field.c
@@ -1,0 +1,55 @@
+#include "utils/field.h"
+#include "utils/fstack.h"
+#include "utils/list.h"
+
+void print_header(struct list_head *output_fields)
+{
+	struct replay_field *field;
+
+	/* do not print anything if not needed */
+	if (list_empty(output_fields))
+		return;
+
+	pr_out("#");
+	list_for_each_entry(field, output_fields, list)
+		pr_out("%s ", field->header);
+
+	pr_out("  FUNCTION\n");
+}
+
+int print_field_data(struct list_head *output_fields, struct field_data *fd)
+{
+	struct replay_field *field;
+
+	if (list_empty(output_fields))
+		return 0;
+
+	pr_out(" ");
+	list_for_each_entry(field, output_fields, list) {
+		field->print(fd);
+		pr_out(" ");
+	}
+	return 1;
+}
+
+int print_empty_field(struct list_head *output_fields)
+{
+	struct replay_field *field;
+
+	if (list_empty(output_fields))
+		return 0;
+
+	pr_out(" ");
+	list_for_each_entry(field, output_fields, list)
+		pr_out("%*s ", field->length, "");
+	return 1;
+}
+
+void add_field(struct list_head *output_fields, struct replay_field *field)
+{
+	if (field->used)
+		return;
+
+	field->used = true;
+	list_add_tail(&field->list, output_fields);
+}

--- a/utils/field.c
+++ b/utils/field.c
@@ -2,46 +2,50 @@
 #include "utils/fstack.h"
 #include "utils/list.h"
 
-void print_header(struct list_head *output_fields, const char *prefix)
+void print_header(struct list_head *output_fields, const char *prefix,
+		  int space)
 {
 	struct display_field *field;
+	bool first = true;
 
 	/* do not print anything if not needed */
 	if (list_empty(output_fields))
 		return;
 
-	pr_out("%s", prefix);
-	list_for_each_entry(field, output_fields, list)
-		pr_out("%s ", field->header);
+	list_for_each_entry(field, output_fields, list) {
+		pr_out("%*s", space, first ? prefix : "");
+		pr_out("%s", field->header);
+		first = false;
+	}
 
-	pr_out("  FUNCTION\n");
+	pr_out("   FUNCTION\n");
 }
 
-int print_field_data(struct list_head *output_fields, struct field_data *fd)
+int print_field_data(struct list_head *output_fields, struct field_data *fd,
+		     int space)
 {
 	struct display_field *field;
 
 	if (list_empty(output_fields))
 		return 0;
 
-	pr_out(" ");
 	list_for_each_entry(field, output_fields, list) {
+		pr_out("%*s", space, "");
 		field->print(fd);
-		pr_out(" ");
 	}
 	return 1;
 }
 
-int print_empty_field(struct list_head *output_fields)
+int print_empty_field(struct list_head *output_fields, int space)
 {
 	struct display_field *field;
 
 	if (list_empty(output_fields))
 		return 0;
 
-	pr_out(" ");
 	list_for_each_entry(field, output_fields, list)
-		pr_out("%*s ", field->length, "");
+		pr_out("%*s", field->length + space, "");
+
 	return 1;
 }
 

--- a/utils/field.c
+++ b/utils/field.c
@@ -58,6 +58,17 @@ void add_field(struct list_head *output_fields, struct display_field *field)
 	list_add_tail(&field->list, output_fields);
 }
 
+static bool check_field_name(struct display_field *field, const char *name)
+{
+	if (!strcmp(field->name, name))
+		return true;
+
+	if (field->alias && !strcmp(field->alias, name))
+		return true;
+
+	return false;
+}
+
 void setup_field(struct list_head *output_fields, struct opts *opts,
 		 void (*setup_default_field)(struct list_head *fields, struct opts*),
 		 struct display_field *field_table[], size_t field_table_size)
@@ -89,7 +100,7 @@ void setup_field(struct list_head *output_fields, struct opts *opts,
 			field = field_table[i];
 
 			pr_dbg("check field \"%s\"\n", field->name);
-			if (strcmp(field->name, p))
+			if (!check_field_name(field, p))
 				continue;
 
 			pr_dbg("add field \"%s\"\n", field->name);

--- a/utils/field.c
+++ b/utils/field.c
@@ -4,7 +4,7 @@
 
 void print_header(struct list_head *output_fields)
 {
-	struct replay_field *field;
+	struct display_field *field;
 
 	/* do not print anything if not needed */
 	if (list_empty(output_fields))
@@ -19,7 +19,7 @@ void print_header(struct list_head *output_fields)
 
 int print_field_data(struct list_head *output_fields, struct field_data *fd)
 {
-	struct replay_field *field;
+	struct display_field *field;
 
 	if (list_empty(output_fields))
 		return 0;
@@ -34,7 +34,7 @@ int print_field_data(struct list_head *output_fields, struct field_data *fd)
 
 int print_empty_field(struct list_head *output_fields)
 {
-	struct replay_field *field;
+	struct display_field *field;
 
 	if (list_empty(output_fields))
 		return 0;
@@ -45,7 +45,7 @@ int print_empty_field(struct list_head *output_fields)
 	return 1;
 }
 
-void add_field(struct list_head *output_fields, struct replay_field *field)
+void add_field(struct list_head *output_fields, struct display_field *field)
 {
 	if (field->used)
 		return;

--- a/utils/field.c
+++ b/utils/field.c
@@ -2,7 +2,7 @@
 #include "utils/fstack.h"
 #include "utils/list.h"
 
-void print_header(struct list_head *output_fields)
+void print_header(struct list_head *output_fields, const char *prefix)
 {
 	struct display_field *field;
 
@@ -10,7 +10,7 @@ void print_header(struct list_head *output_fields)
 	if (list_empty(output_fields))
 		return;
 
-	pr_out("#");
+	pr_out("%s", prefix);
 	list_for_each_entry(field, output_fields, list)
 		pr_out("%s ", field->header);
 

--- a/utils/field.c
+++ b/utils/field.c
@@ -53,3 +53,57 @@ void add_field(struct list_head *output_fields, struct display_field *field)
 	field->used = true;
 	list_add_tail(&field->list, output_fields);
 }
+
+void setup_field(struct list_head *output_fields, struct opts *opts,
+		 void (*setup_default_field)(struct list_head *fields, struct opts*),
+		 struct display_field *field_table[], size_t field_table_size)
+{
+	struct display_field *field;
+	unsigned i;
+	char *str, *p, *s;
+
+	/* default fields */
+	if (opts->fields == NULL) {
+		setup_default_field(output_fields, opts);
+		return;
+	}
+
+	if (!strcmp(opts->fields, "none"))
+		return;
+
+	s = str = xstrdup(opts->fields);
+
+	if (*str == '+') {
+		/* prepend default fields */
+		setup_default_field(output_fields, opts);
+		s++;
+	}
+
+	p = strtok(s, ",");
+	while (p) {
+		for (i = 0; i < field_table_size; i++) {
+			field = field_table[i];
+
+			pr_dbg("check field \"%s\"\n", field->name);
+			if (strcmp(field->name, p))
+				continue;
+
+			pr_dbg("add field \"%s\"\n", field->name);
+			add_field(output_fields, field);
+			break;
+		}
+
+		if (i == field_table_size) {
+			pr_out("uftrace: Unknown field name '%s'\n", p);
+			pr_out("uftrace:   Possible fields are:");
+			for (i = 0; i < field_table_size; i++)
+				pr_out(" %s", field_table[i]->name);
+			pr_out("\n");
+			exit(1);
+		}
+
+		p = strtok(NULL, ",");
+	}
+
+	free(str);
+}

--- a/utils/field.h
+++ b/utils/field.h
@@ -11,7 +11,7 @@ struct field_data {
 	void *arg;
 };
 
-enum replay_field_id {
+enum display_field_id {
 	REPLAY_F_NONE           = -1,
 	REPLAY_F_DURATION,
 	REPLAY_F_TID,
@@ -21,9 +21,9 @@ enum replay_field_id {
 	REPLAY_F_ELAPSED,
 };
 
-struct replay_field {
+struct display_field {
 	struct list_head list;
-	enum replay_field_id id;
+	enum display_field_id id;
 	const char *name;
 	const char *header;
 	int length;
@@ -34,6 +34,6 @@ struct replay_field {
 void print_header(struct list_head *output_fields);
 int print_field_data(struct list_head *output_fields, struct field_data *fd);
 int print_empty_field(struct list_head *output_fields);
-void add_field(struct list_head *output_fields, struct replay_field *field);
+void add_field(struct list_head *output_fields, struct display_field *field);
 
 #endif /* UFTRACE_DISPLAY_FIELD_H */

--- a/utils/field.h
+++ b/utils/field.h
@@ -12,13 +12,18 @@ struct field_data {
 };
 
 enum display_field_id {
-	REPLAY_F_NONE           = -1,
-	REPLAY_F_DURATION,
+	DISPLAY_F_NONE          = -1,
+
+	REPLAY_F_DURATION       = 0,
 	REPLAY_F_TID,
 	REPLAY_F_ADDR,
 	REPLAY_F_TIMESTAMP,
 	REPLAY_F_TIMEDELTA,
 	REPLAY_F_ELAPSED,
+
+	GRAPH_F_TOTAL_TIME      = 0,
+	GRAPH_F_SELF_TIME,
+	GRAPH_F_ADDR,
 };
 
 struct display_field {

--- a/utils/field.h
+++ b/utils/field.h
@@ -36,9 +36,11 @@ struct display_field {
 	void (*print)(struct field_data *fd);
 };
 
-void print_header(struct list_head *output_fields, const char *prefix);
-int print_field_data(struct list_head *output_fields, struct field_data *fd);
-int print_empty_field(struct list_head *output_fields);
+void print_header(struct list_head *output_fields, const char *prefix,
+		  int space);
+int print_field_data(struct list_head *output_fields, struct field_data *fd,
+		     int space);
+int print_empty_field(struct list_head *output_fields, int space);
 void add_field(struct list_head *output_fields, struct display_field *field);
 void setup_field(struct list_head *output_fields, struct opts *opts,
 		 void (*setup_default_field)(struct list_head *fields, struct opts*),

--- a/utils/field.h
+++ b/utils/field.h
@@ -35,5 +35,8 @@ void print_header(struct list_head *output_fields);
 int print_field_data(struct list_head *output_fields, struct field_data *fd);
 int print_empty_field(struct list_head *output_fields);
 void add_field(struct list_head *output_fields, struct display_field *field);
+void setup_field(struct list_head *output_fields, struct opts *opts,
+		 void (*setup_default_field)(struct list_head *fields, struct opts*),
+		 struct display_field *field_table[], size_t field_table_size);
 
 #endif /* UFTRACE_DISPLAY_FIELD_H */

--- a/utils/field.h
+++ b/utils/field.h
@@ -34,6 +34,7 @@ struct display_field {
 	int length;
 	bool used;
 	void (*print)(struct field_data *fd);
+	const char *alias;
 };
 
 void print_header(struct list_head *output_fields, const char *prefix,

--- a/utils/field.h
+++ b/utils/field.h
@@ -31,7 +31,7 @@ struct display_field {
 	void (*print)(struct field_data *fd);
 };
 
-void print_header(struct list_head *output_fields);
+void print_header(struct list_head *output_fields, const char *prefix);
 int print_field_data(struct list_head *output_fields, struct field_data *fd);
 int print_empty_field(struct list_head *output_fields);
 void add_field(struct list_head *output_fields, struct display_field *field);

--- a/utils/field.h
+++ b/utils/field.h
@@ -1,0 +1,39 @@
+#ifndef UFTRACE_FIELD_H
+#define UFTRACE_FIELD_H
+
+#include "utils/fstack.h"
+#include "utils/list.h"
+
+/* data for field display */
+struct field_data {
+	struct ftrace_task_handle *task;
+	struct fstack *fstack;
+	void *arg;
+};
+
+enum replay_field_id {
+	REPLAY_F_NONE           = -1,
+	REPLAY_F_DURATION,
+	REPLAY_F_TID,
+	REPLAY_F_ADDR,
+	REPLAY_F_TIMESTAMP,
+	REPLAY_F_TIMEDELTA,
+	REPLAY_F_ELAPSED,
+};
+
+struct replay_field {
+	struct list_head list;
+	enum replay_field_id id;
+	const char *name;
+	const char *header;
+	int length;
+	bool used;
+	void (*print)(struct field_data *fd);
+};
+
+void print_header(struct list_head *output_fields);
+int print_field_data(struct list_head *output_fields, struct field_data *fd);
+int print_empty_field(struct list_head *output_fields);
+void add_field(struct list_head *output_fields, struct replay_field *field);
+
+#endif /* UFTRACE_DISPLAY_FIELD_H */


### PR DESCRIPTION
The -f/--output-fields option is to specify fields in the replay output.
This patch implements the same feature for graph output.  Users can
customize the output for their needs like below:
```
  $ uftrace graph -f time,selftime,addr
  # Function Call Graph for 't-sort' (session: e07b5987dd5ee757)
  ========== FUNCTION CALL GRAPH ==========
  #   TIME     SELFTIME     ADDRESS     FUNCTION
    10.339 ms                  4004a0 : (1) t-sort
    10.339 ms 134.739 us       4004a0 : (1) main
    53.878 us   2.207 us       4005f1 :  +-(2) foo
    51.671 us  51.671 us       4005c7 :  | (6) loop
                                      :  |
    10.150 ms  57.077 us       400621 :  +-(1) bar
    10.093 ms  10.093 ms       400480 :    (1) usleep
```
The default value is 'time' only.  And it also accepts a special
field name of 'none' which disables the field display and shows function
graph output only.
```
  $ uftrace graph -f none
  # Function Call Graph for 't-sort' (session: e07b5987dd5ee757)
  ========== FUNCTION CALL GRAPH ==========
  (1) t-sort
  (1) main
   +-(2) foo
   | (6) loop
   |
   +-(1) bar
     (1) usleep
```
This patch does NOT change the default graph out at all.