### PR TITLE
Support old gcc version

### DIFF
--- a/arch/i386/common.S
+++ b/arch/i386/common.S
@@ -1,0 +1,6 @@
+#include "utils/asm.h"
+
+ENTRY(get_pc_thunk)
+	movl 0(%esp), %eax
+	ret
+END(get_pc_thunk)

--- a/arch/i386/fentry.S
+++ b/arch/i386/fentry.S
@@ -20,7 +20,7 @@ GLOBAL(__fentry__)
 	jne 1f
 
 	/* hijack return address */
-	call __x86.get_pc_thunk.ax
+	call get_pc_thunk
 	addl $_GLOBAL_OFFSET_TABLE_, %eax
 	addl $fentry_return@GOTOFF, %eax
 	movl %eax, 36(%esp)

--- a/arch/i386/mcount-support.c
+++ b/arch/i386/mcount-support.c
@@ -208,13 +208,15 @@ unsigned long *mcount_arch_parent_location(struct symtabs *symtabs,
 
 		// Assuming that this happens only in main..			
 		bool found_main_ret = false;
+		int stack_index = 0;
+
 		if (!(strcmp(find_main[0], parent_name) || 
 		      strcmp(find_main[1], child_name))) {
 			ret_addr = *parent_loc;
-			for (int i = 1; i < MAX_SEARCH_STACK; i++ ) {
-				search_ret_addr = *(unsigned long *)(parent_loc + i);
+			for (stack_index = 1; stack_index < MAX_SEARCH_STACK; stack_index++) {
+				search_ret_addr = *(unsigned long *)(parent_loc + stack_index);
 				if (search_ret_addr == ret_addr) {
-					parent_loc = parent_loc+i;
+					parent_loc = parent_loc + stack_index;
 					found_main_ret = true;
 				}
 			}

--- a/arch/i386/plthook.S
+++ b/arch/i386/plthook.S
@@ -37,7 +37,7 @@ ENTRY(plt_hooker)
 	cmpl $0, %eax
 	jnz 1f
 	/* get address of plthook_resolver_addr */
-	call __x86.get_pc_thunk.ax
+	call get_pc_thunk
 	addl $_GLOBAL_OFFSET_TABLE_, %eax
 	leal plthook_resolver_addr@GOTOFF(%eax), %eax
 	movl (%eax), %eax


### PR DESCRIPTION
some code of supporting i386 have been not supported from the old version gcc.
this PR is the patch to resolve that.