### PR TITLE
doc: Fix a tiny mistake on read trigger example

### DIFF
--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -262,7 +262,7 @@ The 'time' trigger is to change time filter setting during execution of the func
 
 The `read` trigger is to read some information at runtime.  As of now, reading process memory stat ("proc/statm") from the /proc filesystem and number of page faults ("page-fault") using getrusage(2) are supported only.  The results are printed in comments like below.
 
-    $ uftrace -T b@read=proc/statm ./abc
+    $ uftrace -T a@read=proc/statm ./abc
     # DURATION    TID     FUNCTION
                 [ 1234] | main() {
                 [ 1234] |   a() {

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -256,7 +256,7 @@ The 'time' trigger is to change time filter setting during execution of the func
 
 The `read` trigger is to read some information at runtime.  As of now, reading process memory stat ("proc/statm") from /proc filesystem and number of page faults ("page-fault") using getrusage(2) are supported only.  The results are printed in comments like below.
 
-    $ uftrace record -T b@read=proc/statm ./abc
+    $ uftrace record -T a@read=proc/statm ./abc
     $ uftrace replay
     # DURATION    TID     FUNCTION
                 [ 1234] | main() {


### PR DESCRIPTION
In the man pages of record and live, read trigger examples are a bit wrong
so this patch fixes it.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>