### PR TITLE
fstack: Fix the segfault when using --tid

### DIFF
--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -189,6 +189,7 @@ setup:
 			task->done = true;
 			task->tid  = tid;
 			task->h    = handle;
+			task->t = find_task(&handle->sessions, tid);
 
 			/* need to read the data to check elapsed time */
 			xasprintf(&filename, "%s/%d.dat", handle->dirname, tid);


### PR DESCRIPTION
Currently the task that is chosen by --tid option
task->t become NULL on setup_task_filter().
Hence this crash can occur.
So properly set task->t regardless --tid option.

Fixes #304.