### PR TITLE
Rename 'ftrace' residues -> 'uftrace'

### DIFF
--- a/tests/arch/arm/Makefile
+++ b/tests/arch/arm/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 RM = rm -f
-FTRACE = ../../../ftrace -L ../../.. --flat
+UFTRACE = ../../../uftrace -L ../../.. --flat
 
 #CFLAGS = -g -finstrument-functions
 CFLAGS = -g -pg -fno-omit-frame-pointer
@@ -16,7 +16,7 @@ TARGETS_Os = $(patsubst %,%_Os,$(TARGETS))
 
 ALL_TARGETS = $(TARGETS) $(TARGETS_O1) $(TARGETS_O2) $(TARGETS_O3) $(TARGETS_Os)
 
-test_run = $(FTRACE) $(1) 1 2 3 | sort -k2 | cut -d/ -f2 | cut -d, -f1 | sed -e 's/<[0-9a-f]\+>/<unknown>/'
+test_run = $(UFTRACE) $(1) 1 2 3 | sort -k2 | cut -d/ -f2 | cut -d, -f1 | sed -e 's/<[0-9a-f]\+>/<unknown>/'
 test_and_diff = printf "%20s: " $(1); $(test_run) | diff -U0 $(2) - > $(1)-diff && \
 		printf [${GREEN}OK${RESET}]"\n" || printf [${RED}NG${RESET}]"\n"
 
@@ -51,6 +51,6 @@ test: all
 	@for t in $(TARGETS_Os); do $(call test_and_diff, $${t}, $${t%_Os}_result); done
 
 clean:
-	$(RM) $(ALL_TARGETS) *.o ftrace.data* gmon.out *-diff
+	$(RM) $(ALL_TARGETS) *.o uftrace.data* gmon.out *-diff
 
 .PHONY: clean test arch

--- a/tests/arch/x86_64/Makefile
+++ b/tests/arch/x86_64/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 RM = rm -f
-FTRACE = ../../../ftrace -L ../../.. --flat
+UFTRACE = ../../../uftrace -L ../../.. --flat
 
 CFLAGS = -g -finstrument-functions
 
@@ -17,7 +17,7 @@ TARGETS_Os = $(patsubst %,%_Os,$(TARGETS))
 
 ALL_TARGETS = $(TARGETS) $(TARGETS_O1) $(TARGETS_O2) $(TARGETS_O3) $(TARGETS_Os)
 
-test_run = $(FTRACE) $(1) 1 2 3 | sort -k2 | cut -d/ -f2 | cut -d, -f1 | sed -e 's/<[0-9a-f]\+>/<unknown>/'
+test_run = $(UFTRACE) $(1) 1 2 3 | sort -k2 | cut -d/ -f2 | cut -d, -f1 | sed -e 's/<[0-9a-f]\+>/<unknown>/'
 test_and_diff = printf "%20s: " $(1); $(test_run) | diff -U0 $(2) - > $(1)-diff && \
 		printf [${GREEN}OK${RESET}]"\n" || printf [${RED}NG${RESET}]"\n"
 
@@ -42,6 +42,6 @@ test: all
 	@for t in $(TARGETS_Os); do $(call test_and_diff, $${t}, $${t%_Os}_result); done
 
 clean:
-	$(RM) $(ALL_TARGETS) *.o ftrace.data* gmon.out *-diff
+	$(RM) $(ALL_TARGETS) *.o uftrace.data* gmon.out *-diff
 
 .PHONY: clean test arch

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -21,7 +21,7 @@ class TestBase:
     TEST_SUCCESS_FIXED = -8
 
     objdir = 'objdir' in os.environ and os.environ['objdir'] or '..'
-    ftrace = objdir + '/uftrace --no-pager -L' + objdir
+    uftrace_cmd = objdir + '/uftrace --no-pager -L' + objdir
 
     default_cflags = ['-fno-inline', '-fno-builtin', '-fno-omit-frame-pointer']
 
@@ -130,7 +130,7 @@ class TestBase:
     def runcmd(self):
         """ This function returns (shell) command that runs the test.
             A test case can extend this to setup a complex configuration.  """
-        return '%s %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s %s' % (TestBase.uftrace_cmd, 't-' + self.name)
 
     def task_sort(self, output, ignore_children=False):
         """ This function post-processes output of the test to be compared .

--- a/tests/s-abc.c
+++ b/tests/s-abc.c
@@ -1,5 +1,5 @@
 /*
- * This is a basic test to verify whether ftrace works on the system.
+ * This is a basic test to verify whether uftrace works on the system.
  */
 #include <stdlib.h>
 #include <unistd.h>

--- a/tests/s-arg.c
+++ b/tests/s-arg.c
@@ -1,5 +1,5 @@
 /*
- * This is to test ftrace can work well with passing various arguments
+ * This is to test uftrace can work well with passing various arguments
  * to the functions.
  */
 #include <stdio.h>

--- a/tests/s-thread.c
+++ b/tests/s-thread.c
@@ -1,5 +1,5 @@
 /*
- * This is a basic test that checks ftrace can trace functions
+ * This is a basic test that checks uftrace can trace functions
  * properly within a multi-thread environment.
  */
 #include <stdlib.h>

--- a/tests/t003_thread.py
+++ b/tests/t003_thread.py
@@ -60,4 +60,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s --no-merge %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s --no-merge %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t004_filter_F.py
+++ b/tests/t004_filter_F.py
@@ -16,4 +16,4 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def runcmd(self):
-        return '%s -F a %s' % (TestBase.ftrace, 't-abc')
+        return '%s -F a %s' % (TestBase.uftrace_cmd, 't-abc')

--- a/tests/t005_filter_N.py
+++ b/tests/t005_filter_N.py
@@ -15,4 +15,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -N c %s' % (TestBase.ftrace, 't-abc')
+        return '%s -N c %s' % (TestBase.uftrace_cmd, 't-abc')

--- a/tests/t006_filter_FN.py
+++ b/tests/t006_filter_FN.py
@@ -12,4 +12,4 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def runcmd(self):
-        return '%s -F a -N c %s' % (TestBase.ftrace, 't-abc')
+        return '%s -F a -N c %s' % (TestBase.uftrace_cmd, 't-abc')

--- a/tests/t007_library.py
+++ b/tests/t007_library.py
@@ -20,4 +20,4 @@ class TestCase(TestBase):
                                       ['libabc_test_lib.so'])
 
     def runcmd(self):
-        return '%s --force --no-libcall %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s --force --no-libcall %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t009_fork.py
+++ b/tests/t009_fork.py
@@ -35,4 +35,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s --no-merge %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s --no-merge %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t010_forkexec.py
+++ b/tests/t010_forkexec.py
@@ -31,4 +31,4 @@ class TestCase(TestBase):
         return ret
 
     def runcmd(self):
-        return '%s -F main %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -F main %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t011_vforkexec.py
+++ b/tests/t011_vforkexec.py
@@ -31,4 +31,4 @@ class TestCase(TestBase):
         return ret
 
     def runcmd(self):
-        return '%s -F main %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -F main %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t017_no_libcall.py
+++ b/tests/t017_no_libcall.py
@@ -16,4 +16,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s --no-libcall %s' % (TestBase.ftrace, 't-abc')
+        return '%s --no-libcall %s' % (TestBase.uftrace_cmd, 't-abc')

--- a/tests/t018_filter_regex.py
+++ b/tests/t018_filter_regex.py
@@ -20,4 +20,4 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def runcmd(self):
-        return '%s -F "^alloc.*$" %s' % (TestBase.ftrace, 't-allocfree')
+        return '%s -F "^alloc.*$" %s' % (TestBase.uftrace_cmd, 't-allocfree')

--- a/tests/t019_full_depth.py
+++ b/tests/t019_full_depth.py
@@ -17,4 +17,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -D3 %s' % (TestBase.ftrace, 't-allocfree')
+        return '%s -D3 %s' % (TestBase.uftrace_cmd, 't-allocfree')

--- a/tests/t020_filter_depth.py
+++ b/tests/t020_filter_depth.py
@@ -14,4 +14,4 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def runcmd(self):
-        return '%s -D1 -F "alloc[135]" %s' % (TestBase.ftrace, 't-allocfree')
+        return '%s -D1 -F "alloc[135]" %s' % (TestBase.uftrace_cmd, 't-allocfree')

--- a/tests/t021_filter_plt.py
+++ b/tests/t021_filter_plt.py
@@ -13,4 +13,4 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def runcmd(self):
-        return '%s -F "get.?id@plt" %s' % (TestBase.ftrace, 't-getids')
+        return '%s -F "get.?id@plt" %s' % (TestBase.uftrace_cmd, 't-getids')

--- a/tests/t022_filter_kernel.py
+++ b/tests/t022_filter_kernel.py
@@ -32,4 +32,4 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s -k -F "sys_gete*@kernel" %s' % (TestBase.ftrace, 't-getids')
+        return '%s -k -F "sys_gete*@kernel" %s' % (TestBase.uftrace_cmd, 't-getids')

--- a/tests/t023_replay_filter.py
+++ b/tests/t023_replay_filter.py
@@ -22,12 +22,12 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-allocfree')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-allocfree')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -d %s -F alloc3 -D2 -F "free[15]"' % (TestBase.ftrace, TDIR)
+        return '%s replay -d %s -F alloc3 -D2 -F "free[15]"' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t024_report_basic.py
+++ b/tests/t024_report_basic.py
@@ -20,12 +20,12 @@ class TestCase(TestBase):
 """, sort='report')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s report -d %s' % (TestBase.ftrace, TDIR)
+        return '%s report -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t025_report_s_call.py
+++ b/tests/t025_report_s_call.py
@@ -20,12 +20,12 @@ class TestCase(TestBase):
 """, sort='report')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-sort')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-sort')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s report -d %s -s call,self' % (TestBase.ftrace, TDIR)
+        return '%s report -d %s -s call,self' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t026_filter_trigger.py
+++ b/tests/t026_filter_trigger.py
@@ -27,4 +27,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -F "main" -F "alloc3@depth=1" %s' % (TestBase.ftrace, 't-allocfree')
+        return '%s -F "main" -F "alloc3@depth=1" %s' % (TestBase.uftrace_cmd, 't-allocfree')

--- a/tests/t027_replay_filter_d.py
+++ b/tests/t027_replay_filter_d.py
@@ -30,12 +30,12 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-allocfree')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-allocfree')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -F "main" -F "alloc3@depth=1" -d %s' % (TestBase.ftrace, TDIR)
+        return '%s replay -F "main" -F "alloc3@depth=1" -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t028_replay_backtrace.py
+++ b/tests/t028_replay_backtrace.py
@@ -21,12 +21,12 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-allocfree')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-allocfree')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -T "alloc4@filter,backtrace" -d %s' % (TestBase.ftrace, TDIR)
+        return '%s replay -T "alloc4@filter,backtrace" -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t029_trigger_only.py
+++ b/tests/t029_trigger_only.py
@@ -35,4 +35,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -T "alloc3@depth=1" -T "free@backtrace" %s' % (TestBase.ftrace, 't-allocfree')
+        return '%s -T "alloc3@depth=1" -T "free@backtrace" %s' % (TestBase.uftrace_cmd, 't-allocfree')

--- a/tests/t030_replay_trigger.py
+++ b/tests/t030_replay_trigger.py
@@ -22,12 +22,12 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-allocfree')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-allocfree')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -T "alloc1@depth=2" -T "free2@depth=1,backtrace" -d %s' % (TestBase.ftrace, TDIR)
+        return '%s replay -T "alloc1@depth=2" -T "free2@depth=1,backtrace" -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t031_filter_demangle1.py
+++ b/tests/t031_filter_demangle1.py
@@ -19,4 +19,4 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def runcmd(self):
-        return '%s -F "ns::ns1::foo::bar" %s' % (TestBase.ftrace, 't-namespace')
+        return '%s -F "ns::ns1::foo::bar" %s' % (TestBase.uftrace_cmd, 't-namespace')

--- a/tests/t032_filter_demangle2.py
+++ b/tests/t032_filter_demangle2.py
@@ -13,4 +13,4 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def runcmd(self):
-        return '%s -F "^operator" %s' % (TestBase.ftrace, 't-namespace')
+        return '%s -F "^operator" %s' % (TestBase.uftrace_cmd, 't-namespace')

--- a/tests/t033_filter_demangle3.py
+++ b/tests/t033_filter_demangle3.py
@@ -26,4 +26,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -N ".*ns1::.*" %s' % (TestBase.ftrace, 't-namespace')
+        return '%s -N ".*ns1::.*" %s' % (TestBase.uftrace_cmd, 't-namespace')

--- a/tests/t034_filter_demangle4.py
+++ b/tests/t034_filter_demangle4.py
@@ -14,4 +14,4 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def runcmd(self):
-        return '%s -F "ns1::.*" -N "bar2$" %s' % (TestBase.ftrace, 't-namespace')
+        return '%s -F "ns1::.*" -N "bar2$" %s' % (TestBase.uftrace_cmd, 't-namespace')

--- a/tests/t035_filter_demangle5.py
+++ b/tests/t035_filter_demangle5.py
@@ -26,4 +26,4 @@ class TestCase(TestBase):
 
     # test whether filter option preserves the ordering
     def runcmd(self):
-        return '%s -F "ns1::.*" -N "bar2$" -F "bar2$" %s' % (TestBase.ftrace, 't-namespace')
+        return '%s -F "ns1::.*" -N "bar2$" -F "bar2$" %s' % (TestBase.uftrace_cmd, 't-namespace')

--- a/tests/t036_replay_filter_N.py
+++ b/tests/t036_replay_filter_N.py
@@ -27,12 +27,12 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-namespace')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-namespace')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -d %s -N "bar3$" -Tns::ns2::foo::bar@depth=1' % (TestBase.ftrace, TDIR)
+        return '%s replay -d %s -N "bar3$" -Tns::ns2::foo::bar@depth=1' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t037_trace_onoff.py
+++ b/tests/t037_trace_onoff.py
@@ -25,4 +25,4 @@ class TestCase(TestBase):
 
     def runcmd(self):
         return '%s -T "ns::ns1::foo::bar2@trace_off" -T "ns::ns2::foo::bar2@trace-on" %s' % \
-            (TestBase.ftrace, 't-namespace')
+            (TestBase.uftrace_cmd, 't-namespace')

--- a/tests/t038_trace_disable.py
+++ b/tests/t038_trace_disable.py
@@ -21,4 +21,4 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def runcmd(self):
-        return '%s --disable -T "ns::ns2::foo::bar@traceon" %s' % (TestBase.ftrace, 't-namespace')
+        return '%s --disable -T "ns::ns2::foo::bar@traceon" %s' % (TestBase.uftrace_cmd, 't-namespace')

--- a/tests/t039_trace_onoff_F.py
+++ b/tests/t039_trace_onoff_F.py
@@ -17,4 +17,4 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def runcmd(self):
-        return '%s --disable -F "ns::ns1::foo::bar" -T ".*foo::bar3@trace_on" %s' % (TestBase.ftrace, 't-namespace')
+        return '%s --disable -F "ns::ns1::foo::bar" -T ".*foo::bar3@trace_on" %s' % (TestBase.uftrace_cmd, 't-namespace')

--- a/tests/t040_replay_onoff.py
+++ b/tests/t040_replay_onoff.py
@@ -24,12 +24,12 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-namespace')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-namespace')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -d %s --disable -T "operator new@traceon" -T "malloc@traceoff"' % (TestBase.ftrace, TDIR)
+        return '%s replay -d %s --disable -T "operator new@traceon" -T "malloc@traceoff"' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t041_replay_onoff_N.py
+++ b/tests/t041_replay_onoff_N.py
@@ -23,13 +23,13 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-namespace')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-namespace')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
         return '%s replay -d %s --disable -N "ns2.*" -T "operator new@trace-on" -T "malloc@traceoff"' % \
-            (TestBase.ftrace, TDIR)
+            (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t042_live_disable.py
+++ b/tests/t042_live_disable.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '--disable -F ".*foo::foo" -T .foo::foo@traceon -F .bar2'
         program = 't-' + self.name
         return '%s %s %s' % (uftrace, options, program)

--- a/tests/t043_full_demangle.py
+++ b/tests/t043_full_demangle.py
@@ -26,7 +26,7 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s --demangle=full -N "ns2.*" %s' % (TestBase.ftrace, 't-namespace')
+        return '%s --demangle=full -N "ns2.*" %s' % (TestBase.uftrace_cmd, 't-namespace')
 
     def fixup(self, cflags, result):
         import platform

--- a/tests/t044_report_avg_total.py
+++ b/tests/t044_report_avg_total.py
@@ -20,12 +20,12 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-sort')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-sort')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s report --avg-total -d %s' % (TestBase.ftrace, TDIR)
+        return '%s report --avg-total -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t045_report_avg_self.py
+++ b/tests/t045_report_avg_self.py
@@ -20,12 +20,12 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-sort')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-sort')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s report --avg-self -d %s' % (TestBase.ftrace, TDIR)
+        return '%s report --avg-self -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t046_report_threads.py
+++ b/tests/t046_report_threads.py
@@ -18,12 +18,12 @@ class TestCase(TestBase):
 """, ldflags='-pthread')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-thread-name')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-thread-name')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s report --threads -d %s' % (TestBase.ftrace, TDIR)
+        return '%s report --threads -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t048_malloc_impl.py
+++ b/tests/t048_malloc_impl.py
@@ -13,4 +13,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -F main %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -F main %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t049_column_view.py
+++ b/tests/t049_column_view.py
@@ -60,4 +60,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s --column-view --column-offset=4 --no-merge %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s --column-view --column-offset=4 --no-merge %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t050_no_pltbind.py
+++ b/tests/t050_no_pltbind.py
@@ -42,4 +42,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s --no-pltbind --column-view --no-merge %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s --no-pltbind --column-view --no-merge %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t053_filter_time.py
+++ b/tests/t053_filter_time.py
@@ -17,4 +17,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -t 1ms %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -t 1ms %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t054_filter_time_F.py
+++ b/tests/t054_filter_time_F.py
@@ -12,4 +12,4 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def runcmd(self):
-        return '%s -t 1ms -F bar %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -t 1ms -F bar %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t055_filter_time_N.py
+++ b/tests/t055_filter_time_N.py
@@ -13,4 +13,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -t 1ms -N bar %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -t 1ms -N bar %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t056_filter_time_T.py
+++ b/tests/t056_filter_time_T.py
@@ -13,4 +13,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -t 1ms -T "mem_alloc@trace-off" -T "mem_free@trace-on" %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -t 1ms -T "mem_alloc@trace-off" -T "mem_free@trace-on" %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t057_filter_time_D.py
+++ b/tests/t057_filter_time_D.py
@@ -15,4 +15,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -t 1ms -D3 %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -t 1ms -D3 %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t058_arg_int.py
+++ b/tests/t058_arg_int.py
@@ -28,4 +28,4 @@ class TestCase(TestBase):
         if platform.architecture()[0].startswith('32bit'):
             # int_mul@arg1 is a 'long long', so we should skip arg2
             argopt = '-A "int_(add|sub|div)@arg1,arg2" -A "int_mul@arg1/i64,arg3"'
-        return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)
+        return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)

--- a/tests/t059_arg_str.py
+++ b/tests/t059_arg_str.py
@@ -23,4 +23,4 @@ class TestCase(TestBase):
         return TestBase.build(self, name, cflags, ldflags)
 
     def runcmd(self):
-        return '%s -A "^str_@arg1/s,arg2/s" %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -A "^str_@arg1/s,arg2/s" %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t060_arg_fmt.py
+++ b/tests/t060_arg_fmt.py
@@ -23,4 +23,4 @@ class TestCase(TestBase):
 
     def runcmd(self):
         argopt = '-A "int_add@arg1/i32,arg2/u" -A "int_div@arg1/i16,arg2/x8"'
-        return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)
+        return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)

--- a/tests/t061_arg_plt.py
+++ b/tests/t061_arg_plt.py
@@ -18,7 +18,7 @@ class TestCase(TestBase):
 
     def runcmd(self):
         return '%s -A "getenv|atoi@arg1/s" -A malloc@arg1 %s 100' % \
-            (TestBase.ftrace, 't-' + self.name)
+            (TestBase.uftrace_cmd, 't-' + self.name)
 
     def fixup(self, cflags, result):
         # for some reason, ARM eats up atoi()

--- a/tests/t062_arg_char.py
+++ b/tests/t062_arg_char.py
@@ -21,4 +21,4 @@ class TestCase(TestBase):
 
     def runcmd(self):
         argopt = '-A "foo@arg1/c,arg2/c,arg3/c" -A "bar@arg1/c,arg2/c,arg3/i,arg4/x8"'
-        return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)
+        return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)

--- a/tests/t063_retval.py
+++ b/tests/t063_retval.py
@@ -32,4 +32,4 @@ class TestCase(TestBase):
             argopt  = '-A "int_(add|sub|div)@arg1,arg2" -A "int_mul@arg1/i64,arg3" '
             argopt += '-R "^int_@retval/i32"'
       
-        return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)
+        return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)

--- a/tests/t064_trigger_trace.py
+++ b/tests/t064_trigger_trace.py
@@ -18,5 +18,5 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -t 1ms -T "mem_alloc@trace" %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -t 1ms -T "mem_alloc@trace" %s' % (TestBase.uftrace_cmd, 't-' + self.name)
 

--- a/tests/t065_arg_order.py
+++ b/tests/t065_arg_order.py
@@ -31,4 +31,4 @@ class TestCase(TestBase):
             argopt += '-A "int_(add|sub|div)@arg2" -A "int_mul@arg3/x" '
             argopt += '-A "int_add@arg1/i32"'
 
-        return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)
+        return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)

--- a/tests/t066_no_demangle.py
+++ b/tests/t066_no_demangle.py
@@ -20,4 +20,4 @@ class TestCase(TestBase):
 
     def runcmd(self):
         return '%s --demangle=no -F "_ZN2ns3ns13foo3barEv" %s' % \
-            (TestBase.ftrace, 't-namespace')
+            (TestBase.uftrace_cmd, 't-namespace')

--- a/tests/t067_report_diff.py
+++ b/tests/t067_report_diff.py
@@ -24,14 +24,14 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, XDIR, 't-abc')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, XDIR, 't-abc')
         sp.call(record_cmd.split())
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, YDIR, 't-abc')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, YDIR, 't-abc')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '--sort-column 0 --diff-policy full,percent'  # old behavior
         return '%s report -d %s --diff %s %s' % (uftrace, XDIR, YDIR, options)
 

--- a/tests/t068_filter_time_A.py
+++ b/tests/t068_filter_time_A.py
@@ -24,4 +24,4 @@ class TestCase(TestBase):
 
     def runcmd(self):
         return '%s -t 1ms -R mem_alloc@retval -A mem_free@arg1 -A usleep@plt,arg1 %s' % \
-            (TestBase.ftrace, 't-' + self.name)
+            (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t069_graph.py
+++ b/tests/t069_graph.py
@@ -24,12 +24,12 @@ class TestCase(TestBase):
 """, sort='graph')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s graph -d %s %s' % (TestBase.ftrace, TDIR, FUNC)
+        return '%s graph -d %s %s' % (TestBase.uftrace_cmd, TDIR, FUNC)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t070_graph_backtrace.py
+++ b/tests/t070_graph_backtrace.py
@@ -23,12 +23,12 @@ class TestCase(TestBase):
 """, sort='graph')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-abc')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-abc')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s graph -d %s %s' % (TestBase.ftrace, TDIR, FUNC)
+        return '%s graph -d %s %s' % (TestBase.uftrace_cmd, TDIR, FUNC)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t071_graph_depth.py
+++ b/tests/t071_graph_depth.py
@@ -40,12 +40,12 @@ class TestCase(TestBase):
 """, sort='graph')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-namespace')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-namespace')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s graph -d %s -D5 %s' % (TestBase.ftrace, TDIR, FUNC)
+        return '%s graph -d %s -D5 %s' % (TestBase.uftrace_cmd, TDIR, FUNC)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t072_no_comment.py
+++ b/tests/t072_no_comment.py
@@ -20,4 +20,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s --no-comment %s' % (TestBase.ftrace, 't-abc')
+        return '%s --no-comment %s' % (TestBase.uftrace_cmd, 't-abc')

--- a/tests/t073_lib_filter.py
+++ b/tests/t073_lib_filter.py
@@ -18,4 +18,4 @@ class TestCase(TestBase):
                                       ['libabc_test_lib.so'])
 
     def runcmd(self):
-        return '%s --force -F lib_b@libabc_test %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s --force -F lib_b@libabc_test %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t074_lib_trigger.py
+++ b/tests/t074_lib_trigger.py
@@ -18,4 +18,4 @@ class TestCase(TestBase):
                                       ['libabc_test_lib.so'])
 
     def runcmd(self):
-        return '%s --force --no-libcall -T lib_b@libabc_test,depth=1 %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s --force --no-libcall -T lib_b@libabc_test,depth=1 %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t075_lib_arg.py
+++ b/tests/t075_lib_arg.py
@@ -24,4 +24,4 @@ class TestCase(TestBase):
                                       ['libabc_test_lib.so'])
 
     def runcmd(self):
-        return '%s --force --no-libcall -A ^lib@libabc_test,arg1 %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s --force --no-libcall -A ^lib@libabc_test,arg1 %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t076_lib_replay_F.py
+++ b/tests/t076_lib_replay_F.py
@@ -21,12 +21,12 @@ class TestCase(TestBase):
                                       ['libabc_test_lib.so'])
 
     def pre(self):
-        record_cmd = '%s record --force -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record --force -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -d %s -F lib_b@libabc_test' % (TestBase.ftrace, TDIR)
+        return '%s replay -d %s -F lib_b@libabc_test' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t077_lib_replay_T.py
+++ b/tests/t077_lib_replay_T.py
@@ -21,12 +21,12 @@ class TestCase(TestBase):
                                       ['libabc_test_lib.so'])
 
     def pre(self):
-        record_cmd = '%s record --force --no-libcall -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record --force --no-libcall -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -d %s -T lib_a@libabc_test,depth=2' % (TestBase.ftrace, TDIR)
+        return '%s replay -d %s -T lib_a@libabc_test,depth=2' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t078_max_stack.py
+++ b/tests/t078_max_stack.py
@@ -16,4 +16,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s --max-stack=3 %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s --max-stack=3 %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t079_replay_kernel_D.py
+++ b/tests/t079_replay_kernel_D.py
@@ -30,12 +30,12 @@ class TestCase(TestBase):
             return TestBase.TEST_SKIP
 
         record_cmd = '%s record -K3 -N %s@kernel -d %s %s' % \
-                     (TestBase.ftrace, 'smp_irq_work_interrupt', TDIR, 't-' + self.name)
+                     (TestBase.uftrace_cmd, 'smp_irq_work_interrupt', TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -k -D3 -d %s' % (TestBase.ftrace, TDIR)
+        return '%s replay -k -D3 -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t080_replay_kernel_D2.py
+++ b/tests/t080_replay_kernel_D2.py
@@ -26,12 +26,12 @@ class TestCase(TestBase):
             return TestBase.TEST_SKIP
 
         record_cmd = '%s record -K3 -N %s@kernel -d %s %s' % \
-                     (TestBase.ftrace, 'smp_irq_work_interrupt', TDIR, 't-' + self.name)
+                     (TestBase.uftrace_cmd, 'smp_irq_work_interrupt', TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -k -D2 -d %s' % (TestBase.ftrace, TDIR)
+        return '%s replay -k -D2 -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t081_kernel_depth.py
+++ b/tests/t081_kernel_depth.py
@@ -33,7 +33,7 @@ class TestCase(TestBase):
 
     def runcmd(self):
         return '%s -k --kernel-depth=2 -N %s@kernel -N %s@kernel %s' % \
-            (TestBase.ftrace, 'exit_to_usermode_loop', 'smp_irq_work_interrupt', 't-' + self.name)
+            (TestBase.uftrace_cmd, 'exit_to_usermode_loop', 'smp_irq_work_interrupt', 't-' + self.name)
 
     def fixup(self, cflags, result):
         return result.replace('sys_open', 'sys_openat')

--- a/tests/t082_arg_many.py
+++ b/tests/t082_arg_many.py
@@ -36,4 +36,4 @@ class TestCase(TestBase):
         argopt  = '-A "many@arg1/i32,arg2/i32,arg3/i32,arg4/i32,'
         argopt += 'arg5/i32,arg6/i32,arg7/i32,arg8/i32,arg9/i32,'
         argopt += 'arg10/i32,arg11/i32,arg12/i32,arg13/i32"'
-        return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)
+        return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)

--- a/tests/t083_arg_float.py
+++ b/tests/t083_arg_float.py
@@ -40,4 +40,4 @@ class TestCase(TestBase):
             argopt += '-A "float_mul@fparg1/64,fparg3/32" -R "float_mul@retval/f64" '
             argopt += '-A "float_div@fparg1/64,fparg3/64" -R "float_div@retval/f64"'
 
-        return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)
+        return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)

--- a/tests/t084_arg_mixed.py
+++ b/tests/t084_arg_mixed.py
@@ -40,4 +40,4 @@ class TestCase(TestBase):
             argopt += '-A "mixed_div@arg1/i64,fparg1/80%stack+3" -R "mixed_div@retval/f80" '
             argopt += '-A "mixed_str@arg1/s,fparg1"              -R "mixed_str@retval/s"'
 
-        return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)
+        return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)

--- a/tests/t085_arg_reg.py
+++ b/tests/t085_arg_reg.py
@@ -37,4 +37,4 @@ class TestCase(TestBase):
             argopt = argopt.replace('%xmm0', '%d0')
             argopt = argopt.replace('fparg1/80%stack+1', 'fparg1/80')
 
-        return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)
+        return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)

--- a/tests/t086_arg_stack.py
+++ b/tests/t086_arg_stack.py
@@ -44,4 +44,4 @@ class TestCase(TestBase):
             argopt += '-A "many@arg3/i32%stack+9,arg4/i32%stack+10" '
             argopt += '-A "many@arg5/i32%stack11,arg6/i32%stack12,arg7/i32%stack13"'
 
-        return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)
+        return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)

--- a/tests/t087_arg_variadic.py
+++ b/tests/t087_arg_variadic.py
@@ -32,7 +32,7 @@ class TestCase(TestBase):
             argopt  = '-A "variadic@arg1/s,arg2/c,arg3/s,arg4,arg5,arg6,arg7/i64,fparg9" '
             argopt += '-A "vsnprintf@arg2,arg3/s" '
             argopt += '-A "__vsnprintf_chk@arg2,arg5/s"'
-        return '%s %s %s' % (TestBase.ftrace, argopt, 't-' + self.name)
+        return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)
 
     def fixup(self, cflags, result):
         return result.replace('vsnprintf', "__vsnprintf_chk")

--- a/tests/t088_graph_session.py
+++ b/tests/t088_graph_session.py
@@ -34,12 +34,12 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s graph -d %s %s' % (TestBase.ftrace, TDIR, FUNC)
+        return '%s graph -d %s %s' % (TestBase.uftrace_cmd, TDIR, FUNC)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t089_graph_exit.py
+++ b/tests/t089_graph_exit.py
@@ -21,12 +21,12 @@ class TestCase(TestBase):
 """, sort='graph')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s graph -d %s %s' % (TestBase.ftrace, TDIR, FUNC)
+        return '%s graph -d %s %s' % (TestBase.uftrace_cmd, TDIR, FUNC)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t090_report_recursive.py
+++ b/tests/t090_report_recursive.py
@@ -21,12 +21,12 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s report -d %s' % (TestBase.ftrace, TDIR)
+        return '%s report -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t091_replay_tid.py
+++ b/tests/t091_replay_tid.py
@@ -23,7 +23,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
@@ -39,7 +39,7 @@ class TestCase(TestBase):
                 pass
         if t == 0:
             return 'FAILED TO FIND TID'
-        return '%s replay -d %s -F main --tid %d' % (TestBase.ftrace, TDIR, t)
+        return '%s replay -d %s -F main --tid %d' % (TestBase.uftrace_cmd, TDIR, t)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t092_report_tid.py
+++ b/tests/t092_report_tid.py
@@ -22,7 +22,7 @@ class TestCase(TestBase):
 """, sort='report')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
@@ -38,7 +38,7 @@ class TestCase(TestBase):
                 pass
         if t == 0:
             return 'FAILED TO FIND TID'
-        return '%s report -d %s --tid %d' % (TestBase.ftrace, TDIR, t)
+        return '%s report -d %s --tid %d' % (TestBase.uftrace_cmd, TDIR, t)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t093_report_filter.py
+++ b/tests/t093_report_filter.py
@@ -18,12 +18,12 @@ class TestCase(TestBase):
 """, sort='report')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s report -d %s -F main -N c' % (TestBase.ftrace, TDIR)
+        return '%s report -d %s -F main -N c' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t094_report_depth.py
+++ b/tests/t094_report_depth.py
@@ -21,12 +21,12 @@ class TestCase(TestBase):
 """, sort='report')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s report -d %s -D 3' % (TestBase.ftrace, TDIR)
+        return '%s report -d %s -D 3' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t095_graph_tid.py
+++ b/tests/t095_graph_tid.py
@@ -23,7 +23,7 @@ class TestCase(TestBase):
 """, sort='graph')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
@@ -39,7 +39,7 @@ class TestCase(TestBase):
                 pass
         if t == 0:
             return 'FAILED TO FIND TID'
-        return '%s graph -d %s --tid %d %s' % (TestBase.ftrace, TDIR, t, FUNC)
+        return '%s graph -d %s --tid %d %s' % (TestBase.uftrace_cmd, TDIR, t, FUNC)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t096_graph_filter.py
+++ b/tests/t096_graph_filter.py
@@ -21,12 +21,12 @@ class TestCase(TestBase):
 """, sort='graph')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s graph -d %s -F main -N c %s' % (TestBase.ftrace, TDIR, FUNC)
+        return '%s graph -d %s -F main -N c %s' % (TestBase.uftrace_cmd, TDIR, FUNC)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t097_dump_basic.py
+++ b/tests/t097_dump_basic.py
@@ -34,12 +34,12 @@ reading 5231.dat
 """, sort='dump')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s dump -d %s' % (TestBase.ftrace, TDIR)
+        return '%s dump -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t098_dump_tid.py
+++ b/tests/t098_dump_tid.py
@@ -35,7 +35,7 @@ reading 5188.dat
 """, sort='dump')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
@@ -51,7 +51,7 @@ reading 5188.dat
                 pass
         if t == 0:
             return 'FAILED TO FIND TID'
-        return '%s dump -d %s --tid %d' % (TestBase.ftrace, TDIR, t)
+        return '%s dump -d %s --tid %d' % (TestBase.uftrace_cmd, TDIR, t)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t099_dump_filter.py
+++ b/tests/t099_dump_filter.py
@@ -26,12 +26,12 @@ reading 5231.dat
 """, sort='dump')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s dump -d %s -F main -N c' % (TestBase.ftrace, TDIR)
+        return '%s dump -d %s -F main -N c' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t100_dump_depth.py
+++ b/tests/t100_dump_depth.py
@@ -26,12 +26,12 @@ reading 5231.dat
 """, sort='dump')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s dump -d %s -F main -D 3' % (TestBase.ftrace, TDIR)
+        return '%s dump -d %s -F main -D 3' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t101_dump_chrome.py
+++ b/tests/t101_dump_chrome.py
@@ -24,12 +24,12 @@ class TestCase(TestBase):
 """, sort='chrome')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s dump -d %s -F main -D 4 --chrome' % (TestBase.ftrace, TDIR)
+        return '%s dump -d %s -F main -D 4 --chrome' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t102_dump_flamegraph.py
+++ b/tests/t102_dump_flamegraph.py
@@ -15,12 +15,12 @@ main;a;b;c 1
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s dump -d %s -F main -D 4 --flame-graph' % (TestBase.ftrace, TDIR)
+        return '%s dump -d %s -F main -D 4 --flame-graph' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t103_dump_kernel.py
+++ b/tests/t103_dump_kernel.py
@@ -55,12 +55,12 @@ class TestCase(TestBase):
             return TestBase.TEST_SKIP
 
         record_cmd = '%s record -k -N %s@kernel -d %s %s' % \
-                     (TestBase.ftrace, 'smp_irq_work_interrupt', TDIR, 't-' + self.name)
+                     (TestBase.uftrace_cmd, 'smp_irq_work_interrupt', TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s dump -k --chrome -d %s' % (TestBase.ftrace, TDIR)
+        return '%s dump -k --chrome -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t104_graph_kernel.py
+++ b/tests/t104_graph_kernel.py
@@ -48,12 +48,12 @@ class TestCase(TestBase):
             return TestBase.TEST_SKIP
 
         record_cmd = '%s record -k -N %s@kernel -d %s %s' % \
-                     (TestBase.ftrace, 'smp_irq_work_interrupt', TDIR, 't-' + self.name)
+                     (TestBase.uftrace_cmd, 'smp_irq_work_interrupt', TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s graph -k -d %s %s' % (TestBase.ftrace, TDIR, FUNC)
+        return '%s graph -k -d %s %s' % (TestBase.uftrace_cmd, TDIR, FUNC)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t105_replay_time.py
+++ b/tests/t105_replay_time.py
@@ -19,12 +19,12 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -t 1ms -d %s' % (TestBase.ftrace, TDIR)
+        return '%s replay -t 1ms -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t106_report_time.py
+++ b/tests/t106_report_time.py
@@ -17,12 +17,12 @@ class TestCase(TestBase):
 """, sort='report')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s report -t 1ms -d %s' % (TestBase.ftrace, TDIR)
+        return '%s report -t 1ms -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t107_dump_time.py
+++ b/tests/t107_dump_time.py
@@ -24,12 +24,12 @@ class TestCase(TestBase):
 """, sort='chrome')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s dump -d %s -t 1ms --chrome' % (TestBase.ftrace, TDIR)
+        return '%s dump -d %s -t 1ms --chrome' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t108_graph_time.py
+++ b/tests/t108_graph_time.py
@@ -22,12 +22,12 @@ class TestCase(TestBase):
 """, sort='graph')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s graph -t 1ms -d %s %s' % (TestBase.ftrace, TDIR, FUNC)
+        return '%s graph -t 1ms -d %s %s' % (TestBase.uftrace_cmd, TDIR, FUNC)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t109_replay_time_A.py
+++ b/tests/t109_replay_time_A.py
@@ -25,13 +25,13 @@ class TestCase(TestBase):
 
     def pre(self):
         record_cmd = "%s record -A %s -A %s -R %s -d %s %s" % \
-                     (TestBase.ftrace, 'main@arg1', '(malloc|free|usleep)@plt,arg1', \
+                     (TestBase.uftrace_cmd, 'main@arg1', '(malloc|free|usleep)@plt,arg1', \
                       'malloc@retval', TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -t 1ms -d %s' % (TestBase.ftrace, TDIR)
+        return '%s replay -t 1ms -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t110_replay_time_T.py
+++ b/tests/t110_replay_time_T.py
@@ -22,12 +22,12 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = "%s record -d %s %s" % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = "%s record -d %s %s" % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -t 1ms -T malloc@trace -d %s' % (TestBase.ftrace, TDIR)
+        return '%s replay -t 1ms -T malloc@trace -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t111_kernel_tid.py
+++ b/tests/t111_kernel_tid.py
@@ -35,7 +35,7 @@ class TestCase(TestBase):
             return TestBase.TEST_SKIP
 
         record_cmd = '%s record -k -N %s@kernel -N %s@kernel -d %s %s' % \
-                     (TestBase.ftrace, '*page_fault', 'smp_irq_work_interrupt', TDIR, 't-' + self.name)
+                     (TestBase.uftrace_cmd, '*page_fault', 'smp_irq_work_interrupt', TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
@@ -51,7 +51,7 @@ class TestCase(TestBase):
                 pass
         if t == 0:
             return 'FAILED TO FIND TID'
-        return '%s replay -k -d %s --tid %d' % (TestBase.ftrace, TDIR, t)
+        return '%s replay -k -d %s --tid %d' % (TestBase.uftrace_cmd, TDIR, t)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t112_replay_skip.py
+++ b/tests/t112_replay_skip.py
@@ -22,12 +22,12 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = "%s record -d %s %s" % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = "%s record -d %s %s" % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -F main -d %s' % (TestBase.ftrace, TDIR)
+        return '%s replay -F main -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t113_trigger_time.py
+++ b/tests/t113_trigger_time.py
@@ -19,4 +19,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -t 1ms -T mem_alloc@time=0 %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -t 1ms -T mem_alloc@time=0 %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t114_replay_trg_time.py
+++ b/tests/t114_replay_trg_time.py
@@ -22,12 +22,12 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -t 1ms -T mem_alloc@time=0 -d %s' % (TestBase.ftrace, TDIR)
+        return '%s replay -t 1ms -T mem_alloc@time=0 -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t115_replay_field.py
+++ b/tests/t115_replay_field.py
@@ -21,12 +21,12 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -F main -f time,duration,tid -d %s' % (TestBase.ftrace, TDIR)
+        return '%s replay -F main -f time,duration,tid -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t116_field_none.py
+++ b/tests/t116_field_none.py
@@ -17,7 +17,7 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -F main -f none %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -F main -f none %s' % (TestBase.uftrace_cmd, 't-' + self.name)
 
     def sort(self, output, ignore_children=False):
         return output

--- a/tests/t117_time_range.py
+++ b/tests/t117_time_range.py
@@ -21,11 +21,11 @@ class TestCase(TestBase):
     def pre(self):
         global START
 
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
 
         # find timestamp of function 'c'
-        replay_cmd = '%s replay -d %s -f time -F main' % (TestBase.ftrace, TDIR)
+        replay_cmd = '%s replay -d %s -f time -F main' % (TestBase.uftrace_cmd, TDIR)
         p = sp.Popen(replay_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
         r = p.communicate()[0].decode(errors='ignore')
         START = r.split('\n')[4].split()[0] # skip header, main, a and b (= 4)
@@ -34,7 +34,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -f time -r %s~ -d %s' % (TestBase.ftrace, START, TDIR)
+        return '%s replay -f time -r %s~ -d %s' % (TestBase.uftrace_cmd, START, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t118_thread_tsd.py
+++ b/tests/t118_thread_tsd.py
@@ -26,7 +26,7 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s %s' % (TestBase.uftrace_cmd, 't-' + self.name)
 
     def fixup(self, cflags, result):
         return result.replace('tsd_dtor();', """tsd_dtor() {

--- a/tests/t119_malloc_hook.py
+++ b/tests/t119_malloc_hook.py
@@ -13,4 +13,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -F main %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -F main %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t120_malloc_tsd.py
+++ b/tests/t120_malloc_tsd.py
@@ -26,4 +26,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -F main -F thread %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -F main -F thread %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t121_malloc_fork.py
+++ b/tests/t121_malloc_fork.py
@@ -27,4 +27,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s --no-merge %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s --no-merge %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t122_time_range2.py
+++ b/tests/t122_time_range2.py
@@ -21,11 +21,11 @@ class TestCase(TestBase):
     def pre(self):
         global START
 
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
 
         # find timestamp of function 'c'
-        replay_cmd = '%s replay -d %s -f elapsed -F main' % (TestBase.ftrace, TDIR)
+        replay_cmd = '%s replay -d %s -f elapsed -F main' % (TestBase.uftrace_cmd, TDIR)
         p = sp.Popen(replay_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
         r = p.communicate()[0].decode(errors='ignore')
         START, unit = r.split('\n')[4].split()[0:2] # skip header, main, a and b (= 4)
@@ -35,7 +35,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -f elapsed -r %s~ -d %s' % (TestBase.ftrace, START, TDIR)
+        return '%s replay -f elapsed -r %s~ -d %s' % (TestBase.uftrace_cmd, START, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t124_exception.py
+++ b/tests/t124_exception.py
@@ -26,7 +26,7 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s %s %s' % (TestBase.ftrace, '-N personality_v.', 't-' + self.name)
+        return '%s %s %s' % (TestBase.uftrace_cmd, '-N personality_v.', 't-' + self.name)
 
     def fixup(self, cflags, result):
         r = result.replace("} /* oops */", """} /* oops */

--- a/tests/t125_report_range.py
+++ b/tests/t125_report_range.py
@@ -21,11 +21,11 @@ class TestCase(TestBase):
     def pre(self):
         global START
 
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
 
         # find timestamp of function 'c'
-        replay_cmd = '%s replay -d %s -f time -F main' % (TestBase.ftrace, TDIR)
+        replay_cmd = '%s replay -d %s -f time -F main' % (TestBase.uftrace_cmd, TDIR)
         p = sp.Popen(replay_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
         r = p.communicate()[0].decode(errors='ignore')
         START = r.split('\n')[6].split()[0] # skip header, main, a, b, c and getpid (= 6)
@@ -34,7 +34,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s report -F main -r ~%s -d %s' % (TestBase.ftrace, START, TDIR)
+        return '%s report -F main -r ~%s -d %s' % (TestBase.uftrace_cmd, START, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t126_arg_regex.py
+++ b/tests/t126_arg_regex.py
@@ -42,4 +42,4 @@ class TestCase(TestBase):
         return TestBase.build(self, name, cflags, ldflags)
 
     def runcmd(self):
-        return '%s -A "alloc*@arg1" %s' % (TestBase.ftrace, 't-allocfree')
+        return '%s -A "alloc*@arg1" %s' % (TestBase.uftrace_cmd, 't-allocfree')

--- a/tests/t127_arg_module.py
+++ b/tests/t127_arg_module.py
@@ -42,4 +42,4 @@ class TestCase(TestBase):
         return TestBase.build(self, name, cflags, ldflags)
 
     def runcmd(self):
-        return '%s -A "alloc*@t-allocfree,arg1" %s' % (TestBase.ftrace, 't-allocfree')
+        return '%s -A "alloc*@t-allocfree,arg1" %s' % (TestBase.uftrace_cmd, 't-allocfree')

--- a/tests/t128_arg_module2.py
+++ b/tests/t128_arg_module2.py
@@ -42,4 +42,4 @@ class TestCase(TestBase):
         return TestBase.build(self, name, cflags, ldflags)
 
     def runcmd(self):
-        return '%s -A "alloc*@PLT,arg1" %s' % (TestBase.ftrace, 't-allocfree')
+        return '%s -A "alloc*@PLT,arg1" %s' % (TestBase.uftrace_cmd, 't-allocfree')

--- a/tests/t129_session_tid.py
+++ b/tests/t129_session_tid.py
@@ -28,7 +28,7 @@ class TestCase(TestBase):
         return ret
         
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-abc')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-abc')
         sp.call(record_cmd.split())
         # Replace pid by tid on the SESS line to test backward-compatibility
         sed_cmd = 'sed -i "/SESS/s/pid/tid/g" %s/task.txt' % (TDIR)
@@ -36,7 +36,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -d %s' % (TestBase.ftrace, TDIR)
+        return '%s replay -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t130_thread_exec.py
+++ b/tests/t130_thread_exec.py
@@ -35,4 +35,4 @@ task: 23290
         return ret
 
     def runcmd(self):
-        return '%s -N ^__ %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -N ^__ %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t132_trigger_kernel.py
+++ b/tests/t132_trigger_kernel.py
@@ -32,7 +32,7 @@ class TestCase(TestBase):
         # the -T option works on replay time and accept a regex
         # while -N option works on record time and accept a glob
         return '%s -K3 -T %s@kernel,depth=1 -N %s@kernel -N %s@kernel %s' % \
-            (TestBase.ftrace, '^sys_', 'exit_to_usermode_loop', 'smp_irq_work_interrupt', 't-' + self.name)
+            (TestBase.uftrace_cmd, '^sys_', 'exit_to_usermode_loop', 'smp_irq_work_interrupt', 't-' + self.name)
 
     def fixup(self, cflags, result):
         return result.replace('sys_open', 'sys_openat')

--- a/tests/t133_long_string.py
+++ b/tests/t133_long_string.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
 
     def runcmd(self):
         return '%s -A printf@arg1/s,arg2/s -A __printf_chk@arg2/s,arg3/s %s %s' % \
-            (TestBase.ftrace, 't-' + self.name, "0123456789" * 10)
+            (TestBase.uftrace_cmd, 't-' + self.name, "0123456789" * 10)
 
     def fixup(self, cflags, result):
         return result.replace('printf', '__printf_chk')

--- a/tests/t135_trigger_time2.py
+++ b/tests/t135_trigger_time2.py
@@ -27,11 +27,11 @@ class TestCase(TestBase):
     def pre(self):
         global TIME, UNIT
 
-        record_cmd = '%s record -F main -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -F main -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
 
         # find timestamp of function 'malloc'
-        replay_cmd = '%s replay -d %s -F malloc' % (TestBase.ftrace, TDIR)
+        replay_cmd = '%s replay -d %s -F malloc' % (TestBase.uftrace_cmd, TDIR)
         p = sp.Popen(replay_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
         r = p.communicate()[0].decode(errors='ignore')
         TIME, UNIT = r.split('\n')[1].split()[0:2] # skip header
@@ -41,7 +41,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -T main@time=%.3f%s -d %s' % (TestBase.ftrace, TIME, UNIT, TDIR)
+        return '%s replay -T main@time=%.3f%s -d %s' % (TestBase.uftrace_cmd, TIME, UNIT, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t136_dynamic.py
+++ b/tests/t136_dynamic.py
@@ -24,4 +24,4 @@ class TestCase(TestBase):
         return TestBase.build(self, name, '-pg -mfentry -mnop-mcount', ldflags)
 
     def runcmd(self):
-        return '%s -P %s %s' % (TestBase.ftrace, 'a.?', 't-' + self.name)
+        return '%s -P %s %s' % (TestBase.uftrace_cmd, 'a.?', 't-' + self.name)

--- a/tests/t137_kernel_tid_update.py
+++ b/tests/t137_kernel_tid_update.py
@@ -37,6 +37,6 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         filters = '-F main -F sys_open@kernel -F sys_close@kernel'
         return '%s -k %s %s' % (uftrace, filters, 't-' + self.name)

--- a/tests/t138_kernel_dynamic.py
+++ b/tests/t138_kernel_dynamic.py
@@ -27,7 +27,7 @@ class TestCase(TestBase):
 
     def runcmd(self):
         return '%s -k -P %s %s openclose' % \
-            (TestBase.ftrace, 'sys_*@kernel', 't-' + self.name)
+            (TestBase.uftrace_cmd, 'sys_*@kernel', 't-' + self.name)
 
     def fixup(self, cflags, result):
         return result.replace('sys_open', 'sys_openat')

--- a/tests/t139_kernel_dynamic2.py
+++ b/tests/t139_kernel_dynamic2.py
@@ -26,4 +26,4 @@ class TestCase(TestBase):
     # check syscall name would corrected (for SyS_ prefix)
     def runcmd(self):
         return '%s -k -P %s %s openclose' % \
-            (TestBase.ftrace, 'sys_open@kernel', 't-' + self.name)
+            (TestBase.uftrace_cmd, 'sys_open@kernel', 't-' + self.name)

--- a/tests/t140_dynamic_xray.py
+++ b/tests/t140_dynamic_xray.py
@@ -28,4 +28,4 @@ class TestCase(TestBase):
         return r
 
     def runcmd(self):
-        return '%s -P %s %s' % (TestBase.ftrace, 'a.?', 't-' + self.name)
+        return '%s -P %s %s' % (TestBase.uftrace_cmd, 'a.?', 't-' + self.name)

--- a/tests/t141_recv_basic.py
+++ b/tests/t141_recv_basic.py
@@ -25,15 +25,15 @@ class TestCase(TestBase):
     recv_p = None
 
     def pre(self):
-        recv_cmd = '%s recv -d %s' % (TestBase.ftrace, TDIR)
+        recv_cmd = '%s recv -d %s' % (TestBase.uftrace_cmd, TDIR)
         self.recv_p = sp.Popen(recv_cmd.split())
 
-        record_cmd = '%s record -H %s %s' % (TestBase.ftrace, 'localhost', 't-abc')
+        record_cmd = '%s record -H %s %s' % (TestBase.uftrace_cmd, 'localhost', 't-abc')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -d %s' % (TestBase.ftrace, TDIR2)
+        return '%s replay -d %s' % (TestBase.uftrace_cmd, TDIR2)
 
     def post(self, ret):
         self.recv_p.terminate()

--- a/tests/t142_recv_multi.py
+++ b/tests/t142_recv_multi.py
@@ -25,22 +25,22 @@ class TestCase(TestBase):
     recv_p = None
 
     def pre(self):
-        recv_cmd = '%s recv -d %s' % (TestBase.ftrace, TDIR)
+        recv_cmd = '%s recv -d %s' % (TestBase.uftrace_cmd, TDIR)
         self.recv_p = sp.Popen(recv_cmd.split())
 
         # recorded but not used
-        record_cmd = '%s record -H %s %s' % (TestBase.ftrace, 'localhost', 't-abc')
+        record_cmd = '%s record -H %s %s' % (TestBase.uftrace_cmd, 'localhost', 't-abc')
         sp.call(record_cmd.split())
 
         # use this
-        record_cmd = '%s record -H %s -d %s %s' % (TestBase.ftrace, 'localhost', TDIR2, 't-abc')
+        record_cmd = '%s record -H %s -d %s %s' % (TestBase.uftrace_cmd, 'localhost', TDIR2, 't-abc')
         sp.call(record_cmd.split())
 
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
         import os.path
-        return '%s replay -d %s' % (TestBase.ftrace, os.path.join(TDIR, TDIR2))
+        return '%s replay -d %s' % (TestBase.uftrace_cmd, os.path.join(TDIR, TDIR2))
 
     def post(self, ret):
         self.recv_p.terminate()

--- a/tests/t143_recv_kernel.py
+++ b/tests/t143_recv_kernel.py
@@ -32,16 +32,16 @@ class TestCase(TestBase):
         if os.path.exists('/.dockerenv'):
             return TestBase.TEST_SKIP
 
-        recv_cmd = '%s recv -d %s' % (TestBase.ftrace, TDIR)
+        recv_cmd = '%s recv -d %s' % (TestBase.uftrace_cmd, TDIR)
         self.recv_p = sp.Popen(recv_cmd.split())
 
         record_cmd = '%s record -H %s -k -N %s@kernel -d %s %s' % \
-                     (TestBase.ftrace, 'localhost', 'smp_irq_work_interrupt', TDIR2, 't-' + self.name)
+                     (TestBase.uftrace_cmd, 'localhost', 'smp_irq_work_interrupt', TDIR2, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -d %s' % (TestBase.ftrace, os.path.join(TDIR, TDIR2))
+        return '%s replay -d %s' % (TestBase.uftrace_cmd, os.path.join(TDIR, TDIR2))
 
     def post(self, ret):
         self.recv_p.terminate()

--- a/tests/t145_longjmp3.py
+++ b/tests/t145_longjmp3.py
@@ -36,7 +36,7 @@ class TestCase(TestBase):
 
     def runcmd(self):
         args = '-A .?longjmp@arg2 -R .?setjmp@retval'
-        return '%s %s %s' % (TestBase.ftrace, args, 't-' + self.name)
+        return '%s %s %s' % (TestBase.uftrace_cmd, args, 't-' + self.name)
 
     def fixup(self, cflags, result):
         return result.replace('__longjmp_chk', "longjmp")

--- a/tests/t146_arg_std_string.py
+++ b/tests/t146_arg_std_string.py
@@ -32,4 +32,4 @@ class TestCase(TestBase):
         retval = '-R ^std_string_ret@retval/S'
         opts = '-F main -F ^std_string_ -D 1'
         name = 't-' + self.name
-        return '%s %s %s %s %s' % (TestBase.ftrace, arg, retval, opts, name)
+        return '%s %s %s %s %s' % (TestBase.uftrace_cmd, arg, retval, opts, name)

--- a/tests/t147_event_sdt.py
+++ b/tests/t147_event_sdt.py
@@ -16,4 +16,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -E uftrace:* %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -E uftrace:* %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t148_event_kernel.py
+++ b/tests/t148_event_kernel.py
@@ -58,4 +58,4 @@ class TestCase(TestBase):
     def runcmd(self):
         arg  = '-E sched_switch@kernel'
         name = 't-' + self.name
-        return '%s %s %s' % (TestBase.ftrace, arg, name)
+        return '%s %s %s' % (TestBase.uftrace_cmd, arg, name)

--- a/tests/t149_event_kernel2.py
+++ b/tests/t149_event_kernel2.py
@@ -68,4 +68,4 @@ class TestCase(TestBase):
     def runcmd(self):
         arg  = '-E sched:sched_process_*@kernel --kernel-full --event-full'
         name = 't-' + self.name
-        return '%s %s %s' % (TestBase.ftrace, arg, name)
+        return '%s %s %s' % (TestBase.uftrace_cmd, arg, name)

--- a/tests/t150_recv_event.py
+++ b/tests/t150_recv_event.py
@@ -22,18 +22,18 @@ class TestCase(TestBase):
     recv_p = None
 
     def pre(self):
-        recv_cmd = '%s recv -d %s' % (TestBase.ftrace, TDIR)
+        recv_cmd = '%s recv -d %s' % (TestBase.uftrace_cmd, TDIR)
         self.recv_p = sp.Popen(recv_cmd.split())
 
         server = '-H 127.0.0.1'
         option = '-E uftrace:event'
         prog   = 't-' + self.name
-        record_cmd = '%s record %s %s %s' % (TestBase.ftrace, server, option, prog)
+        record_cmd = '%s record %s %s %s' % (TestBase.uftrace_cmd, server, option, prog)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -d %s' % (TestBase.ftrace, TDIR2)
+        return '%s replay -d %s' % (TestBase.uftrace_cmd, TDIR2)
 
     def post(self, ret):
         self.recv_p.terminate()

--- a/tests/t151_recv_runcmd.py
+++ b/tests/t151_recv_runcmd.py
@@ -27,10 +27,10 @@ class TestCase(TestBase):
 
     def pre(self):
         self.file_p = open(TMPF, 'w+')
-        recv_cmd = TestBase.ftrace.split() + ['recv', '-d', TDIR, '--run-cmd', TestBase.ftrace + ' replay']
+        recv_cmd = TestBase.uftrace_cmd.split() + ['recv', '-d', TDIR, '--run-cmd', TestBase.uftrace_cmd + ' replay']
         self.recv_p = sp.Popen(recv_cmd, stdout=self.file_p, stderr=self.file_p)
 
-        record_cmd = '%s record -H %s %s' % (TestBase.ftrace, 'localhost', 't-' + self.name)
+        record_cmd = '%s record -H %s %s' % (TestBase.uftrace_cmd, 'localhost', 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t152_read_proc_statm.py
+++ b/tests/t152_read_proc_statm.py
@@ -20,7 +20,7 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         args    = '-F main -T b@read=proc/statm'
         prog    = 't-' + self.name
         return '%s %s %s' % (uftrace, args, prog)

--- a/tests/t153_read_page_fault.py
+++ b/tests/t153_read_page_fault.py
@@ -20,7 +20,7 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         args    = '-F main -T b@read=page-fault'
         prog    = 't-' + self.name
         return '%s %s %s' % (uftrace, args, prog)

--- a/tests/t154_keep_pid.py
+++ b/tests/t154_keep_pid.py
@@ -25,7 +25,7 @@ task: 22067
 """)
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '--keep-pid --no-pager'
         program ='t-' + self.name
         return '%s %s %s' % (uftrace, options, program)

--- a/tests/t155_trigger_finish.py
+++ b/tests/t155_trigger_finish.py
@@ -23,7 +23,7 @@ task: 4131
 """)
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '-F main -T getpid@finish'
         program = 't-' + self.name
         return '%s %s %s' % (uftrace, options, program)

--- a/tests/t156_trigger_finish2.py
+++ b/tests/t156_trigger_finish2.py
@@ -25,7 +25,7 @@ task: 6565
 """, lang='C++')
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '-F main -T ns::ns1::foo::bar3@finish'
         program = 't-' + self.name
         return '%s %s %s' % (uftrace, options, program)

--- a/tests/t157_script_python.py
+++ b/tests/t157_script_python.py
@@ -10,12 +10,12 @@ class TestCase(TestBase):
         TestBase.__init__(self, 'abc', '5')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-abc')
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-abc')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '-F main -S ../scripts/count.py'
         return '%s script -d %s %s' % (uftrace, TDIR, options)
 

--- a/tests/t158_report_diff_policy1.py
+++ b/tests/t158_report_diff_policy1.py
@@ -24,14 +24,14 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s -F main %s 0' % (TestBase.ftrace, XDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s -F main %s 0' % (TestBase.uftrace_cmd, XDIR, 't-' + self.name)
         sp.call(record_cmd.split())
-        record_cmd = '%s record -d %s -F main %s 1' % (TestBase.ftrace, YDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s -F main %s 1' % (TestBase.uftrace_cmd, YDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '--diff-policy compact,no-percent,abs'  # new default
         return '%s report -d %s --diff %s %s' % (uftrace, XDIR, YDIR, options)
 

--- a/tests/t159_report_diff_policy2.py
+++ b/tests/t159_report_diff_policy2.py
@@ -24,14 +24,14 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s -F main %s 0' % (TestBase.ftrace, XDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s -F main %s 0' % (TestBase.uftrace_cmd, XDIR, 't-' + self.name)
         sp.call(record_cmd.split())
-        record_cmd = '%s record -d %s -F main %s 1' % (TestBase.ftrace, YDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s -F main %s 1' % (TestBase.uftrace_cmd, YDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '--diff-policy full,no-abs -s call,total'
         return '%s report -d %s --diff %s %s' % (uftrace, YDIR, XDIR, options)
 

--- a/tests/t160_report_diff_policy3.py
+++ b/tests/t160_report_diff_policy3.py
@@ -24,14 +24,14 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s -F main %s 0' % (TestBase.ftrace, XDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s -F main %s 0' % (TestBase.uftrace_cmd, XDIR, 't-' + self.name)
         sp.call(record_cmd.split())
-        record_cmd = '%s record -d %s -F main %s 1' % (TestBase.ftrace, YDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s -F main %s 1' % (TestBase.uftrace_cmd, YDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '--diff-policy percent -s func'
         return '%s report -d %s --diff %s %s' % (uftrace, XDIR, YDIR, options)
 

--- a/tests/t163_event_sched.py
+++ b/tests/t163_event_sched.py
@@ -23,7 +23,7 @@ class TestCase(TestBase):
         return TestCase.TEST_SUCCESS
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '-D 2 -F main -F bar -E linux:schedule'
         program = 't-' + self.name
         return '%s %s %s' % (uftrace, options, program)

--- a/tests/t164_report_sched.py
+++ b/tests/t164_report_sched.py
@@ -25,12 +25,12 @@ class TestCase(TestBase):
             return TestBase.TEST_SKIP
 
         options = '-d %s -E %s' % (TDIR, 'linux:schedule')
-        record_cmd = '%s record %s %s' % (TestBase.ftrace, options, 't-' + self.name)
+        record_cmd = '%s record %s %s' % (TestBase.uftrace_cmd, options, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s report -d %s' % (TestBase.ftrace, TDIR)
+        return '%s report -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t165_graph_sched.py
+++ b/tests/t165_graph_sched.py
@@ -29,12 +29,12 @@ class TestCase(TestBase):
             return TestBase.TEST_SKIP
 
         options = '-d %s -E %s' % (TDIR, 'linux:schedule')
-        record_cmd = '%s record %s %s' % (TestBase.ftrace, options, 't-' + self.name)
+        record_cmd = '%s record %s %s' % (TestBase.uftrace_cmd, options, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s graph -d %s %s' % (TestBase.ftrace, TDIR, FUNC)
+        return '%s graph -d %s %s' % (TestBase.uftrace_cmd, TDIR, FUNC)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t166_dump_sched.py
+++ b/tests/t166_dump_sched.py
@@ -42,12 +42,12 @@ class TestCase(TestBase):
             return TestBase.TEST_SKIP
 
         options = '-d %s -E %s' % (TDIR, 'linux:schedule')
-        record_cmd = '%s record %s %s' % (TestBase.ftrace, options, 't-' + self.name)
+        record_cmd = '%s record %s %s' % (TestBase.uftrace_cmd, options, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s dump -d %s -F main --chrome' % (TestBase.ftrace, TDIR)
+        return '%s dump -d %s -F main --chrome' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t167_recv_sched.py
+++ b/tests/t167_recv_sched.py
@@ -33,16 +33,16 @@ class TestCase(TestBase):
         if not TestBase.check_perf_paranoid(self):
             return TestBase.TEST_SKIP
 
-        recv_cmd = '%s recv -d %s' % (TestBase.ftrace, TDIR)
+        recv_cmd = '%s recv -d %s' % (TestBase.uftrace_cmd, TDIR)
         self.recv_p = sp.Popen(recv_cmd.split())
 
         options = '-H %s -E %s' % ('localhost', 'linux:schedule')
-        record_cmd = '%s record %s %s' % (TestBase.ftrace, options, 't-' + self.name)
+        record_cmd = '%s record %s %s' % (TestBase.uftrace_cmd, options, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -d %s' % (TestBase.ftrace, TDIR2)
+        return '%s replay -d %s' % (TestBase.uftrace_cmd, TDIR2)
 
     def post(self, ret):
         self.recv_p.terminate()

--- a/tests/t168_lib_nested.py
+++ b/tests/t168_lib_nested.py
@@ -26,4 +26,4 @@ class TestCase(TestBase):
                                       cflags, ldflags)
 
     def runcmd(self):
-        return "%s %s %s" % (TestBase.ftrace, "-D3 --nest-libcall", 't-' + self.name)
+        return "%s %s %s" % (TestBase.uftrace_cmd, "-D3 --nest-libcall", 't-' + self.name)

--- a/tests/t169_script_args.py
+++ b/tests/t169_script_args.py
@@ -24,7 +24,7 @@ class TestCase(TestBase):
         f.write(script)
         f.close()
 
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '-A fopen@arg1/s'
         program = 't-' + self.name
         record_cmd = '%s record -d %s %s %s' % (uftrace, TDIR, options, program)
@@ -34,7 +34,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '-S ' + FILE
         return '%s script -d %s %s' % (uftrace, TDIR, options)
 

--- a/tests/t170_script_filter.py
+++ b/tests/t170_script_filter.py
@@ -30,7 +30,7 @@ a exit
         f.write(script)
         f.close()
 
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         program = 't-' + self.name
         record_cmd = '%s record -d %s %s' % (uftrace, TDIR, program)
 
@@ -39,7 +39,7 @@ a exit
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '-S ' + FILE
         return '%s script -d %s %s' % (uftrace, TDIR, options)
 

--- a/tests/t171_script_option.py
+++ b/tests/t171_script_option.py
@@ -27,7 +27,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '-S ' + FILE
         program = 't-' + self.name
         return '%s %s %s' % (uftrace, options, program)

--- a/tests/t172_trigger_filter.py
+++ b/tests/t172_trigger_filter.py
@@ -20,7 +20,7 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '-T main@filter,depth=3 -T ^ns::ns2@notrace'
         program = 't-' + self.name
         return '%s %s %s' % (uftrace, options, program)

--- a/tests/t173_trigger_args.py
+++ b/tests/t173_trigger_args.py
@@ -32,7 +32,7 @@ class TestCase(TestBase):
         return TestBase.build(self, name, cflags, ldflags)
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '-T main@filter,depth=3,arg1'
         program = 't-' + self.name
         return '%s %s %s' % (uftrace, options, program)

--- a/tests/t174_replay_filter_kernel.py
+++ b/tests/t174_replay_filter_kernel.py
@@ -25,12 +25,12 @@ class TestCase(TestBase):
             return TestBase.TEST_SKIP
 
         record_cmd = '%s record -k -N %s@kernel -d %s %s' % \
-                     (TestBase.ftrace, 'smp_irq_work_interrupt', TDIR, 't-' + self.name)
+                     (TestBase.uftrace_cmd, 'smp_irq_work_interrupt', TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -F main -D2 -F ^sys_open@kernel -d %s' % (TestBase.ftrace, TDIR)
+        return '%s replay -F main -D2 -F ^sys_open@kernel -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t175_filter_time_read.py
+++ b/tests/t175_filter_time_read.py
@@ -20,7 +20,7 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         args    = "-F main -t 1ms -T '(foo|bar)@read=proc/statm'"
         prog    = 't-' + self.name
         return '%s %s %s' % (uftrace, args, prog)

--- a/tests/t176_arg_fptr.py
+++ b/tests/t176_arg_fptr.py
@@ -60,7 +60,7 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '--no-merge -T pthread_create@arg3/p'
         program = 't-' + self.name
         return '%s %s %s' % (uftrace, options, program)

--- a/tests/t177_report_diff_policy4.py
+++ b/tests/t177_report_diff_policy4.py
@@ -24,14 +24,14 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s -F main %s 0' % (TestBase.ftrace, XDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s -F main %s 0' % (TestBase.uftrace_cmd, XDIR, 't-' + self.name)
         sp.call(record_cmd.split())
-        record_cmd = '%s record -d %s -F main %s 1' % (TestBase.ftrace, YDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s -F main %s 1' % (TestBase.uftrace_cmd, YDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = '--diff-policy compact -s func'
         return '%s report -d %s --diff %s %s' % (uftrace, XDIR, YDIR, options)
 

--- a/tests/t178_arg_auto1.py
+++ b/tests/t178_arg_auto1.py
@@ -17,4 +17,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -F main -A ^str -R ^str %s hello' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -F main -A ^str -R ^str %s hello' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t179_arg_auto2.py
+++ b/tests/t179_arg_auto2.py
@@ -17,7 +17,7 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -F main --auto-args %s hello' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -F main --auto-args %s hello' % (TestBase.uftrace_cmd, 't-' + self.name)
 
     def sort(self, output):
         result = []

--- a/tests/t180_arg_auto3.py
+++ b/tests/t180_arg_auto3.py
@@ -19,7 +19,7 @@ class TestCase(TestBase):
     # override calloc() to save 2nd argument only
     def runcmd(self):
         return '%s -F main -A calloc@arg2 --auto-args %s hello' % \
-            (TestBase.ftrace, 't-' + self.name)
+            (TestBase.uftrace_cmd, 't-' + self.name)
 
     def sort(self, output):
         result = []

--- a/tests/t181_graph_full.py
+++ b/tests/t181_graph_full.py
@@ -30,12 +30,12 @@ class TestCase(TestBase):
 """, sort='graph')
 
     def pre(self):
-        record_cmd = '%s record %s -d %s %s' % (TestBase.ftrace, NOFILTERS, TDIR, 't-' + self.name)
+        record_cmd = '%s record %s -d %s %s' % (TestBase.uftrace_cmd, NOFILTERS, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s graph -d %s' % (TestBase.ftrace, TDIR)
+        return '%s graph -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t182_thread_exit.py
+++ b/tests/t182_thread_exit.py
@@ -32,4 +32,4 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s --no-merge %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s --no-merge %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t183_info_quote.py
+++ b/tests/t183_info_quote.py
@@ -38,14 +38,14 @@ class TestCase(TestBase):
 
     def pre(self):
         record_cmd = '%s record -d %s %s %s' % \
-                     (TestBase.ftrace, TDIR, 't-' + self.name, '"uftrace"')
+                     (TestBase.uftrace_cmd, TDIR, 't-' + self.name, '"uftrace"')
         f = open('/dev/null')
         sp.call(record_cmd.split(), stdout=f, stderr=f)
         f.close()
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s info -d %s' % (TestBase.ftrace, TDIR)
+        return '%s info -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t184_arg_enum.py
+++ b/tests/t184_arg_enum.py
@@ -19,7 +19,7 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        return '%s -F main --auto-args %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -F main --auto-args %s' % (TestBase.uftrace_cmd, 't-' + self.name)
 
     def sort(self, output):
         result = []

--- a/tests/t187_graph_field.py
+++ b/tests/t187_graph_field.py
@@ -25,12 +25,12 @@ class TestCase(TestBase):
 """, sort='graph')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s graph -f +self,addr -d %s %s' % (TestBase.ftrace, TDIR, FUNC)
+        return '%s graph -f +self,addr -d %s %s' % (TestBase.uftrace_cmd, TDIR, FUNC)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t188_graph_field_none.py
+++ b/tests/t188_graph_field_none.py
@@ -25,12 +25,12 @@ class TestCase(TestBase):
 """, sort='graph')
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s graph -f none -d %s %s' % (TestBase.ftrace, TDIR, FUNC)
+        return '%s graph -f none -d %s %s' % (TestBase.uftrace_cmd, TDIR, FUNC)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t189_replay_field2.py
+++ b/tests/t189_replay_field2.py
@@ -25,12 +25,12 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        record_cmd = '%s record -d %s %s' % (TestBase.ftrace, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
-        return '%s replay -F main -f task -d %s' % (TestBase.ftrace, TDIR)
+        return '%s replay -F main -f task -d %s' % (TestBase.uftrace_cmd, TDIR)
 
     def post(self, ret):
         sp.call(['rm', '-rf', TDIR])

--- a/tests/t190_trigger_autoargs.py
+++ b/tests/t190_trigger_autoargs.py
@@ -16,4 +16,4 @@ class TestCase(TestBase):
 
     def runcmd(self):
         return '%s -F main -T calloc@trace-off -T strcmp@trace-on,auto-args %s hello' % \
-            (TestBase.ftrace, 't-' + self.name)
+            (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t191_posix_spawn.py
+++ b/tests/t191_posix_spawn.py
@@ -37,4 +37,4 @@ class TestCase(TestBase):
         return ret
 
     def runcmd(self):
-        return '%s -F main %s' % (TestBase.ftrace, 't-' + self.name)
+        return '%s -F main %s' % (TestBase.uftrace_cmd, 't-' + self.name)

--- a/tests/t192_lib_name.py
+++ b/tests/t192_lib_name.py
@@ -26,7 +26,7 @@ class TestCase(TestBase):
                                       cflags, ldflags)
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         options = "--nest-libcall --libname -f +module"
         program = 't-' + self.name
         return "%s %s %s" % (uftrace, options, program)

--- a/tests/t193_read_pmu_cycle.py
+++ b/tests/t193_read_pmu_cycle.py
@@ -20,7 +20,7 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         args    = '-F main -T b@read=pmu-cycle'
         prog    = 't-' + self.name
         return '%s %s %s' % (uftrace, args, prog)

--- a/tests/t194_read_pmu_cache.py
+++ b/tests/t194_read_pmu_cache.py
@@ -20,7 +20,7 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         args    = '-F main -T b@read=pmu-cache'
         prog    = 't-' + self.name
         return '%s %s %s' % (uftrace, args, prog)

--- a/tests/t195_read_pmu_branch.py
+++ b/tests/t195_read_pmu_branch.py
@@ -20,7 +20,7 @@ class TestCase(TestBase):
 """)
 
     def runcmd(self):
-        uftrace = TestBase.ftrace
+        uftrace = TestBase.uftrace_cmd
         args    = '-F main -T b@read=pmu-branch'
         prog    = 't-' + self.name
         return '%s %s %s' % (uftrace, args, prog)

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -64,11 +64,11 @@ enum trigger_read_type {
 #define ARG_TYPE_REG    2
 #define ARG_TYPE_STACK  3
 
-/* should match with ftrace_arg_format above */
+/* should match with uftrace_arg_format above */
 #define ARG_SPEC_CHARS  "diuxscfSpe"
 
 /**
- * ftrace_arg_spec contains arguments and return value info.
+ * uftrace_arg_spec contains arguments and return value info.
  *
  * If idx is zero, it means the recorded data is return value.
  *

--- a/utils/session.c
+++ b/utils/session.c
@@ -95,8 +95,8 @@ static void delete_session_map(struct symtabs *symtabs)
 /**
  * create_session - create a new task session from session message
  * @sessions: session link to manage sessions and tasks
- * @msg: ftrace session message read from task file
- * @dirname: ftrace data directory name
+ * @msg: uftrace session message read from task file
+ * @dirname: uftrace data directory name
  * @exename: executable name started this session
  *
  * This function allocates a new session started by a task.  The new


### PR DESCRIPTION
This is trivial patches:
 - Rename 'ftrace' residues on some comments to 'uftrace'
 - Rename TestBase.ftrace to TestBase.uftrace_cmd to be more readable