### PR TITLE
demangler: Ignore new 'misc/demangler' binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ cscope.*
 *.sw[opn]
 *.patch
 *.orig
+misc/demangler


### PR DESCRIPTION
The commit 2094fe4 ("demangler: Add an executable
"demangler" file") generates a binary misc/demangler,
so add it to .gitignore.

Signed-off-by: Taeung Song <treeze.taeung@gmail.com>