### PR TITLE
build: Add DEBUG=1 and TRACE=1 make options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ INSTALL = install
 
 export ARCH CC AR LD RM srcdir objdir LDFLAGS
 
-COMMON_CFLAGS := -O2 -g -D_GNU_SOURCE $(CFLAGS) $(CPPFLAGS)
+COMMON_CFLAGS := -D_GNU_SOURCE $(CFLAGS) $(CPPFLAGS)
 COMMON_CFLAGS +=  -iquote $(srcdir) -iquote $(objdir) -iquote $(srcdir)/arch/$(ARCH)
 #CFLAGS-DEBUG = -g -D_GNU_SOURCE $(CFLAGS_$@)
 COMMON_LDFLAGS := -lelf -lrt -ldl -pthread $(LDFLAGS)
@@ -74,6 +74,19 @@ LIB_CFLAGS += -fPIC -fvisibility=hidden -fno-omit-frame-pointer
 UFTRACE_LDFLAGS = $(COMMON_LDFLAGS) $(LDFLAGS_$@) $(LDFLAGS_uftrace)
 DEMANGLER_LDFLAGS = $(COMMON_LDFLAGS) $(LDFLAGS_$@) $(LDFLAGS_demangler)
 LIB_LDFLAGS = $(COMMON_LDFLAGS) $(LDFLAGS_$@) $(LDFLAGS_lib) -Wl,--no-undefined
+
+ifeq ($(DEBUG), 1)
+  COMMON_CFLAGS += -O0 -g
+else
+  COMMON_CFLAGS += -O2 -g
+endif
+
+ifeq ($(TRACE), 1)
+  UFTRACE_CFLAGS += -pg -fno-omit-frame-pointer
+  DEMANGLER_CFLAGS += -pg -fno-omit-frame-pointer
+  TRACEEVENT_CFLAGS += -pg -fno-omit-frame-pointer
+  # cannot add -pg to LIB_CFLAGS because mcount() is not reentrant
+endif
 
 export UFTRACE_CFLAGS LIB_CFLAGS
 


### PR DESCRIPTION
This patch provides two make options for debugging purposes.

DEBUG option allows uftrace build with -O0 option to make it easy to run
it with some debuggers such as gdb.  The usage is as follows:

    $ make DEBUG=1

PG option allows uftrace build with -pg option to make it tracable with
another uftrace.  The usage is as follows:

    $ make PG=1

    $ uftrace -t 3ms -- uftrace record -d xxx tests/t-abc
    # DURATION     TID     FUNCTION
                [ 19570] | main() {
                [ 19570] |   command_record() {
      47.038 us [ 19570] |     fork();
                [ 19570] |     do_main_loop() {
                [ 19574] |     } /* fork */
                [ 19574] |     do_child_exec() {
                [ 19574] |       execv() {
                [ 19570] |       load_module_symtabs() {
                [ 19570] |         load_symtab() {
       3.031 ms [ 19570] |           qsort();
       4.839 ms [ 19570] |           qsort();
      10.578 ms [ 19570] |         } /* load_symtab */
       6.530 ms [ 19570] |         qsort();
                [ 19570] |         update_symtab_using_dynsym() {
       3.756 ms [ 19570] |           qsort();
       6.118 ms [ 19570] |         } /* update_symtab_using_dynsym */
       4.654 ms [ 19570] |         load_symtab();
      41.465 ms [ 19570] |       } /* load_module_symtabs */
      45.049 ms [ 19570] |     } /* do_main_loop */
      45.335 ms [ 19570] |   } /* command_record */
      45.375 ms [ 19570] | } /* main */

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>