### PR TITLE
dump: Add task name to chrome dump output

### DIFF
--- a/cmd-dump.c
+++ b/cmd-dump.c
@@ -934,9 +934,9 @@ static void print_chrome_footer(struct uftrace_dump_ops *ops,
 	buf[strlen(buf) - 1] = '\0';
 
 	pr_out("\n], \"displayTimeUnit\": \"ns\", \"metadata\": {\n");
+	pr_out("\"recorded_time\":\"%s\",\n", buf);
 	if (handle->hdr.info_mask & (1UL << CMDLINE))
-		pr_out("\"command_line\":\"%s\",\n", handle->info.cmdline);
-	pr_out("\"recorded_time\":\"%s\"\n", buf);
+		pr_out("\"command_line\":\"%s\"\n", handle->info.cmdline);
 	pr_out("} }\n");
 
 	/*

--- a/cmd-dump.c
+++ b/cmd-dump.c
@@ -1279,9 +1279,6 @@ perf:
 	if (!has_perf_data(handle) || uftrace_done)
 		goto footer;
 
-	/* force get_perf_record() to read from file */
-	handle->last_perf_idx = -1;
-
 	for (i = 0; i < handle->nr_perf; i++) {
 		struct uftrace_perf_reader *perf = &handle->perf[i];
 
@@ -1295,6 +1292,9 @@ perf:
 				break;
 
 			ops->perf_event(ops, perf, rec);
+
+			/* for re-read perf data from file */
+			perf->valid = false;
 		}
 	}
 

--- a/cmd-dump.c
+++ b/cmd-dump.c
@@ -8,6 +8,7 @@
 #include <sys/stat.h>
 
 #include "uftrace.h"
+#include "version.h"
 #include "utils/list.h"
 #include "utils/utils.h"
 #include "utils/fstack.h"
@@ -934,6 +935,7 @@ static void print_chrome_footer(struct uftrace_dump_ops *ops,
 	buf[strlen(buf) - 1] = '\0';
 
 	pr_out("\n], \"displayTimeUnit\": \"ns\", \"metadata\": {\n");
+	pr_out("\"version\":\"uftrace %s\",\n", UFTRACE_VERSION);
 	pr_out("\"recorded_time\":\"%s\",\n", buf);
 	if (handle->hdr.info_mask & (1UL << CMDLINE))
 		pr_out("\"command_line\":\"%s\"\n", handle->info.cmdline);

--- a/cmd-dump.c
+++ b/cmd-dump.c
@@ -804,8 +804,13 @@ static void print_chrome_header(struct uftrace_dump_ops *ops,
 				struct opts *opts)
 {
 	struct uftrace_chrome_dump *chrome = container_of(ops, typeof(*chrome), ops);
+	struct uftrace_info *info = &handle->info;
 
 	pr_out("{\"traceEvents\":[\n");
+	pr_out("{\"ts\":0,\"ph\":\"M\",\"pid\":%d,"
+	       "\"name\":\"process_name\","
+	       "\"args\":{\"name\":\"%s\"}},\n",
+	       info->tids[0], basename(info->exename));
 
 	chrome->last_comma = false;
 }
@@ -916,6 +921,18 @@ static void print_chrome_perf_event(struct uftrace_dump_ops *ops,
 				    struct uftrace_perf_reader *perf,
 				    struct uftrace_record *frs)
 {
+	uint64_t evt_id = frs->addr;
+
+	switch (evt_id) {
+	case EVENT_ID_PERF_COMM:
+		pr_out(",\n{\"ts\":0,\"ph\":\"M\",\"pid\":%d,"
+		       "\"name\":\"process_name\","
+		       "\"args\":{\"name\":\"%s\"}}",
+		       perf->tid, perf->u.comm.comm);
+		break;
+	default:
+		break;
+	};
 }
 
 static void print_chrome_footer(struct uftrace_dump_ops *ops,

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -275,7 +275,10 @@ class TestBase:
         for ln in o['traceEvents']:
             if ln['name'].startswith('__'):
                 continue
-            result.append("%s %s" % (ln['ph'], ln['name']))
+            if ln['ph'] == "M" and ln['name'] == "process_name":
+                result.append("%s %s %s" % (ln['ph'], ln['name'], ln['args']))
+            else:
+                result.append("%s %s" % (ln['ph'], ln['name']))
         return '\n'.join(result)
 
     def sort(self, output, ignore_children=False):

--- a/tests/t101_dump_chrome.py
+++ b/tests/t101_dump_chrome.py
@@ -9,6 +9,8 @@ class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'abc', """
 {"traceEvents":[
+{"ts":0,"ph":"M","pid":5231,"name":"process_name","args":{"name":"t-abc"}},
+{"ts":0,"ph":"M","pid":5231,"name":"thread_name","args":{"name":"t-abc"}},
 {"ts":58348873444,"ph":"B","pid":5231,"name":"main"},
 {"ts":58348873444,"ph":"B","pid":5231,"name":"a"},
 {"ts":58348873445,"ph":"B","pid":5231,"name":"b"},

--- a/tests/t107_dump_time.py
+++ b/tests/t107_dump_time.py
@@ -9,6 +9,8 @@ class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'sleep', """
 {"traceEvents":[
+{"ts":0,"ph":"M","pid":32537,"name":"process_name","args":{"name":"t-sleep"}},
+{"ts":0,"ph":"M","pid":32537,"name":"thread_name","args":{"name":"t-sleep"}},
 {"ts":56466448731,"ph":"B","pid":32537,"name":"main"},
 {"ts":56466448731,"ph":"B","pid":32537,"name":"foo"},
 {"ts":56466448742,"ph":"B","pid":32537,"name":"bar"},

--- a/tests/t166_dump_sched.py
+++ b/tests/t166_dump_sched.py
@@ -9,6 +9,8 @@ class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'sleep', """
 {"traceEvents":[
+{"ts":0,"ph":"M","pid":306,"name":"process_name","args":{"name":"t-sleep"}},
+{"ts":0,"ph":"M","pid":306,"name":"thread_name","args":{"name":"t-sleep"}},
 {"ts":112150305218.363,"ph":"B","pid":306,"name":"__monstartup"},
 {"ts":112150305220.090,"ph":"E","pid":306,"name":"__monstartup"},
 {"ts":112150305224.313,"ph":"B","pid":306,"name":"__cxa_atexit"},

--- a/tests/t196_chrome_taskname.py
+++ b/tests/t196_chrome_taskname.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+import subprocess as sp
+
+TDIR='xxx'
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'taskname', ldflags='-pthread', result="""
+{"traceEvents":[
+{"ts":0,"ph":"M","pid":4694,"name":"process_name","args":{"name":"t-taskname"}},
+{"ts":0,"ph":"M","pid":4694,"name":"thread_name","args":{"name":"t-taskname"}},
+{"ts":13453314717.085,"ph":"B","pid":4694,"name":"main"},
+{"ts":13453314717.245,"ph":"B","pid":4694,"name":"task_name1"},
+{"ts":13453314717.814,"ph":"B","pid":4694,"name":"prctl"},
+{"ts":0,"ph":"M","pid":4694,"name":"process_name","args":{"name":"foo"}},
+{"ts":0,"ph":"M","pid":4694,"name":"thread_name","args":{"name":"foo"}},
+{"ts":13453314720.072,"ph":"E","pid":4694,"name":"prctl"},
+{"ts":13453314720.665,"ph":"E","pid":4694,"name":"task_name1"},
+{"ts":13453314720.793,"ph":"B","pid":4694,"name":"task_name2"},
+{"ts":13453314720.920,"ph":"B","pid":4694,"name":"pthread_self"},
+{"ts":13453314721.080,"ph":"E","pid":4694,"name":"pthread_self"},
+{"ts":13453314721.264,"ph":"B","pid":4694,"name":"pthread_setname_np"},
+{"ts":0,"ph":"M","pid":4694,"name":"process_name","args":{"name":"bar"}},
+{"ts":0,"ph":"M","pid":4694,"name":"thread_name","args":{"name":"bar"}},
+{"ts":13453314722.478,"ph":"E","pid":4694,"name":"pthread_setname_np"},
+{"ts":13453314722.631,"ph":"E","pid":4694,"name":"task_name2"},
+{"ts":13453314722.695,"ph":"E","pid":4694,"name":"main"}
+], "displayTimeUnit": "ns", "metadata": {
+"command_line":"../uftrace --no-pager -L.. record -d xxx t-taskname",
+"recorded_time":"Tue Jan 30 16:05:24 2018"
+} }
+""", sort='chrome')
+
+    def pre(self):
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
+        sp.call(record_cmd.split())
+        return TestBase.TEST_SUCCESS
+
+    def runcmd(self):
+        return '%s dump --chrome -F main -d %s' % (TestBase.uftrace_cmd, TDIR)
+
+    def post(self, ret):
+        sp.call(['rm', '-rf', TDIR])
+        return ret

--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -412,6 +412,7 @@ ok:
 	handle->kernel = NULL;
 	handle->nr_perf = 0;
 	handle->perf = NULL;
+	handle->last_perf_idx = -1;
 	INIT_LIST_HEAD(&handle->events);
 
 	if (fread(&handle->hdr, sizeof(handle->hdr), 1, fp) != 1)

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -1788,7 +1788,6 @@ static void __fstack_consume(struct ftrace_task_handle *task,
 		}
 
 		perf->valid = false;
-		handle->last_perf_idx = -1;
 	}
 
 	update_first_timestamp(handle, task, rstack);

--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -1608,6 +1608,7 @@ retry:
 	}
 
 	memcpy(&(*taskp)->kstack, first_rstack, sizeof(*first_rstack));
+	kernel->last_read_cpu = first_cpu;
 
 	return first_cpu;
 }

--- a/utils/kernel.h
+++ b/utils/kernel.h
@@ -24,6 +24,7 @@ struct uftrace_kernel_writer {
 
 struct uftrace_kernel_reader {
 	int				nr_cpus;
+	int				last_read_cpu;
 	bool				skip_out;
 	char				*dirname;
 	int				*fds;

--- a/utils/perf.c
+++ b/utils/perf.c
@@ -370,9 +370,12 @@ again:
 
 		if (handle->needs_byte_swap) {
 			u.c.tid            = bswap_32(u.c.tid);
+			u.c.pid            = bswap_32(u.c.pid);
 			u.c.sample_id.time = bswap_64(u.c.sample_id.time);
 		}
 
+		perf->u.comm.pid  = u.c.pid;
+		perf->u.comm.exec = h.misc & PERF_RECORD_MISC_COMM_EXEC;
 		strncpy(perf->u.comm.comm, u.c.comm, sizeof(u.c.comm));
 
 		perf->time = u.c.sample_id.time;

--- a/utils/perf.c
+++ b/utils/perf.c
@@ -455,7 +455,7 @@ struct uftrace_record * get_perf_record(struct ftrace_file_handle *handle,
 {
 	static struct uftrace_record rec;
 
-	if (handle->last_perf_idx == -1) {
+	if (!perf->valid) {
 		if (read_perf_event(handle, perf) < 0)
 			return NULL;
 	}

--- a/utils/perf.h
+++ b/utils/perf.h
@@ -60,6 +60,8 @@ struct uftrace_task_event {
 };
 
 struct uftrace_comm_event {
+	int		pid;
+	bool		exec;
 	char		comm[16];
 };
 
@@ -84,6 +86,10 @@ static inline void record_perf_data(struct uftrace_perf_writer *perf,
 				    int cpu, int sock) {}
 
 #endif /* HAVE_PERF_CLOCKID */
+
+#ifndef  PERF_RECORD_MISC_COMM_EXEC
+# define PERF_RECORD_MISC_COMM_EXEC  (1 << 13)
+#endif
 
 #ifdef HAVE_PERF_CTXSW
 # define PERF_CTXSW_AVAILABLE  1


### PR DESCRIPTION
It'd be a lot better to show the task name of each process in chrome
trace output so that users can understand what the process does.

This patch adds the task name info in chrome dump output as follows:

    $ uftrace record -F main tests/t-taskname

    $ uftrace dump --chrome
    {"traceEvents":[
    {"ts":0,"ph":"M","pid":9413,"name":"process_name","args":{"name":"t-taskname"}},
    {"ts":15429161593.248,"ph":"B","pid":9413,"name":"main"},
    {"ts":15429161593.548,"ph":"B","pid":9413,"name":"task_name1"},
    {"ts":15429161593.726,"ph":"B","pid":9413,"name":"prctl"},
    {"ts":0,"ph":"M","pid":9413,"name":"process_name","args":{"name":"foo"}},
    {"ts":15429161598.204,"ph":"E","pid":9413,"name":"prctl"},
    {"ts":15429161598.926,"ph":"E","pid":9413,"name":"task_name1"},
    {"ts":15429161599.183,"ph":"B","pid":9413,"name":"task_name2"},
    {"ts":15429161599.300,"ph":"B","pid":9413,"name":"pthread_self"},
    {"ts":15429161599.452,"ph":"E","pid":9413,"name":"pthread_self"},
    {"ts":15429161599.633,"ph":"B","pid":9413,"name":"pthread_setname_np"},
    {"ts":0,"ph":"M","pid":9413,"name":"process_name","args":{"name":"bar"}},
    {"ts":15429161601.324,"ph":"E","pid":9413,"name":"pthread_setname_np"},
    {"ts":15429161601.468,"ph":"E","pid":9413,"name":"task_name2"},
    {"ts":15429161601.567,"ph":"E","pid":9413,"name":"main"}
    ], "displayTimeUnit": "ns", "metadata": {
    "command_line":"uftrace record -F main tests/t-taskname",
    "recorded_time":"Tue Jan 30 16:38:19 2018"
    } }

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>