### PR TITLE
uftrace: Add -h option

### DIFF
--- a/doc/uftrace.md
+++ b/doc/uftrace.md
@@ -56,6 +56,9 @@ OPTIONS
 -?, \--help
 :   Print help message and list of options with description
 
+-h, \--help
+:   Print help message and list of options with description
+
 \--usage
 :   Print usage string
 

--- a/uftrace.c
+++ b/uftrace.c
@@ -166,6 +166,7 @@ static struct argp_option uftrace_options[] = {
 	{ "record", OPT_record, 0, 0, "Record a new trace data before running command" },
 	{ "auto-args", OPT_auto_args, 0, 0, "Show arguments and return value of known functions" },
 	{ "libname", OPT_libname, 0, 0, "Show libname name with symbol name" },
+	{ "help", 'h', 0, 0, "Give this help list" },
 	{ 0 }
 };
 
@@ -471,6 +472,10 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 		}
 		else
 			opts->event = opt_add_string(opts->event, arg);
+		break;
+
+	case 'h':
+		argp_state_help (state, state->out_stream, ARGP_HELP_STD_HELP);
 		break;
 
 	case OPT_flat:


### PR DESCRIPTION
I solved issue #319 .

The -h option is to print help message. It's the short version of --help
option.

Although -? option has a same role as -h option, the -h option is easier
to assume --help option than the -? option.

So it is useful to add the -h option.

Signed-off-by: Sangwon Hong <qpakzk@gmail.com>