### PR TITLE
test: Filter out personality routunes in C++ exception test cases

### DIFF
--- a/tests/t185_exception2.py
+++ b/tests/t185_exception2.py
@@ -18,3 +18,6 @@ class TestCase(TestBase):
    0.087 us [ 25279] |   bar();
   23.092 us [ 25279] | } /* main */
 """)
+
+    def runcmd(self):
+        return '%s %s %s' % (TestBase.uftrace_cmd, '-N personality_v.', 't-' + self.name)

--- a/tests/t186_exception3.py
+++ b/tests/t186_exception3.py
@@ -46,3 +46,6 @@ class TestCase(TestBase):
   14.948 us [ 16014] |   } /* catch_exc */
   85.226 us [ 16014] | } /* main */
 """)
+
+    def runcmd(self):
+        return '%s %s %s' % (TestBase.uftrace_cmd, '-N personality_v.', 't-' + self.name)


### PR DESCRIPTION
The personality routines such as `__gxx_personality_v0()`
can make output be various so exclude them.
Test case 124 already do it so fix test case 185 and 186.

Like the commit 019c1fd ("test: Update C++ exception test case")

Before:
```bash
./runtest.py exception
Test case                 pg             finstrument-fu
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
124 exception           : OK OK OK OK OK OK OK OK OK OK
185 exception2          : NG NG NG NG NG NG NG NG NG NG
186 exception3          : NG NG NG NG NG NG NG NG NG NG
```

After:
```sh
./runtest.py exception
Test case                 pg             finstrument-fu
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
124 exception           : OK OK OK OK OK OK OK OK OK OK
185 exception2          : OK OK OK OK OK OK OK OK OK OK
186 exception3          : OK OK OK OK OK OK OK OK OK OK

```