### PR TITLE
uftrace: Fix wrong old uftrace data name

### DIFF
--- a/uftrace.h
+++ b/uftrace.h
@@ -18,7 +18,7 @@
 #define UFTRACE_FILE_VERSION  4
 #define UFTRACE_FILE_VERSION_MIN  3
 #define UFTRACE_DIR_NAME     "uftrace.data"
-#define UFTRACE_DIR_OLD_NAME  "ftrace.dir"
+#define UFTRACE_DIR_OLD_NAME "uftrace.data.old"
 
 #define UFTRACE_RECV_PORT  8090
 


### PR DESCRIPTION
Hi @namhyung,

Default old uftrace data name should be `uftrace.data.old`,
not `ftrace.dir`. I found this problem that can find uftrace
old data due to wrong old name below case:
( it is related to https://github.com/namhyung/uftrace/blob/master/utils/data-file.c#L383-L384)

Before:
```
  $ ls
  uftrace.data.old

  $ uftrace replay
  WARN: cannot open record data: uftrace.data: No such file or directory
```
So rename it.

After:
```
  $ ls
  uftrace.data.old

  $ uftrace replay
  # DURATION     TID     FUNCTION
     1.221 us [ 22468] | __monstartup();
     0.985 us [ 22468] | __cxa_atexit();
              [ 22468] | main() {
              [ 22468] |   printf() {
...
```