### PR TITLE
 record: Use {get,put}_libmcount_path()

### DIFF
--- a/cmd-live.c
+++ b/cmd-live.c
@@ -77,7 +77,7 @@ static bool can_skip_replay(struct opts *opts, int record_result)
 static void setup_child_environ(struct opts *opts)
 {
 	char buf[4096];
-	char *old_preload, *old_libpath;
+	char *old_preload, *old_libpath, *libpath;
 
 	if (opts->lib_path) {
 		strcpy(buf, opts->lib_path);
@@ -103,22 +103,19 @@ static void setup_child_environ(struct opts *opts)
 	else
 		setenv("LD_LIBRARY_PATH", buf, 1);
 
-	if (opts->lib_path)
-		snprintf(buf, sizeof(buf), "%s/libmcount/libmcount.so", opts->lib_path);
-	else
-		strcpy(buf, "libmcount.so");
+	libpath = get_libmcount_path(opts);
 
 	old_preload = getenv("LD_PRELOAD");
 	if (old_preload) {
-		size_t len = strlen(buf) + strlen(old_preload) + 2;
+		size_t len = strlen(libpath) + strlen(old_preload) + 2;
 		char *preload = xmalloc(len);
 
-		snprintf(preload, len, "%s:%s", buf, old_preload);
+		snprintf(preload, len, "%s:%s", libpath, old_preload);
 		setenv("LD_PRELOAD", preload, 1);
 		free(preload);
 	}
 	else
-		setenv("LD_PRELOAD", buf, 1);
+		setenv("LD_PRELOAD", libpath, 1);
 }
 
 int command_live(int argc, char *argv[], struct opts *opts)

--- a/cmd-live.c
+++ b/cmd-live.c
@@ -104,6 +104,8 @@ static void setup_child_environ(struct opts *opts)
 		setenv("LD_LIBRARY_PATH", buf, 1);
 
 	libpath = get_libmcount_path(opts);
+	if (libpath == NULL)
+		pr_err_ns("cannot found libmcount.so\n");
 
 	old_preload = getenv("LD_PRELOAD");
 	if (old_preload) {

--- a/cmd-live.c
+++ b/cmd-live.c
@@ -76,32 +76,15 @@ static bool can_skip_replay(struct opts *opts, int record_result)
 
 static void setup_child_environ(struct opts *opts)
 {
-	char buf[4096];
-	char *old_preload, *old_libpath, *libpath;
-
-	if (opts->lib_path) {
-		strcpy(buf, opts->lib_path);
-		strcat(buf, "/libmcount:");
-	} else {
-		/* to make strcat() work */
-		buf[0] = '\0';
-	}
+	char *old_preload, *libpath;
 
 #ifdef INSTALL_LIB_PATH
-	strcat(buf, INSTALL_LIB_PATH);
-#endif
-
-	old_libpath = getenv("LD_LIBRARY_PATH");
-	if (old_libpath) {
-		size_t len = strlen(buf) + strlen(old_libpath) + 2;
-		char *libpath = xmalloc(len);
-
-		snprintf(libpath, len, "%s:%s", buf, old_libpath);
+	if (!opts->lib_path) {
+		libpath = strjoin(getenv("LD_LIBRARY_PATH"), INSTALL_LIB_PATH, ":");
 		setenv("LD_LIBRARY_PATH", libpath, 1);
 		free(libpath);
 	}
-	else
-		setenv("LD_LIBRARY_PATH", buf, 1);
+#endif
 
 	libpath = get_libmcount_path(opts);
 	if (libpath == NULL)

--- a/cmd-record.c
+++ b/cmd-record.c
@@ -87,7 +87,7 @@ static char *build_debug_domain_string(void)
 	return domain;
 }
 
-static char * get_libmcount_path(struct opts *opts)
+char * get_libmcount_path(struct opts *opts)
 {
 	char *libmcount, *lib = xmalloc(4096);
 	bool must_use_multi_thread = check_libpthread(opts->exename);
@@ -124,7 +124,7 @@ static char * get_libmcount_path(struct opts *opts)
 	return lib;
 }
 
-static void put_libmcount_path(char *libpath)
+void put_libmcount_path(char *libpath)
 {
 	free(libpath);
 }

--- a/cmd-record.c
+++ b/cmd-record.c
@@ -142,31 +142,15 @@ void put_libmcount_path(char *libpath)
 static void setup_child_environ(struct opts *opts, int pfd)
 {
 	char buf[4096];
-	char *old_preload, *old_libpath, *libpath;
-
-	if (opts->lib_path) {
-		strcpy(buf, opts->lib_path);
-		strcat(buf, "/libmcount:");
-	} else {
-		/* to make strcat() work */
-		buf[0] = '\0';
-	}
+	char *old_preload, *libpath;
 
 #ifdef INSTALL_LIB_PATH
-	strcat(buf, INSTALL_LIB_PATH);
-#endif
-
-	old_libpath = getenv("LD_LIBRARY_PATH");
-	if (old_libpath) {
-		size_t len = strlen(buf) + strlen(old_libpath) + 2;
-		char *libpath = xmalloc(len);
-
-		snprintf(libpath, len, "%s:%s", buf, old_libpath);
+	if (!opts->lib_path) {
+		libpath = strjoin(getenv("LD_LIBRARY_PATH"), INSTALL_LIB_PATH, ":");
 		setenv("LD_LIBRARY_PATH", libpath, 1);
 		free(libpath);
 	}
-	else
-		setenv("LD_LIBRARY_PATH", buf, 1);
+#endif
 
 	if (opts->filter) {
 		char *filter_str = uftrace_clear_kernel(opts->filter);

--- a/cmd-record.c
+++ b/cmd-record.c
@@ -245,8 +245,12 @@ static void setup_child_environ(struct opts *opts, int pfd)
 	if (opts->patt_type != PATT_REGEX)
 		setenv("UFTRACE_PATTERN", get_filter_pattern(opts->patt_type), 1);
 
-	if (opts->lib_path)
+	if (opts->lib_path) {
 		snprintf(buf, sizeof(buf), "%s/libmcount/", opts->lib_path);
+
+		if (access(buf, F_OK) != 0 && errno == ENOENT)
+			snprintf(buf, sizeof(buf), "%s/", opts->lib_path);
+	}
 	else
 		buf[0] = '\0';  /* to make strcat() work */
 

--- a/uftrace.h
+++ b/uftrace.h
@@ -276,6 +276,9 @@ int read_task_file(struct uftrace_session_link *sess, char *dirname,
 int read_task_txt_file(struct uftrace_session_link *sess, char *dirname,
 		       bool needs_session, bool sym_rel_addr);
 
+char * get_libmcount_path(struct opts *opts);
+void put_libmcount_path(char *libpath);
+
 #define SESSION_ID_LEN  16
 
 struct uftrace_session {


### PR DESCRIPTION
If we use `{get,put}_libmcount_path()` functions,

First, we can check both the library path the user gave with `-L`
and second path appending "/libmcount"(for test).

Second, we can previously check whether libmcount*.so files exist or no,
to avoid errors that can occur when recording.

How about this patches ?