### PR TITLE
utils: Fix to avoid realloc fail in strjoin

### DIFF
--- a/cmd-live.c
+++ b/cmd-live.c
@@ -80,9 +80,17 @@ static void setup_child_environ(struct opts *opts)
 
 #ifdef INSTALL_LIB_PATH
 	if (!opts->lib_path) {
-		libpath = strjoin(getenv("LD_LIBRARY_PATH"), INSTALL_LIB_PATH, ":");
-		setenv("LD_LIBRARY_PATH", libpath, 1);
-		free(libpath);
+		char *envbuf = getenv("LD_LIBRARY_PATH");
+
+		if (envbuf) {
+			envbuf = xstrdup(envbuf);
+			libpath = strjoin(envbuf, INSTALL_LIB_PATH, ":");
+			setenv("LD_LIBRARY_PATH", libpath, 1);
+			free(libpath);
+		}
+		else {
+			setenv("LD_LIBRARY_PATH", INSTALL_LIB_PATH, 1);
+		}
 	}
 #endif
 

--- a/cmd-record.c
+++ b/cmd-record.c
@@ -146,9 +146,17 @@ static void setup_child_environ(struct opts *opts, int pfd)
 
 #ifdef INSTALL_LIB_PATH
 	if (!opts->lib_path) {
-		libpath = strjoin(getenv("LD_LIBRARY_PATH"), INSTALL_LIB_PATH, ":");
-		setenv("LD_LIBRARY_PATH", libpath, 1);
-		free(libpath);
+		char *envbuf = getenv("LD_LIBRARY_PATH");
+
+		if (envbuf) {
+			envbuf = xstrdup(envbuf);
+			libpath = strjoin(envbuf, INSTALL_LIB_PATH, ":");
+			setenv("LD_LIBRARY_PATH", libpath, 1);
+			free(libpath);
+		}
+		else {
+			setenv("LD_LIBRARY_PATH", INSTALL_LIB_PATH, 1);
+		}
 	}
 #endif
 

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -391,13 +391,14 @@ uint64_t parse_time(char *arg, int limited_digits)
 
 /**
  * strjoin - join two strings with a delimiter
- * @left:  string to join (at left)
- * @right: string to join (at right)
+ * @left:  string buffer to join (dynamic allocated, can be NULL)
+ * @right: string to join
  * @delim: delimiter inserted between the two
  *
  * This function returns a new string that concatenates @left and @right
  * with @delim.  Note that if @left is #NULL, @delim will be omitted and
- * a copy of @right will be returned.
+ * a copy of @right will be returned.  @left must be dynamically allocated
+ * buffer so that it can be passed to realloc.
  */
 char * strjoin(char *left, char *right, const char *delim)
 {


### PR DESCRIPTION
Since strjoin internally uses realloc passing the @left argument, the
@left must be dynamically allocated buffer.

But the commit 5eb6468 passes a buffer by getting getenv(), which makes
realloc in strjoin fail.

This patch fixes the problem and adds such information to strjoin
function to prevent such misuse.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>