### PR TITLE
info: Fix program version that recorded the data

### DIFF
--- a/tests/t097_dump_basic.py
+++ b/tests/t097_dump_basic.py
@@ -14,7 +14,7 @@ uftrace file header: header size   = 40
 uftrace file header: endian        = 1 (little)
 uftrace file header: class         = 2 (64 bit)
 uftrace file header: features      = 0x363 (PLTHOOK | TASK_SESSION | SYM_REL_ADDR | MAX_STACK | PERF_EVENT | AUTO_ARGS)
-uftrace file header: info          = 0x1bff
+uftrace file header: info          = 0x3bff
 
 reading 5231.dat
 58348.873430946   5231: [entry] __monstartup(4004d0) depth: 0

--- a/tests/t098_dump_tid.py
+++ b/tests/t098_dump_tid.py
@@ -14,7 +14,7 @@ uftrace file header: header size   = 40
 uftrace file header: endian        = 1 (little)
 uftrace file header: class         = 2 (64 bit)
 uftrace file header: features      = 0x363 (PLTHOOK | TASK_SESSION | SYM_REL_ADDR | MAX_STACK | PERF_EVENT | AUTO_ARGS)
-uftrace file header: info          = 0x1bff
+uftrace file header: info          = 0x3bff
 
 reading 5186.dat
 58071.916834908   5186: [entry] main(400590) depth: 0

--- a/tests/t099_dump_filter.py
+++ b/tests/t099_dump_filter.py
@@ -14,7 +14,7 @@ uftrace file header: header size   = 40
 uftrace file header: endian        = 1 (little)
 uftrace file header: class         = 2 (64 bit)
 uftrace file header: features      = 0x363 (PLTHOOK | TASK_SESSION | SYM_REL_ADDR | MAX_STACK | PERF_EVENT | AUTO_ARGS)
-uftrace file header: info          = 0x1bff
+uftrace file header: info          = 0x3bff
 
 reading 5231.dat
 58348.873444506   5231: [entry] main(400512) depth: 0

--- a/tests/t100_dump_depth.py
+++ b/tests/t100_dump_depth.py
@@ -14,7 +14,7 @@ uftrace file header: header size   = 40
 uftrace file header: endian        = 1 (little)
 uftrace file header: class         = 2 (64 bit)
 uftrace file header: features      = 0x363 (PLTHOOK | TASK_SESSION | SYM_REL_ADDR | MAX_STACK | PERF_EVENT | AUTO_ARGS)
-uftrace file header: info          = 0x1bff
+uftrace file header: info          = 0x3bff
 
 reading 5231.dat
 58348.873444506   5231: [entry] main(400512) depth: 0

--- a/uftrace.h
+++ b/uftrace.h
@@ -85,6 +85,7 @@ enum uftrace_info_bits {
 	ARG_SPEC,
 	RECORD_DATE,
 	PATTERN_TYPE,
+	VERSION,
 };
 
 struct uftrace_info {
@@ -122,6 +123,7 @@ struct uftrace_info {
 	float load5;
 	float load15;
 	enum uftrace_pattern_type patt_type;
+	char *uftrace_version;
 };
 
 enum {


### PR DESCRIPTION
Solve #343 .

The `program version` showed uftrace version of currently running `uftrace info`.

Fix uftrace version that recorded the data.

When recording the data, write uftrace version in `uftrace.data/info` file. So It is possible to show a correct uftrace version by reading `uftrace.data/info` file.