### PR TITLE
test: Suppress generating buffer overflow detection calls

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -23,7 +23,8 @@ class TestBase:
     objdir = 'objdir' in os.environ and os.environ['objdir'] or '..'
     uftrace_cmd = objdir + '/uftrace --no-pager -L' + objdir
 
-    default_cflags = ['-fno-inline', '-fno-builtin', '-fno-omit-frame-pointer']
+    default_cflags = ['-fno-inline', '-fno-builtin',
+                      '-fno-omit-frame-pointer', '-D_FORTIFY_SOURCE=0']
 
     def __init__(self, name, result, lang='C', cflags='', ldflags='', sort='task'):
         self.name = name

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -373,8 +373,11 @@ class TestBase:
                 f = open('result', 'w')
                 f.write(result_tested + '\n')
                 f.close()
-                p = sp.Popen(['diff', '-U1', 'expect', 'result'], stdout=sp.PIPE)
                 print("%s: diff result of %s" % (name, cflags))
+                try:
+                    p = sp.Popen(['colordiff', '-U1', 'expect', 'result'], stdout=sp.PIPE)
+                except:
+                    p = sp.Popen(['diff', '-U1', 'expect', 'result'], stdout=sp.PIPE)
                 print(p.communicate()[0].decode(errors='ignore'))
                 os.remove('expect')
                 os.remove('result')

--- a/tests/s-thread-exit.c
+++ b/tests/s-thread-exit.c
@@ -16,10 +16,12 @@ void *thread_main(void *arg)
 
 int main(void)
 {
-	for (int i = 0; i < NUM_THREAD; i++)
+	int i;
+
+	for (i = 0; i < NUM_THREAD; i++)
 		pthread_create(&threads[i], NULL, &thread_main, NULL);
 
-	for (int i = 0; i < NUM_THREAD; i++)
+	for (i = 0; i < NUM_THREAD; i++)
 		pthread_join(threads[i], NULL);
 
 	return 0;

--- a/tests/t015_longjmp.py
+++ b/tests/t015_longjmp.py
@@ -15,6 +15,3 @@ class TestCase(TestBase):
    0.105 us [29065] |   bar();
   36.125 us [29065] | } /* main */
 """)
-
-    def fixup(self, cflags, result):
-        return result.replace('longjmp', "__longjmp_chk")

--- a/tests/t087_arg_variadic.py
+++ b/tests/t087_arg_variadic.py
@@ -25,14 +25,9 @@ class TestCase(TestBase):
     def runcmd(self):
         argopt  = '-A "variadic@arg1/s,arg2/c,arg3/s,arg4,arg5,arg6,arg7/i64,fparg1" '
         argopt += '-A "vsnprintf@arg2,arg3/s" '
-        argopt += '-A "__vsnprintf_chk@arg2,arg5/s"'
 
         import platform
         if platform.machine().startswith('i686'):
             argopt  = '-A "variadic@arg1/s,arg2/c,arg3/s,arg4,arg5,arg6,arg7/i64,fparg9" '
             argopt += '-A "vsnprintf@arg2,arg3/s" '
-            argopt += '-A "__vsnprintf_chk@arg2,arg5/s"'
         return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)
-
-    def fixup(self, cflags, result):
-        return result.replace('vsnprintf', "__vsnprintf_chk")

--- a/tests/t133_long_string.py
+++ b/tests/t133_long_string.py
@@ -20,8 +20,5 @@ class TestCase(TestBase):
         return TestBase.build(self, name, cflags, ldflags)
 
     def runcmd(self):
-        return '%s -A printf@arg1/s,arg2/s -A __printf_chk@arg2/s,arg3/s %s %s' % \
+        return '%s -A printf@arg1/s,arg2/s %s %s' % \
             (TestBase.uftrace_cmd, 't-' + self.name, "0123456789" * 10)
-
-    def fixup(self, cflags, result):
-        return result.replace('printf', '__printf_chk')

--- a/tests/t144_longjmp2.py
+++ b/tests/t144_longjmp2.py
@@ -19,6 +19,3 @@ class TestCase(TestBase):
    0.671 us [ 3024] |   } /* _setjmp */
    7.291 us [ 3024] | } /* main */
 """)
-
-    def fixup(self, cflags, result):
-        return result.replace('longjmp', "__longjmp_chk")

--- a/tests/t145_longjmp3.py
+++ b/tests/t145_longjmp3.py
@@ -13,30 +13,24 @@ class TestCase(TestBase):
    1.823 us [ 4107] |   getpid();
    0.182 us [ 4107] |   _setjmp() = 0;
             [ 4107] |   foo() {
-            [ 4107] |     __longjmp_chk(1) {
+            [ 4107] |     longjmp(1) {
    8.790 us [ 4107] |   } = 1; /* _setjmp */
    0.540 us [ 4107] |   getpid();
             [ 4107] |   bar() {
             [ 4107] |     baz() {
-            [ 4107] |       __longjmp_chk(2) {
+            [ 4107] |       longjmp(2) {
    1.282 us [ 4107] |   } = 2; /* _setjmp */
    0.540 us [ 4107] |   getpid();
             [ 4107] |   foo() {
-            [ 4107] |     __longjmp_chk(3) {
+            [ 4107] |     longjmp(3) {
    0.578 us [ 4107] |   } = 3; /* _setjmp */
             [ 4107] |   bar() {
             [ 4107] |     baz() {
-            [ 4107] |       __longjmp_chk(4) {
+            [ 4107] |       longjmp(4) {
    0.642 us [ 4107] |   } = 4; /* _setjmp */
   18.019 us [ 4107] | } /* main */
 """)
 
-    def build(self, name, cflags='', ldflags=''):
-        return TestBase.build(self, name, cflags + ' -D_FORTIFY_SOURCE=2', ldflags)
-
     def runcmd(self):
         args = '-A .?longjmp@arg2 -R .?setjmp@retval'
         return '%s %s %s' % (TestBase.uftrace_cmd, args, 't-' + self.name)
-
-    def fixup(self, cflags, result):
-        return result.replace('__longjmp_chk', "longjmp")


### PR DESCRIPTION
_FORTIFY_SOURCE macro is used by default when optimization is on.  It generates additional buffer overflow detection calls.  So this fixes those kind of useless difference.

This also includes to use `colordiff` instead of `diff` for better comparison.