### PR TITLE
record: Add --no-randomize-addr to disable ASLR

### DIFF
--- a/cmd-record.c
+++ b/cmd-record.c
@@ -17,6 +17,7 @@
 #include <sys/eventfd.h>
 #include <sys/resource.h>
 #include <sys/epoll.h>
+#include <sys/personality.h>
 
 #include "uftrace.h"
 #include "libmcount/mcount.h"
@@ -1869,6 +1870,12 @@ int do_child_exec(int pfd[2], int ready, struct opts *opts,
 		  int argc, char *argv[])
 {
 	uint64_t dummy;
+
+	if (opts->no_randomize_addr) {
+		/* disable ASLR (Address Space Layout Randomization) */
+		if (personality(ADDR_NO_RANDOMIZE) < 0)
+			pr_dbg("disabling ASLR failed\n");
+	}
 
 	close(pfd[0]);
 

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -142,6 +142,9 @@ OPTIONS
 --match=*TYPE*
 :   Use pattern match using TYPE.  Possible types are `regex` and `glob`.  Default is `regex`.
 
+--no-randomize-addr
+:   Disable ASLR (Address Space Layout Randomization).  It makes the target process fix its address space layout.
+
 
 FILTERS
 =======

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -111,6 +111,9 @@ OPTIONS
 --match=*TYPE*
 :   Use pattern match using TYPE.  Possible types are `regex` and `glob`.  Default is `regex`.
 
+--no-randomize-addr
+:   Disable ASLR (Address Space Layout Randomization).  It makes the target process fix its address space layout.
+
 
 FILTERS
 =======

--- a/uftrace.c
+++ b/uftrace.c
@@ -96,6 +96,7 @@ enum options {
 	OPT_auto_args,
 	OPT_libname,
 	OPT_match_type,
+	OPT_no_randomize_addr,
 };
 
 static struct argp_option uftrace_options[] = {
@@ -168,6 +169,7 @@ static struct argp_option uftrace_options[] = {
 	{ "auto-args", OPT_auto_args, 0, 0, "Show arguments and return value of known functions" },
 	{ "libname", OPT_libname, 0, 0, "Show libname name with symbol name" },
 	{ "match", OPT_match_type, "TYPE", 0, "Support pattern match: regex, glob (default: regex)" },
+	{ "no-randomize-addr", OPT_no_randomize_addr, 0, 0, "Disable ASLR (Address Space Layout Randomization)" },
 	{ "help", 'h', 0, 0, "Give this help list" },
 	{ 0 }
 };
@@ -721,6 +723,10 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 			pr_use("invalid match pattern: %s (ignoring...)\n", arg);
 			opts->patt_type = PATT_REGEX;
 		}
+		break;
+
+	case OPT_no_randomize_addr:
+		opts->no_randomize_addr = true;
 		break;
 
 	case ARGP_KEY_ARG:

--- a/uftrace.h
+++ b/uftrace.h
@@ -246,6 +246,7 @@ struct opts {
 	bool record;
 	bool auto_args;
 	bool libname;
+	bool no_randomize_addr;
 	struct uftrace_time_range range;
 	enum uftrace_pattern_type patt_type;
 };


### PR DESCRIPTION
Most system enables ASLR by default for security reasons, but it makes
difficult to analyze target processes execution from its address
information because its address space is randomized.

Pratik Bhatu requested to turn off ASLR for easiser analysis of target
processes, so this patch adds a new option --no-randomize-addr to
disable ASLR.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>