### PR TITLE
implement the attaching to already running process. 

### DIFF
--- a/arch/x86_64/Makefile
+++ b/arch/x86_64/Makefile
@@ -8,6 +8,7 @@ include $(srcdir)/Makefile.include
 ARCH_ENTRY_SRC = $(wildcard $(sdir)/*.S)
 ARCH_MCOUNT_SRC = $(wildcard $(sdir)/mcount-*.c) $(sdir)/regs.c $(sdir)/symbol.c
 ARCH_UFTRACE_SRC = $(sdir)/cpuinfo.c $(sdir)/regs.c $(sdir)/symbol.c
+ARCH_UFTRACE_SRC += $(sdir)/inject.c
 
 ARCH_MCOUNT_OBJS  = $(patsubst $(sdir)/%.S,$(odir)/%.op,$(ARCH_ENTRY_SRC))
 ARCH_MCOUNT_OBJS += $(patsubst $(sdir)/%.c,$(odir)/%.op,$(ARCH_MCOUNT_SRC))

--- a/arch/x86_64/inject.c
+++ b/arch/x86_64/inject.c
@@ -1,0 +1,296 @@
+/*
+ * Linux module for injecting shared object to the process by using ptrace.
+ *
+ * copied from: https://github.com/gaffe23/linux-inject
+ * Released under the GPL v2+.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/user.h>
+#include <wait.h>
+#include <sys/time.h>
+#include "utils/inject-utils.h"
+#include "utils/ptrace.h"
+#include "utils/utils.h"
+
+/*
+ * inject_shared_lib()
+ *
+ * This is the code that will actually be injected into the target process.
+ * This code is responsible for loading the shared library into the target
+ * process' address space.  First, it calls malloc() to allocate a buffer to
+ * hold the filename of the library to be loaded. Then, it calls
+ * __libc_dlopen_mode(), libc's implementation of dlopen(), to load the desired
+ * shared library. Finally, it calls free() to free the buffer containing the
+ * library name. Each time it needs to give control back to the injector
+ * process, it breaks back in by executing an "int $3" instruction. See the
+ * comments below for more details on how this works.
+ *
+ */
+
+void inject_shared_lib(long mallocaddr, long freeaddr, long dlopenaddr)
+{
+	// here are the assumptions I'm making about what data will be located
+	// where at the time the target executes this code:
+	//
+	//   rdi = address of malloc() in target process
+	//   rsi = address of free() in target process
+	//   rdx = address of __libc_dlopen_mode() in target process
+	//   rcx = size of the path to the shared library we want to load
+
+	// save addresses of free() and __libc_dlopen_mode() on the stack for later use
+	asm(
+		// rsi is going to contain the address of free(). it's going to get wiped
+		// out by the call to malloc(), so save it on the stack for later
+		"push %rsi \n"
+		// same thing for rdx, which will contain the address of _dl_open()
+		"push %rdx"
+	);
+
+	// call malloc() from within the target process
+	asm(
+		// save previous value of r9, because we're going to use it to call malloc()
+		"push %r9 \n"
+		// now move the address of malloc() into r9
+		"mov %rdi,%r9 \n"
+		// choose the amount of memory to allocate with malloc() based on the size
+		// of the path to the shared library passed via rcx
+		"mov %rcx,%rdi \n"
+		// now call r9; malloc()
+		"callq *%r9 \n"
+		// after returning from malloc(), pop the previous value of r9 off the stack
+		"pop %r9 \n"
+		// break in so that we can see what malloc() returned
+		"int $3"
+	);
+
+	// call __libc_dlopen_mode() to load the shared library
+	asm(
+		// get the address of __libc_dlopen_mode() off of the stack so we can call it
+		"pop %rdx \n"
+		// as before, save the previous value of r9 on the stack
+		"push %r9 \n"
+		// copy the address of __libc_dlopen_mode() into r9
+		"mov %rdx,%r9 \n"
+		// 1st argument to __libc_dlopen_mode(): filename = the address of the buffer returned by malloc()
+		"mov %rax,%rdi \n"
+		// 2nd argument to __libc_dlopen_mode(): flag = RTLD_LAZY
+		"movabs $1,%rsi \n"
+		// call __libc_dlopen_mode()
+		"callq *%r9 \n"
+		// restore old r9 value
+		"pop %r9 \n"
+		// break in so that we can see what __libc_dlopen_mode() returned
+		"int $3"
+	);
+
+	// call free() to free the buffer we allocated earlier.
+	//
+	// Note: I found that if you put a nonzero value in r9, free() seems to
+	// interpret that as an address to be freed, even though it's only
+	// supposed to take one argument. As a result, I had to call it using a
+	// register that's not used as part of the x64 calling convention. I
+	// chose rbx.
+	asm(
+		// at this point, rax should still contain our malloc()d buffer from earlier.
+		// we're going to free it, so move rax into rdi to make it the first argument to free().
+		"mov %rax,%rdi \n"
+		// pop rsi so that we can get the address to free(), which we pushed onto the stack a while ago.
+		"pop %rsi \n"
+		// save previous rbx value
+		"push %rbx \n"
+		// load the address of free() into rbx
+		"mov %rsi,%rbx \n"
+		// zero out rsi, because free() might think that it contains something that should be freed
+		"xor %rsi,%rsi \n"
+		// break in so that we can check out the arguments right before making the call
+		"int $3 \n"
+		// call free()
+		"callq *%rbx \n"
+		// restore previous rbx value
+		"pop %rbx"
+	);
+
+	// we already overwrote the RET instruction at the end of this function
+	// with an INT 3, so at this point the injector will regain control of
+	// the target's execution.
+}
+
+/*
+ * inject_shared_lib_end()
+ *
+ * This function's only purpose is to be contiguous to inject_shared_lib(),
+ * so that we can use its address to more precisely figure out how long
+ * inject_shared_lib() is.
+ *
+ */
+
+void inject_shared_lib_end()
+{
+}
+
+int inject(char* libname, pid_t pid)
+{
+	char* lib_path = realpath(libname, NULL);
+	pid_t target = 0;
+
+	if(!lib_path) {
+		pr_err_ns("can't find file \"%s\"\n", libname);
+	}
+	target = pid;
+
+	int lib_path_length = strlen(lib_path) + 1;
+
+	int mypid = getpid();
+	long mylibcaddr = getlibcaddr(mypid);
+
+	// find the addresses of the syscalls that we'd like to use inside the
+	// target, as loaded inside THIS process (i.e. NOT the target process)
+	long malloc_addr = get_function_addr("malloc");
+	long free_addr = get_function_addr("free");
+	long dlopen_addr = get_function_addr("__libc_dlopen_mode");
+
+	// use the base address of libc to calculate offsets for the syscalls
+	// we want to use
+	long malloc_offset = malloc_addr - mylibcaddr;
+	long free_offset = free_addr - mylibcaddr;
+	long dlopen_offset = dlopen_addr - mylibcaddr;
+
+
+	// get the target process' libc address and use it to find the
+	// addresses of the syscalls we want to use inside the target process
+	long target_libc_addr = getlibcaddr(target);
+	long target_malloc_addr = target_libc_addr + malloc_offset;
+	long target_free_addr = target_libc_addr + free_offset;
+	long target_dlopen_addr = target_libc_addr + dlopen_offset;
+
+	struct user_regs_struct oldregs, regs;
+	memset(&oldregs, 0, sizeof(struct user_regs_struct));
+	memset(&regs, 0, sizeof(struct user_regs_struct));
+
+	ptrace_attach(target);
+
+	ptrace_getregs(target, &oldregs);
+	memcpy(&regs, &oldregs, sizeof(struct user_regs_struct));
+
+	// find a good address to copy code to
+	long addr = freespaceaddr(target) + sizeof(long);
+
+	// now that we have an address to copy code to, set the target's rip to
+	// it. we have to advance by 2 bytes here because rip gets incremented
+	// by the size of the current instruction, and the instruction at the
+	// start of the function to inject always happens to be 2 bytes long.
+	regs.rip = addr + 2;
+
+	// pass arguments to my function inject_shared_lib() by loading them
+	// into the right registers. note that this will definitely only work
+	// on x64, because it relies on the x64 calling convention, in which
+	// arguments are passed via registers rdi, rsi, rdx, rcx, r8, and r9.
+	// see comments in inject_shared_lib() for more details.
+	regs.rdi = target_malloc_addr;
+	regs.rsi = target_free_addr;
+	regs.rdx = target_dlopen_addr;
+	regs.rcx = lib_path_length;
+	ptrace_setregs(target, &regs);
+
+	// figure out the size of inject_shared_lib() so we know how big of a buffer to allocate.
+	size_t inject_shared_lib_size = (intptr_t)inject_shared_lib_end - (intptr_t)inject_shared_lib;
+
+	// also figure out where the RET instruction at the end of
+	// inject_shared_lib() lies so that we can overwrite it with an INT 3
+	// in order to break back into the target process. note that on x64,
+	// gcc and clang both force function addresses to be word-aligned,
+	// which means that functions are padded with NOPs. as a result, even
+	// though we've found the length of the function, it is very likely
+	// padded with NOPs, so we need to actually search to find the RET.
+	intptr_t inject_shared_lib_ret = (intptr_t)find_ret(inject_shared_lib_end) - (intptr_t)inject_shared_lib;
+
+	// back up whatever data used to be at the address we want to modify.
+	char* backup = malloc(inject_shared_lib_size * sizeof(char));
+	ptrace_read(target, addr, backup, inject_shared_lib_size);
+
+	// set up a buffer to hold the code we're going to inject into the
+	// target process.
+	char* newcode = malloc(inject_shared_lib_size * sizeof(char));
+	memset(newcode, 0, inject_shared_lib_size * sizeof(char));
+
+	// copy the code of inject_shared_lib() to a buffer.
+	memcpy(newcode, inject_shared_lib, inject_shared_lib_size - 1);
+	// overwrite the RET instruction with an INT 3.
+	newcode[inject_shared_lib_ret] = INTEL_INT3_INSTRUCTION;
+
+	// copy inject_shared_lib()'s code to the target address inside the
+	// target process' address space.
+	ptrace_write(target, addr, newcode, inject_shared_lib_size);
+
+	// now that the new code is in place, let the target run our injected
+	// code.
+	ptrace_cont(target);
+
+
+	// at this point, the target should have run malloc(). check its return
+	// value to see if it succeeded, and bail out cleanly if it didn't.
+	struct user_regs_struct malloc_regs;
+	memset(&malloc_regs, 0, sizeof(struct user_regs_struct));
+	ptrace_getregs(target, &malloc_regs);
+	unsigned long long target_buf = malloc_regs.rax;
+	if(target_buf == 0) {
+		restore_state_and_detach(target, addr, backup, inject_shared_lib_size, oldregs);
+		free(backup);
+		free(newcode);
+		pr_err_ns("malloc() failed to allocate memory\n");
+	}
+
+	// if we get here, then malloc likely succeeded, so now we need to copy
+	// the path to the shared library we want to inject into the buffer
+	// that the target process just malloc'd. this is needed so that it can
+	// be passed as an argument to __libc_dlopen_mode later on.
+
+	// read the current value of rax, which contains malloc's return value,
+	// and copy the name of our shared library to that address inside the
+	// target process.
+	ptrace_write(target, target_buf, lib_path, lib_path_length);
+
+	// continue the target's execution again in order to call
+	// __libc_dlopen_mode.
+	ptrace_cont(target);
+
+	// check out what the registers look like after calling dlopen.
+	struct user_regs_struct dlopen_regs;
+	memset(&dlopen_regs, 0, sizeof(struct user_regs_struct));
+	ptrace_getregs(target, &dlopen_regs);
+	unsigned long long lib_addr = dlopen_regs.rax;
+
+	// if rax is 0 here, then __libc_dlopen_mode failed, and we should bail
+	// out cleanly.
+	if(lib_addr == 0) {
+		restore_state_and_detach(target, addr, backup, inject_shared_lib_size, oldregs);
+		free(backup);
+		free(newcode);
+		pr_err_ns("__libc_dlopen_mode() failed to load %s\n", libname);
+	}
+
+	// now check /proc/pid/maps to see whether injection was successful.
+	if(checkloaded(target, libname)) {
+		pr_dbg("\"%s\" successfully injected\n", libname);
+	}
+	else {
+		pr_err_ns("could not inject \"%s\"\n", libname);
+	}
+
+	// as a courtesy, free the buffer that we allocated inside the target
+	// process. we don't really care whether this succeeds, so don't
+	// bother checking the return value.
+	ptrace_cont(target);
+
+	// at this point, if everything went according to plan, we've loaded
+	// the shared library inside the target process, so we're done. restore
+	// the old state and detach from the target.
+	restore_state_and_detach(target, addr, backup, inject_shared_lib_size, oldregs);
+	free(backup);
+	free(newcode);
+
+	return 0;
+}

--- a/cmd-dynamic.c
+++ b/cmd-dynamic.c
@@ -1,0 +1,476 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <assert.h>
+#include <dirent.h>
+#include <pthread.h>
+#include <signal.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <sys/ioctl.h>
+#include <sys/eventfd.h>
+#include <sys/resource.h>
+#include <sys/epoll.h>
+#include <fnmatch.h>
+#include <linux/limits.h>
+#include <sys/ptrace.h>
+#include <sys/time.h>
+
+#include "uftrace.h"
+#include "libmcount/mcount.h"
+#include "utils/utils.h"
+#include "utils/symbol.h"
+#include "utils/list.h"
+#include "utils/filter.h"
+#include "utils/kernel.h"
+#include "utils/perf.h"
+#include "utils/compiler.h"
+#include "utils/env-file.h"
+
+
+// define which method to use.
+#define DYNAMIC_TO_PROCESS 0
+
+static bool has_perf_event;
+static char absolute_file_path[PATH_MAX];
+extern int do_main_loop(int pfd[2], int ready, struct opts *opts, int pid);
+extern bool check_linux_schedule_event(char *events,
+				       enum uftrace_pattern_type ptype);
+extern bool check_linux_perf_event(char *events);
+extern char *build_debug_domain_string(void);
+extern int inject(char* libname, pid_t pid);
+
+#define ERROR_WITHOUT_LDPRELOAD \
+"you must specify LD_PRELOAD path by using '-L' option if want use \n"	\
+"\tdynamic tracing to the process.\n"
+
+/*
+ * Create a temporary file to save the environment variable for uftrace.
+ *
+ * in case for dynamic tracing to processes, we use file to passing
+ * environment variable for uftrace because LD_PRELOAD not work.
+ */
+static void make_uftrace_environ_file(struct opts *opts, int pfd)
+{
+	char buf[4096];
+	char *old_preload, *old_libpath;
+	int env_fd;
+	int method = DYNAMIC_TO_PROCESS;
+
+	env_fd = create_env_file();
+	if (env_fd < 0)
+		pr_err_ns("FILE OPEN FAILED\n");
+
+	if (opts->pid) {
+		method = DYNAMIC_TO_PROCESS;
+	}
+
+	if (opts->lib_path) {
+		strcpy(buf, opts->lib_path);
+		strcat(buf, "/libmcount:");
+	} else {
+		if (method == DYNAMIC_TO_PROCESS) {
+			pr_err_ns(ERROR_WITHOUT_LDPRELOAD);
+		}
+		/* to make strcat() work */
+		buf[0] = '\0';
+	}
+
+#ifdef INSTALL_LIB_PATH
+	strcat(buf, INSTALL_LIB_PATH);
+#endif
+
+	old_libpath = getenv("LD_LIBRARY_PATH");
+	if (old_libpath) {
+		size_t len = strlen(buf) + strlen(old_libpath) + 2;
+		char *libpath = xmalloc(len);
+
+		snprintf(libpath, len, "%s:%s", buf, old_libpath);
+		set_env_to_file(env_fd, "LD_LIBRARY_PATH", libpath);
+		free(libpath);
+	}
+	else {
+		set_env_to_file(env_fd, "LD_LIBRARY_PATH", buf);
+	}
+
+	if (opts->filter) {
+		char *filter_str = uftrace_clear_kernel(opts->filter);
+
+		if (filter_str) {
+			set_env_to_file(env_fd, "UFTRACE_FILTER", filter_str);
+			free(filter_str);
+		}
+	}
+
+	if (opts->trigger) {
+		char *trigger_str = uftrace_clear_kernel(opts->trigger);
+
+		if (trigger_str) {
+			set_env_to_file(env_fd, "UFTRACE_TRIGGER", trigger_str);
+			free(trigger_str);
+		}
+	}
+
+	if (opts->retval) {
+		char *retval_str = uftrace_clear_kernel(opts->retval);
+
+		if (retval_str) {
+			set_env_to_file(env_fd, "UFTRACE_RETVAL", retval_str);
+			free(retval_str);
+		}
+	}
+
+	if (opts->auto_args) {
+		set_env_to_file(env_fd, "UFTRACE_AUTO_ARGS", "1");
+	}
+
+	if (opts->patch) {
+		char *patch_str = uftrace_clear_kernel(opts->patch);
+
+		if (patch_str) {
+			set_env_to_file(env_fd, "UFTRACE_PATCH", patch_str);
+			free(patch_str);
+		}
+	}
+
+	if (opts->event) {
+		char *event_str = uftrace_clear_kernel(opts->event);
+
+		if (event_str) {
+			set_env_to_file(env_fd, "UFTRACE_EVENT", event_str);
+			free(event_str);
+		}
+	}
+
+	if (opts->depth != OPT_DEPTH_DEFAULT) {
+		snprintf(buf, sizeof(buf), "%d", opts->depth);
+		set_env_to_file(env_fd, "UFTRACE_DEPTH", buf);
+	}
+
+	if (opts->max_stack != OPT_RSTACK_DEFAULT) {
+		snprintf(buf, sizeof(buf), "%d", opts->max_stack);
+		set_env_to_file(env_fd, "UFTRACE_MAX_STACK", buf);
+	}
+
+	if (opts->threshold) {
+		snprintf(buf, sizeof(buf), "%"PRIu64, opts->threshold);
+		set_env_to_file(env_fd, "UFTRACE_THRESHOLD", buf);
+	}
+
+	if (opts->libcall) {
+		set_env_to_file(env_fd, "UFTRACE_PLTHOOK", "1");
+
+		if (opts->want_bind_not) {
+			/* do not update GOTPLT after resolving symbols */
+			set_env_to_file(env_fd, "LD_BIND_NOT", "1");
+		}
+
+		if (opts->nest_libcall) {
+			set_env_to_file(env_fd, "UFTRACE_NEST_LIBCALL", "1");
+		}
+	}
+
+	if (strcmp(opts->dirname, UFTRACE_DIR_NAME)) {
+		set_env_to_file(env_fd, "UFTRACE_DIR", opts->dirname);
+	}
+
+	if (opts->bufsize != SHMEM_BUFFER_SIZE) {
+		snprintf(buf, sizeof(buf), "%lu", opts->bufsize);
+		set_env_to_file(env_fd, "UFTRACE_BUFFER", buf);
+	}
+
+	if (opts->logfile) {
+		snprintf(buf, sizeof(buf), "%d", fileno(logfp));
+		set_env_to_file(env_fd, "UFTRACE_LOGFD", buf);
+	}
+
+	snprintf(buf, sizeof(buf), "%d", pfd);
+	set_env_to_file(env_fd, "UFTRACE_PIPE", buf);
+	set_env_to_file(env_fd, "UFTRACE_SHMEM", "1");
+
+	if (debug) {
+		snprintf(buf, sizeof(buf), "%d", debug);
+		set_env_to_file(env_fd, "UFTRACE_DEBUG", buf);
+		set_env_to_file(env_fd, "UFTRACE_DEBUG_DOMAIN", build_debug_domain_string());
+	}
+
+	if(opts->disabled) {
+		set_env_to_file(env_fd, "UFTRACE_DISABLED", "1");
+	}
+
+	if (log_color == COLOR_ON) {
+		snprintf(buf, sizeof(buf), "%d", log_color);
+		set_env_to_file(env_fd, "UFTRACE_COLOR", buf);
+	}
+
+	snprintf(buf, sizeof(buf), "%d", demangler);
+	set_env_to_file(env_fd, "UFTRACE_DEMANGLE", buf);
+
+	if ((opts->kernel || has_kernel_event(opts->event)) &&
+	    check_kernel_pid_filter()) {
+		set_env_to_file(env_fd, "UFTRACE_KERNEL_PID_UPDATE", "1");
+	}
+
+	if (opts->script_file) {
+		set_env_to_file(env_fd, "UFTRACE_SCRIPT", opts->script_file);
+	}
+
+	if (opts->lib_path)
+		snprintf(buf, sizeof(buf), "%s/libmcount/", opts->lib_path);
+	else
+		buf[0] = '\0';  /* to make strcat() work */
+
+	strcat(buf, "libmcount-dynamic.so");
+	pr_dbg("using %s library for tracing\n", buf);
+
+	old_preload = getenv("LD_PRELOAD");
+	if (old_preload) {
+		size_t len = strlen(buf) + strlen(old_preload) + 2;
+		char *preload = xmalloc(len);
+
+		snprintf(preload, len, "%s:%s", buf, old_preload);
+		set_env_to_file(env_fd, "LD_PRELOAD", preload);
+		free(preload);
+	}
+	else {
+		set_env_to_file(env_fd, "LD_PRELOAD", buf);
+	}
+
+	// The process ID to inject the shared object.
+	snprintf(buf, sizeof(buf), "%d", getpid());
+	set_env_to_file(env_fd, "UFTRACE_PID", buf);
+
+	// The below code should be placed at the end.
+	set_env_to_file(env_fd, "XRAY_OPTIONS", "patch_premain=false");
+	close(env_fd);
+}
+
+// settings for using dynamic tracing feature.
+void setup_uftrace_environ(struct opts *opts, int pfd)
+{
+	make_uftrace_environ_file(opts, pfd);
+}
+
+
+char* get_libtrigger_path(struct opts *opts)
+{
+	char *lib = xmalloc(PATH_MAX);
+	char *libtrigger = "libtrigger.so";
+        if (opts->lib_path) {
+                snprintf(lib, PATH_MAX, "%s/libmcount/%s", opts->lib_path, libtrigger);
+
+                if (access(lib, F_OK) == 0) {
+                        return lib;
+                }
+                else if (errno == ENOENT) {
+                        snprintf(lib, PATH_MAX, "%s/%s", opts->lib_path, libtrigger);                        if (access(lib, F_OK) == 0)
+                                return lib;
+                }
+                free(lib);
+                return NULL;
+        }
+
+#ifdef INSTALL_LIB_PATH
+        snprintf(lib, PATH_MAX, "%s/%s", INSTALL_LIB_PATH, libtrigger);
+        if (access(lib, F_OK) != 0 && errno == ENOENT)
+                pr_warn("Didn't you run 'make install' ?\n");
+#endif
+        strcpy(lib, libtrigger);
+	return lib;
+}
+
+
+/*
+ * inject the shared object 'libtrigger.so' to processes.
+ *
+ * inject libtrigger.so using '__libc_dlopen_mode' which export
+ * from 'libc.so'. This is because libc.so is always loaded.
+ * Another option is to use 'dlopen' which exported from libdl.so,
+ * but 'libdl.so' will not always load.
+ *
+ * we must  have to load 'libmcount-dynamic.so' but '__libc_dlopen_mode'
+ * will failed to load it. maybe there is some complex issue.
+ *
+ * therefore, we inject 'libtrigger.so' to the process first.
+ * after it loaded, it will load 'libmcount-dynamic.so' continuly
+ * with using 'dlopen'.
+ */
+void do_inject(int pfd[2], int ready, struct opts *opts, char *argv[])
+{
+	int target_pid = opts->pid;
+	char* libtrigger_path;
+        uint64_t dummy;
+        close(pfd[0]);
+	setup_uftrace_environ(opts, pfd[1]);
+
+        if (read(ready, &dummy, sizeof(dummy)) != (ssize_t)sizeof(dummy))
+                pr_err("waiting for parent failed");
+
+	libtrigger_path = get_libtrigger_path(opts);
+
+	if(libtrigger_path == NULL)
+		pr_err("connot found libtrigger.so at %s\n", libtrigger_path);
+	pr_dbg("libtrigger found at : %s\n", libtrigger_path);
+	inject(libtrigger_path, target_pid);
+}
+
+/*
+find the executable file for the process you want to inject.
+Local symbol informations are required to use dynamic tracing.
+*/
+int find_exefile(struct opts *opts) {
+	DIR *directory = opendir("/proc/");
+	char* exePath;
+	int exePathLen = 0x1000;
+	ssize_t len;
+	pid_t pid = opts->pid;
+
+	if (!directory)
+		return 0;
+	exePath = malloc(exePathLen * sizeof(char));
+	sprintf(exePath, "/proc/%d/exe", pid);
+	exePath[exePathLen-1] = '\0';
+	len = readlink(exePath, absolute_file_path, PATH_MAX - 1);
+	if(len == -1) {
+		free(exePath);
+		return 0;
+	}
+	absolute_file_path[len] = '\0';
+	free(exePath);
+	closedir(directory);
+	opts->exename = absolute_file_path;
+	return 1;
+}
+
+#define UFTRACE_MSG  "Cannot trace '%s': No such executable file\n"	\
+"\tNote that uftrace doesn't search $PATH for you.\n"			\
+"\tIf you really want to trace executables in the $PATH,\n"		\
+"\tplease give it the absolute pathname (like /usr/bin/%s).\n"
+
+#define UFTRACE_ELF_MSG  "Cannot trace '%s': Invalid file\n"		\
+"\tThis file doesn't look like an executable ELF file.\n"		\
+"\tPlease check whether it's a kind of script or shell functions.\n"
+
+#define MACHINE_MSG  "Cannot trace '%s': Unsupported machine\n"		\
+"\tThis machine type (%u) is not supported currently.\n"		\
+"\tSorry about that!\n"
+
+#define STATIC_MSG  "Cannot trace static binary: %s\n"			\
+"\tIt seems to be compiled with -static, rebuild the binary without it.\n"
+
+#ifndef  EM_AARCH64
+# define EM_AARCH64  183
+#endif
+
+static void check_binary_dynamic_avilable(struct opts *opts)
+{
+	int fd;
+	int chk;
+	size_t i;
+	char elf_ident[EI_NIDENT];
+	uint16_t e_type;
+	uint16_t e_machine;
+	uint16_t supported_machines[] = {
+		EM_X86_64, EM_ARM, EM_AARCH64, EM_386
+	};
+
+	pr_dbg3("checking binary %s\n", opts->exename);
+
+	if (access(opts->exename, X_OK) < 0) {
+		if (errno == ENOENT && opts->exename[0] != '/') {
+			pr_err_ns(UFTRACE_MSG, opts->exename, opts->exename);
+		}
+		pr_err("Cannot trace '%s'", opts->exename);
+	}
+
+	fd = open(opts->exename, O_RDONLY);
+	if (fd < 0)
+		pr_err("Cannot open '%s'", opts->exename);
+
+	if (read(fd, elf_ident, sizeof(elf_ident)) < 0)
+		pr_err("Cannot read '%s'", opts->exename);
+
+	if (memcmp(elf_ident, ELFMAG, SELFMAG))
+		pr_err_ns(UFTRACE_ELF_MSG, opts->exename);
+
+	if (read(fd, &e_type, sizeof(e_type)) < 0)
+		pr_err("Cannot read '%s'", opts->exename);
+
+	if (e_type != ET_EXEC && e_type != ET_DYN)
+		pr_err_ns(UFTRACE_ELF_MSG, opts->exename);
+
+	if (read(fd, &e_machine, sizeof(e_machine)) < 0)
+		pr_err("Cannot read '%s'", opts->exename);
+
+	for (i = 0; i < ARRAY_SIZE(supported_machines); i++) {
+		if (e_machine == supported_machines[i])
+			break;
+	}
+	if (i == ARRAY_SIZE(supported_machines))
+		pr_err_ns(MACHINE_MSG, opts->exename, e_machine);
+
+	chk = check_static_binary(opts->exename);
+	if (chk) {
+		if (chk < 0)
+			pr_err_ns("Cannot check '%s'\n", opts->exename);
+		else
+			pr_err_ns(STATIC_MSG, opts->exename);
+	}
+
+	close(fd);
+}
+
+int command_dynamic(int argc, char *argv[], struct opts *opts)
+{
+	int pid;
+	int pfd[2];
+	int efd;
+	int ret = -1;
+
+	if (pipe(pfd) < 0)
+		pr_err("cannot setup internal pipe");
+
+	if (create_directory(opts->dirname) < 0)
+		return -1;
+
+	/* apply script-provided options */
+	if (opts->script_file)
+		parse_script_opt(opts);
+
+
+	if (!find_exefile(opts))
+		pr_err("Cannot find executable file path\n");
+
+	pr_dbg("FIND EXECUTABLE FILE PATH : %s\n", opts->exename);
+
+	// Check the binary to ensure that
+	// dynamic tracing is available.
+	check_binary_dynamic_avilable(opts);
+
+	has_perf_event = check_linux_schedule_event(opts->event,
+						    opts->patt_type);
+
+	fflush(stdout);
+
+	efd = eventfd(0, EFD_CLOEXEC | EFD_SEMAPHORE);
+	if (efd < 0)
+		pr_dbg("creating eventfd failed: %d\n", efd);
+
+	pid = fork();
+
+        if (pid < 0)
+                pr_err("cannot start child process");
+
+	// Dynamic to process
+	if (pid == 0)
+		do_inject(pfd, efd, opts, argv);
+	else
+		ret = do_main_loop(pfd, efd, opts, pid);
+	return ret;
+}

--- a/cmd-record.c
+++ b/cmd-record.c
@@ -71,7 +71,7 @@ static bool can_use_fast_libmcount(struct opts *opts)
 	return true;
 }
 
-static char *build_debug_domain_string(void)
+char *build_debug_domain_string(void)
 {
 	int i, d;
 	static char domain[2*DBG_DOMAIN_MAX + 1];
@@ -1510,8 +1510,8 @@ static void check_binary(struct opts *opts)
 	close(fd);
 }
 
-static bool check_linux_schedule_event(char *events,
-				       enum uftrace_pattern_type ptype)
+bool check_linux_schedule_event(char *events,
+		enum uftrace_pattern_type ptype)
 {
 	struct strv strv = STRV_INIT;
 	char *evt;

--- a/libmcount/mcount-dynamic.c
+++ b/libmcount/mcount-dynamic.c
@@ -1,0 +1,92 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <signal.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/uio.h>
+#include <sys/ptrace.h>
+#include <signal.h>
+
+#define PR_FMT     "mcount-dynamic"
+#define PR_DOMAIN  DBG_MCOUNT
+
+#include "libmcount/mcount.h"
+#include "libmcount/internal.h"
+#include "utils/utils.h"
+#include "utils/symbol.h"
+#include "utils/filter.h"
+#include "utils/script.h"
+#include "utils/env-file.h"
+
+/*
+ * previous mcount_startup() the contructor.
+ */
+void pre_startup()
+{
+	int fd_envfile;
+	fd_envfile = open_env_file();
+	set_env_from_file(fd_envfile);
+
+	/*
+	 * the Process output is delayed for unknown reasons when using
+	 * dynamic tracing. cannot found the reason of delay but below code
+	 * can mitigation the symptom.
+	 */
+	setvbuf(stdout, NULL, _IONBF, 1024);
+	setvbuf(stderr, NULL, _IONBF, 1024);
+}
+
+/*
+ * configuration for dynamic tracing.
+ */
+void config_for_dynamic() {
+	char *pipefd_str;
+	char *uftrace_pid_str;
+	int uftrace_pid;
+
+	struct stat statbuf;
+
+	uftrace_pid_str = getenv("UFTRACE_PID");
+	if (uftrace_pid_str) {
+		pr_dbg("uftrace process PID : %s\n", uftrace_pid_str);
+		uftrace_pid = strtol(uftrace_pid_str, NULL, 0);
+		if (uftrace_pid == 0) {
+			pr_err_ns("Cannot parse UFTRACE_PID from environment. \n");
+		}
+	} else {
+		pr_err_ns("Cannot found UFTRACE_PID from environment. \n");
+	}
+
+	pipefd_str = getenv("UFTRACE_PIPE");
+	if (pipefd_str) {
+		pfd = strtol(pipefd_str, NULL, 0);
+
+		char fd_path[64];
+		snprintf(fd_path, sizeof(fd_path), "/proc/%d/fd/%d", uftrace_pid, pfd);
+		pr_dbg("open uftrace process : %s\n", fd_path);
+		pfd = open(fd_path, O_RDWR);
+		/* minimal sanity check */
+		if (fstat(pfd, &statbuf) < 0 || !S_ISFIFO(statbuf.st_mode)) {
+			pr_dbg("ignore invalid pipe fd: %d\n", pfd);
+			pfd = -1;
+		}
+	}
+}
+
+/*
+ * post mcount_startup() the constructor.
+ */
+void post_startup()
+{
+	config_for_dynamic();
+}
+
+
+// TODO : make test and get the grade A+.
+

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -1417,13 +1417,26 @@ void __visible_default __cyg_profile_func_exit(void *child, void *parent)
 UFTRACE_ALIAS(__cyg_profile_func_exit);
 
 #ifndef UNIT_TEST
+
+__weak void pre_startup()
+{
+	// do something pre "mcount_startup" here.
+}
+
+__weak void post_startup()
+{
+	// do something post "mcount_startup" here.
+}
+
 /*
  * Initializer and Finalizer
  */
 static void __attribute__((constructor))
 mcount_init(void)
 {
+	pre_startup();
 	mcount_startup();
+	post_startup();
 }
 
 static void __attribute__((destructor))

--- a/libmcount/trigger.c
+++ b/libmcount/trigger.c
@@ -1,0 +1,120 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+#include <unistd.h>
+#include <string.h>
+#include <signal.h>
+#include <sys/time.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <inttypes.h>
+
+#include "libmcount/mcount.h"
+#include "utils/env-file.h"
+#include "utils/utils.h"
+
+
+#define ERROR_LIBRARY_NOT_EXIST \
+"%s does not exist libmcount shared object .\n" 			\
+"\tmake sure that the file exists. \n\n"				\
+"\t[notification]\n"							\
+"\twhen you use dynamic tracing to the process, you must specify the\n"	\
+"\tabsolute path of 'libmcount-dynamic.so' not the relative path.\n\n" 	\
+"\tfor example:\n" 							\
+"\t[BADD]./uftrace dynamic -L. --pid=xxxx \n"				\
+"\t[GOOD]./uftrace dynaimc -L/home/m/uftrace  --pid=xxxx \n"
+
+#define ERROR_DATADIR_NOT_EXIST \
+"Cannot access to the %s for saving uftrace datas.\n"  			\
+"\tmake sure that the path exists. \n\n" 				\
+"\t[notification]\n"							\
+"\twhen you use dynamic tracing to the process, you must specify the\n"	\
+"\tabsolute path of data-dir.\n\n" 					\
+"\tfor example:\n" 							\
+"\t[BADD]./uftrace dynamic -L/home/m/uftrace --pid=xxxx \n" 		\
+"\t[GOOD]./uftrace dynaimc -L/home/m/uftrace"				\
+"--data=/home/m/uftrace/data --pid=xxxx \n"
+
+#define ERROR_ENVFILE_NOT_EXIST \
+"\tCannot access to the %s which contain environment variable.\n"
+
+
+__attribute__((weak)) void build_debug_domain(char *dbg_domain_str)
+{
+        int i, len;
+
+        if (dbg_domain_str == NULL)
+                return;
+
+        len = strlen(dbg_domain_str);
+        for (i = 0; i < len; i += 2) {
+                const char *pos;
+                char domain = dbg_domain_str[i];
+                int level = dbg_domain_str[i+1] - '0';
+                int d;
+
+                pos = strchr(DBG_DOMAIN_STR, domain);
+                if (pos == NULL)
+                        continue;
+
+                d = pos - DBG_DOMAIN_STR;
+                dbg_domain[d] = level;
+        }
+}
+
+__attribute__((constructor)) void so_main() {
+	char* debug_str;
+	char* preload_library_path;
+	char* data_dir_path;
+	int fd_envfile;
+	struct stat file;
+
+	outfp = stdout;
+	logfp = stderr;
+
+        /*
+        the Process output is delayed for unknown reasons when using
+        dynamic tracing. cannot found the reason of delay but below code
+        can mitigation the symptom.
+        */
+        setvbuf(stdout, NULL, _IONBF, 1024);
+        setvbuf(stderr, NULL, _IONBF, 1024);
+
+	fd_envfile = open_env_file();
+	if (fd_envfile < 0) {
+		printf(ERROR_ENVFILE_NOT_EXIST, ENV_FILE);
+	}
+	set_env_from_file(fd_envfile);
+	preload_library_path = getenv("LD_PRELOAD");
+	data_dir_path = getenv("UFTRACE_DIR");
+
+	debug_str = getenv("UFTRACE_DEBUG");
+        if (debug_str) {
+                debug = strtol(debug_str, NULL, 0);
+                build_debug_domain(getenv("UFTRACE_DEBUG_DOMAIN"));
+        }
+
+	pr_dbg("LIBRARY PATH : %s\n", preload_library_path);
+	pr_dbg("DATADIR PATH : %s\n", data_dir_path);
+
+	if (stat(data_dir_path, &file) == 0) {
+		pr_dbg("DATA-DIR EXIST : %s\n", data_dir_path);
+	} else {
+		pr_err_ns(ERROR_DATADIR_NOT_EXIST, data_dir_path);
+	}
+
+	if (stat(preload_library_path, &file) == 0) {
+		pr_dbg("LIBRARY EXIST : %s\n", preload_library_path);
+	} else {
+		pr_err_ns(ERROR_LIBRARY_NOT_EXIST, preload_library_path);
+	}
+
+	void* handle = dlopen(preload_library_path, RTLD_LAZY);
+	if (!handle) {
+		pr_err_ns("%s\n", dlerror());
+        }
+}
+
+

--- a/uftrace.h
+++ b/uftrace.h
@@ -177,6 +177,7 @@ struct ftrace_file_handle {
 #define UFTRACE_MODE_GRAPH   8
 #define UFTRACE_MODE_SCRIPT  9
 #define UFTRACE_MODE_TUI     10
+#define UFTRACE_MODE_DYNAMIC 11
 
 #define UFTRACE_MODE_DEFAULT  UFTRACE_MODE_LIVE
 
@@ -206,6 +207,7 @@ struct opts {
 	int kernel_depth;
 	int max_stack;
 	int port;
+	int pid;
 	int color;
 	int column_offset;
 	int sort_column;
@@ -268,6 +270,7 @@ int command_dump(int argc, char *argv[], struct opts *opts);
 int command_graph(int argc, char *argv[], struct opts *opts);
 int command_script(int argc, char *argv[], struct opts *opts);
 int command_tui(int argc, char *argv[], struct opts *opts);
+int command_dynamic(int argc, char *argv[], struct opts *opts);
 
 extern volatile bool uftrace_done;
 

--- a/utils/env-file.c
+++ b/utils/env-file.c
@@ -1,0 +1,72 @@
+#include "utils/env-file.h"
+
+int create_env_file() {
+	int fd;
+	fd = open(ENV_FILE, O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+	return fd;
+}
+
+
+int open_env_file() {
+	int fd;
+	fd = open(ENV_FILE, O_RDONLY);
+	return fd;
+}
+
+/*
+ * write a line to uftrace environment file with given argument fd.
+ * a line contain key-value pair with separator '='.
+ * like this,
+ *
+ * [example]
+ * UFTRACE_PLTHOOK=1
+ */
+void set_env_to_file(int fd, char* key, char* value)
+{
+	char buf[256];
+	sprintf(buf, "%s", key);
+	sprintf(buf + strlen(buf), "%s", "=");
+	sprintf(buf + strlen(buf), "%s\n", value);
+	write(fd, buf, strlen(buf));
+}
+
+void set_env_from_file(int fd) {
+	char buf[4096] = {0,};
+	char key[1024] = {0,};
+	char value[1024] = {0,};
+
+	int count = read(fd, buf, 4096);
+	if (count < 0) {
+		pr_err_ns("FILE READ FAILED\n");
+	}
+	close(fd);
+
+	bool flag = true;
+	uint32_t key_index = 0;
+	uint32_t value_index = 0;
+	for(int i=0;buf[i] != '\0';i++) {
+		if(buf[i] == '\n') {
+			pr_dbg("ENVIRONMENT\t%s : %s \n", key, value);
+			setenv(key, value, 1);
+			flag = true;
+			key_index=0;
+			memset(key, 0, sizeof(key));
+			continue;
+		}
+		if(buf[i] == '=') {
+			if (flag) {
+			flag = false;
+			value_index=0;
+			memset(value, 0, sizeof(value));
+			continue;
+			}
+		}
+		if (flag) {
+			key[key_index++]=buf[i];
+		} else {
+			value[value_index++]=buf[i];
+		}
+	}
+}
+
+

--- a/utils/env-file.h
+++ b/utils/env-file.h
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdbool.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include "utils/utils.h"
+
+#define ENV_FILE  "/tmp/uftrace_environ_file"
+
+int create_env_file();
+int open_env_file();
+void set_env_to_file(int fd, char* key, char* value);
+void set_env_from_file(int fd);

--- a/utils/inject-utils.c
+++ b/utils/inject-utils.c
@@ -1,0 +1,172 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <dirent.h>
+#include <string.h>
+#include <unistd.h>
+#include <dlfcn.h>
+
+#include "inject-utils.h"
+#include "utils.h"
+
+/*
+ * freespaceaddr()
+ *
+ * Search the target process' /proc/pid/maps entry and find an executable
+ * region of memory that we can use to run code in.
+ *
+ * args:
+ * - pid_t pid: pid of process to inspect
+ *
+ * returns:
+ * - a long containing the address of an executable region of memory inside the
+ *   specified process' address space.
+ *
+ */
+
+long freespaceaddr(pid_t pid)
+{
+	FILE *fp;
+	char filename[30];
+	char line[850];
+	long addr;
+	char str[20];
+	char perms[5];
+	sprintf(filename, "/proc/%d/maps", pid);
+	fp = fopen(filename, "r");
+	if(fp == NULL)
+		pr_err("cannot open /proc/%d/maps \n", pid);
+	while(fgets(line, 850, fp) != NULL) {
+		sscanf(line, "%lx-%*x %s %*s %s %*d", &addr, perms, str);
+		if(strstr(perms, "x") != NULL) {
+			break;
+		}
+	}
+	fclose(fp);
+	return addr;
+}
+
+/*
+ * getlibcaddr()
+ *
+ * Gets the base address of libc.so inside a process by reading /proc/pid/maps.
+ *
+ * args:
+ * - pid_t pid: the pid of the process whose libc.so base address we should
+ *   find
+ *
+ * returns:
+ * - a long containing the base address of libc.so inside that process
+ *
+ */
+
+long getlibcaddr(pid_t pid)
+{
+	FILE *fp;
+	char filename[30];
+	char line[850];
+	long addr;
+	sprintf(filename, "/proc/%d/maps", pid);
+	fp = fopen(filename, "r");
+	if(fp == NULL)
+		pr_err("cannot open /proc/%d/maps \n", pid);
+	while(fgets(line, 850, fp) != NULL) {
+		sscanf(line, "%lx-%*x %*s %*s %*s %*d", &addr);
+		if(strstr(line, "libc-") != NULL) {
+			break;
+		}
+	}
+	fclose(fp);
+	return addr;
+}
+
+/*
+ * checkloaded()
+ *
+ * Given a process ID and the name of a shared library, check whether that
+ * process has loaded the shared library by reading entries in its
+ * /proc/[pid]/maps file.
+ *
+ * args:
+ * - pid_t pid: the pid of the process to check
+ * - char* libname: the library to search /proc/[pid]/maps for
+ *
+ * returns:
+ * - an int indicating whether or not the library has been loaded into the
+ *   process (1 = yes, 0 = no)
+ *
+ */
+
+int checkloaded(pid_t pid, char* libname)
+{
+	FILE *fp;
+	char filename[30];
+	char line[850];
+	long addr;
+	sprintf(filename, "/proc/%d/maps", pid);
+	fp = fopen(filename, "r");
+	if(fp == NULL)
+		pr_err("cannot open /proc/%d/maps \n", pid);
+	while(fgets(line, 850, fp) != NULL) {
+		sscanf(line, "%lx-%*x %*s %*s %*s %*d", &addr);
+		if(strstr(line, libname) != NULL) {
+			fclose(fp);
+			return 1;
+		}
+	}
+	fclose(fp);
+	return 0;
+}
+
+/*
+ * get_function_addr()
+ *
+ * Find the address of a function within our own loaded copy of libc.so.
+ *
+ * args:
+ * - char* funcName: name of the function whose address we want to find
+ *
+ * returns:
+ * - a long containing the address of that function
+ *
+ */
+
+long get_function_addr(char* func_name)
+{
+	void* self = dlopen("libc.so.6", RTLD_LAZY);
+	void* func_addr = dlsym(self, func_name);
+	return (long)func_addr;
+}
+
+/*
+ * find_ret()
+ *
+ * Starting at an address somewhere after the end of a function, search for the
+ * "ret" instruction that ends it. We do this by searching for a 0xc3 byte, and
+ * assuming that it represents that function's "ret" instruction. This should
+ * be a safe assumption. Function addresses are word-aligned, and so there's
+ * usually extra space at the end of a function. This space is always padded
+ * with "nop"s, so we'll end up just searching through a series of "nop"s
+ * before finding our "ret". In other words, it's unlikely that we'll run into
+ * a 0xc3 byte that corresponds to anything other than an actual "ret"
+ * instruction.
+ *
+ * Note that this function only applies to x86 and x86_64, and not ARM.
+ *
+ * args:
+ * - void* endAddr: the ending address of the function whose final "ret"
+ *   instruction we want to find
+ *
+ * returns:
+ * - an unsigned char* pointing to the address of the final "ret" instruction
+ *   of the specified function
+ *
+ */
+
+unsigned char* find_ret(void* end_addr)
+{
+	unsigned char* ret_inst_addr = end_addr;
+	while(*ret_inst_addr != INTEL_RET_INSTRUCTION) {
+		ret_inst_addr--;
+	}
+	return ret_inst_addr;
+}

--- a/utils/inject-utils.h
+++ b/utils/inject-utils.h
@@ -1,0 +1,8 @@
+#define INTEL_RET_INSTRUCTION 0xc3
+#define INTEL_INT3_INSTRUCTION 0xcc
+
+long freespaceaddr(pid_t pid);
+long getlibcaddr(pid_t pid);
+int checkloaded(pid_t pid, char* libname);
+long get_function_addr(char* funcName);
+unsigned char* find_ret(void* end_addr);

--- a/utils/ptrace.c
+++ b/utils/ptrace.c
@@ -1,0 +1,250 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ptrace.h>
+#include <sys/user.h>
+#include <wait.h>
+#include <time.h>
+
+#include "ptrace.h"
+#include "utils.h"
+
+/*
+ * ptrace_attach()
+ *
+ * Use ptrace() to attach to a process. This requires calling waitpid() to
+ * determine when the process is ready to be traced.
+ *
+ * args:
+ * - int pid: pid of the process to attach to
+ *
+ */
+void ptrace_attach(pid_t target)
+{
+	int waitpidstatus;
+
+	if(ptrace(PTRACE_ATTACH, target, NULL, NULL) == -1) {
+		pr_err("ptrace(PTRACE_ATTACH) failed\n");
+	}
+
+	if(waitpid(target, &waitpidstatus, WUNTRACED) != target) {
+		pr_err("waitpid(%d) failed\n", target);
+	}
+}
+
+/*
+ * ptrace_detach()
+ *
+ * Detach from a process that is being ptrace()d. Unlike ptrace_cont(), this
+ * completely ends our relationship with the target process.
+ *
+ * args:
+ * - int pid: pid of the process to detach from. this process must already be
+ *   ptrace()d by us in order for this to work.
+ *
+ */
+void ptrace_detach(pid_t target)
+{
+	if(ptrace(PTRACE_DETACH, target, NULL, NULL) == -1) {
+		pr_err("ptrace(PTRACE_DETACH) failed\n");
+	}
+}
+
+/*
+ * ptrace_getregs()
+ *
+ * Use ptrace() to get a process' current register state.  Uses REG_TYPE
+ * preprocessor macro in order to allow for both ARM and x86/x86_64
+ * functionality.
+ *
+ * args:
+ * - int pid: pid of the target process
+ * - struct REG_TYPE* regs: a struct (either user_regs_struct or user_regs,
+ *   depending on architecture) to store the resulting register data in
+ *
+ */
+void ptrace_getregs(pid_t target, struct REG_TYPE* regs)
+{
+	if(ptrace(PTRACE_GETREGS, target, NULL, regs) == -1) {
+		pr_err("ptrace(PTRACE_GETREGS) failed\n");
+	}
+}
+
+/*
+ * ptrace_cont()
+ *
+ * Continue the execution of a process being traced using ptrace(). Note that
+ * this is different from ptrace_detach(): we still retain control of the
+ * target process after this call.
+ *
+ * args:
+ * - int pid: pid of the target process
+ *
+ */
+void ptrace_cont(pid_t target)
+{
+	struct timespec* sleeptime = malloc(sizeof(struct timespec));
+
+	sleeptime->tv_sec = 1;
+	sleeptime->tv_nsec = 0000000;
+
+	if(ptrace(PTRACE_CONT, target, NULL, NULL) == -1) {
+		pr_err("ptrace(PTRACE_CONT) failed\n");
+	}
+
+	nanosleep(sleeptime, NULL);
+
+	// make sure the target process received SIGTRAP after stopping.
+	checktargetsig(target);
+}
+
+/*
+ * ptrace_setregs()
+ *
+ * Use ptrace() to set the target's register state.
+ *
+ * args:
+ * - int pid: pid of the target process
+ * - struct REG_TYPE* regs: a struct (either user_regs_struct or user_regs,
+ *   depending on architecture) containing the register state to be set in the
+ *   target process
+ *
+ */
+void ptrace_setregs(pid_t target, struct REG_TYPE* regs)
+{
+	if(ptrace(PTRACE_SETREGS, target, NULL, regs) == -1) {
+		pr_err("ptrace(PTRACE_SETREGS) failed\n");
+	}
+}
+
+/*
+ * ptrace_getsiginfo()
+ *
+ * Use ptrace() to determine what signal was most recently raised by the target
+ * process. This is primarily used for to determine whether the target process
+ * has segfaulted.
+ *
+ * args:
+ * - int pid: pid of the target process
+ *
+ * returns:
+ * - a siginfo_t containing information about the most recent signal raised by
+ *   the target process
+ *
+ */
+siginfo_t ptrace_getsiginfo(pid_t target)
+{
+	siginfo_t targetsig;
+	if(ptrace(PTRACE_GETSIGINFO, target, NULL, &targetsig) == -1)
+	{
+		pr_err("ptrace(PTRACE_GETSIGINFO) failed\n");
+	}
+	return targetsig;
+}
+
+/*
+ * ptrace_read()
+ *
+ * Use ptrace() to read the contents of a target process' address space.
+ *
+ * args:
+ * - int pid: pid of the target process
+ * - unsigned long addr: the address to start reading from
+ * - void *vptr: a pointer to a buffer to read data into
+ * - int len: the amount of data to read from the target
+ *
+ */
+void ptrace_read(int pid, unsigned long addr, void *vptr, int len)
+{
+	int bytesRead = 0;
+	int i = 0;
+	long word = 0;
+	long *ptr = (long *) vptr;
+
+	while (bytesRead < len) {
+		word = ptrace(PTRACE_PEEKTEXT, pid, addr + bytesRead, NULL);
+		if(word == -1) {
+			pr_err("ptrace(PTRACE_PEEKTEXT) failed\n");
+			exit(1);
+		}
+		bytesRead += sizeof(word);
+		ptr[i++] = word;
+	}
+}
+
+/*
+ * ptrace_write()
+ *
+ * Use ptrace() to write to the target process' address space.
+ *
+ * args:
+ * - int pid: pid of the target process
+ * - unsigned long addr: the address to start writing to
+ * - void *vptr: a pointer to a buffer containing the data to be written to the
+ *   target's address space
+ * - int len: the amount of data to write to the target
+ *
+ */
+void ptrace_write(int pid, unsigned long addr, void *vptr, int len)
+{
+	int byteCount = 0;
+	long word = 0;
+
+	while (byteCount < len) {
+		memcpy(&word, vptr + byteCount, sizeof(word));
+		word = ptrace(PTRACE_POKETEXT, pid, addr + byteCount, word);
+		if(word == -1) {
+			pr_err("ptrace(PTRACE_POKETEXT) failed\n");
+		}
+		byteCount += sizeof(word);
+	}
+}
+
+/*
+ * checktargetsig()
+ *
+ * Check what signal was most recently returned by the target process being
+ * ptrace()d. We expect a SIGTRAP from the target process, so raise an error
+ * and exit if we do not receive that signal. The most likely non-SIGTRAP
+ * signal for us to receive would be SIGSEGV.
+ *
+ * args:
+ * - int pid: pid of the target process
+ *
+ */
+void checktargetsig(int pid)
+{
+	// check the signal that the child stopped with.
+	siginfo_t targetsig = ptrace_getsiginfo(pid);
+
+	// if it wasn't SIGTRAP, then something bad happened (most likely a
+	// segfault).
+	if(targetsig.si_signo != SIGTRAP) {
+		pr_dbg("instead of expected SIGTRAP, target stopped with signal %d: %s\n", targetsig.si_signo, strsignal(targetsig.si_signo));
+		pr_dbg("sending process %d a SIGSTOP signal for debugging purposes\n", pid);
+		ptrace(PTRACE_CONT, pid, NULL, SIGSTOP);
+		pr_err("EXIT");
+	}
+}
+
+/*
+ * restore_state_and_detach()
+ *
+ * Once we're done debugging a target process, restore the process' backed-up
+ * data and register state and let it go on its merry way.
+ *
+ * args:
+ * - pid_t target: pid of the target process
+ * - unsigned long addr: address within the target's address space to write
+ *   backed-up data to
+ * - void* backup: a buffer pointing to the backed-up data
+ * - int datasize: the amount of backed-up data to write
+ * - struct REG_TYPE oldregs: backed-up register state to restore
+ *
+ */
+void restore_state_and_detach(pid_t target, unsigned long addr, void* backup, int datasize, struct REG_TYPE oldregs)
+{
+	ptrace_write(target, addr, backup, datasize);
+	ptrace_setregs(target, &oldregs);
+	ptrace_detach(target);
+}

--- a/utils/ptrace.h
+++ b/utils/ptrace.h
@@ -1,0 +1,21 @@
+#include <sys/ptrace.h>
+#include <sys/user.h>
+#include <wait.h>
+#include <time.h>
+
+#ifdef ARM
+	#define REG_TYPE user_regs
+#else
+	#define REG_TYPE user_regs_struct
+#endif
+
+void ptrace_attach(pid_t target);
+void ptrace_detach(pid_t target);
+void ptrace_getregs(pid_t target, struct REG_TYPE* regs);
+void ptrace_cont(pid_t target);
+void ptrace_setregs(pid_t target, struct REG_TYPE* regs);
+siginfo_t ptrace_getsiginfo(pid_t target);
+void ptrace_read(int pid, unsigned long addr, void *vptr, int len);
+void ptrace_write(int pid, unsigned long addr, void *vptr, int len);
+void checktargetsig(int pid);
+void restore_state_and_detach(pid_t target, unsigned long addr, void* backup, int datasize, struct REG_TYPE oldregs);


### PR DESCRIPTION
this PR contains implementation of TODO that attaching the already running process. 

usage : 
'./uftrace dynamic -L`pwd` --data=`pwd`/xxx --pid=<target pid>'

explain: 
use 'ptrace' to load 'libtrigger.so' into the target process. Later 'libtrigger.so' will load 'libmcount-dynamic.so'. Currently 'libmcount-dynamic.so' is almost identical to 'libmcount.so'. The only difference is that the environment variables are read from file which save environment variable. Currently, 'libmcount-dynamic.so' can only perform functions related to plthook.
