### PR TITLE
utils: Make gray color more distinguishable

### DIFF
--- a/utils/debug.c
+++ b/utils/debug.c
@@ -24,7 +24,7 @@
 #define TERM_COLOR_BLUE		"\033[1;34m"  /* bright blue */
 #define TERM_COLOR_MAGENTA	"\033[35m"
 #define TERM_COLOR_CYAN		"\033[36m"
-#define TERM_COLOR_GRAY		"\033[37m"
+#define TERM_COLOR_GRAY		"\033[2m"
 
 int debug;
 FILE *logfp;


### PR DESCRIPTION
Since current gray color looks same as normal color depending on the
terminal environment, this has to be much clear on every envinronment.

So this patch changes gray color to more distinguishable gray.  It will
make user comfortable when reading replay output.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>