### PR TITLE
uftrace: Check if wrong tid value or not

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -507,7 +507,10 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 		break;
 
 	case OPT_tid_filter:
-		opts->tid = opt_add_string(opts->tid, arg);
+		if (strtol(arg, NULL, 0) <= 0)
+			pr_use("invalid thread id: %s\n", arg);
+		else
+			opts->tid = opt_add_string(opts->tid, arg);
 		break;
 
 	case OPT_no_merge:


### PR DESCRIPTION
If given wrong tid value with --tid option,
some problems can occur at setup_task_filter().
So check given tid value. Hanbum Park reported this
problem with the dump subcommand.

Fixes: #374

Signed-off-by: Taeung Song <treeze.taeung@gmail.com>