### PR TITLE
session: Fix missing kernel base addr problem

### DIFF
--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -1308,7 +1308,6 @@ static void mcount_startup(void)
 	symtabs.filename = mcount_exename;
 
 	record_proc_maps(dirname, mcount_session_name(), &symtabs);
-	set_kernel_base(&symtabs, mcount_session_name());
 	load_symtabs(&symtabs, NULL, mcount_exename);
 
 	if (pattern_str)

--- a/libmcount/record.c
+++ b/libmcount/record.c
@@ -868,6 +868,8 @@ void record_proc_maps(char *dirname, const char *sess_id,
 	if (ofp == NULL)
 		pr_err("cannot open for writing maps file");
 
+	symtabs->kernel_base = -1ULL;
+
 	while (fgets(buf, sizeof(buf), ifp)) {
 		unsigned long start, end;
 		char prot[5];
@@ -885,8 +887,10 @@ void record_proc_maps(char *dirname, const char *sess_id,
 		 * but [stack] is still needed to get kernel base address.
 		 */
 		if (path[0] == '[') {
-			if (strncmp(path, "[stack", 6) == 0)
+			if (strncmp(path, "[stack", 6) == 0) {
+				symtabs->kernel_base = get_kernel_base(buf);
 				goto next;
+			}
 			else
 				continue;
 		}

--- a/libmcount/record.c
+++ b/libmcount/record.c
@@ -880,9 +880,16 @@ void record_proc_maps(char *dirname, const char *sess_id,
 			   &start, &end, prot, path) != 4)
 			continue;
 
-		/* skip special mappings like [heap], [stack] */
-		if (path[0] == '[')
-			continue;
+		/*
+		 * skip special mappings like [heap], [vdso] etc.
+		 * but [stack] is still needed to get kernel base address.
+		 */
+		if (path[0] == '[') {
+			if (strncmp(path, "[stack", 6) == 0)
+				goto next;
+			else
+				continue;
+		}
 
 		/* use first mapping only (even if it's non-exec) */
 		if (last_libname && !strcmp(last_libname, path))
@@ -912,7 +919,7 @@ void record_proc_maps(char *dirname, const char *sess_id,
 
 		map->next = NULL;
 		prev_map = map;
-
+next:
 		fprintf(ofp, "%s", buf);
 	}
 

--- a/utils/session.c
+++ b/utils/session.c
@@ -49,6 +49,10 @@ void read_session_map(char *dirname, struct symtabs *symtabs, char *sid)
 			   &start, &end, prot, path) != 4)
 			continue;
 
+		/* skip the [stack] mapping */
+		if (path[0] == '[')
+			continue;
+
 		/* use first mapping only (even if it's non-exec) */
 		if (last_libname && !strcmp(last_libname, path)) {
 			if (symtabs->filename && !strcmp(path, symtabs->filename))

--- a/utils/session.c
+++ b/utils/session.c
@@ -50,8 +50,11 @@ void read_session_map(char *dirname, struct symtabs *symtabs, char *sid)
 			continue;
 
 		/* skip the [stack] mapping */
-		if (path[0] == '[')
+		if (path[0] == '[') {
+			if (strncmp(path, "[stack", 6) == 0)
+				symtabs->kernel_base = get_kernel_base(buf);
 			continue;
+		}
 
 		/* use first mapping only (even if it's non-exec) */
 		if (last_libname && !strcmp(last_libname, path)) {
@@ -150,7 +153,6 @@ void create_session(struct uftrace_session_link *sessions,
 
 	read_session_map(dirname, &s->symtabs, s->sid);
 	load_symtabs(&s->symtabs, dirname, s->exename);
-	set_kernel_base(&s->symtabs, s->sid);
 
 	load_module_symtabs(&s->symtabs);
 

--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -1847,7 +1847,7 @@ void print_symtabs(struct symtabs *symtabs)
 	}
 }
 
-static uint64_t get_kernel_base(char *str)
+uint64_t get_kernel_base(char *str)
 {
 	uint64_t addr = strtoull(str, NULL, 16);
 
@@ -1862,30 +1862,6 @@ static uint64_t get_kernel_base(char *str)
 	} else {
 		return 0x800000000000ULL;
 	}
-}
-
-void set_kernel_base(struct symtabs *symtabs, const char *session_id)
-{
-	FILE *fp;
-	char buf[PATH_MAX];
-	char line[200];
-	uint64_t kernel_base_addr = -1ULL;
-
-	snprintf(buf, sizeof(buf), "%s/sid-%.*s.map",
-		 symtabs->dirname, SESSION_ID_LEN, session_id);
-
-	fp = fopen(buf, "r");
-	if (fp == NULL)
-		pr_err("open %s file failed", buf);
-
-	while (fgets(line, sizeof(line), fp) != NULL) {
-		if (strstr(line, "[stack") != NULL) {
-			kernel_base_addr = get_kernel_base(line);
-		}
-	}
-	fclose(fp);
-
-	symtabs->kernel_base = kernel_base_addr;
 }
 
 #ifdef UNIT_TEST

--- a/utils/symbol.h
+++ b/utils/symbol.h
@@ -90,7 +90,7 @@ static inline uint64_t get_real_address(uint64_t addr)
 	return addr;
 }
 
-void set_kernel_base(struct symtabs *symtabs, const char *session_id);
+uint64_t get_kernel_base(char *str);
 
 struct sym * find_symtabs(struct symtabs *symtabs, uint64_t addr);
 struct sym * find_symname(struct symtab *symtab, const char *name);


### PR DESCRIPTION
Based on current master branch,
I found this problem in the hello world case with `-k` option
like below:
```
  $ sudo uftrace -k ./hello
  hello
     1.107 us [ 25464] | __monstartup();
     0.994 us [ 25464] | __cxa_atexit();
              [ 25464] | main() {
              [ 25464] |   puts() {
     0.537 us [ 25464] |     <ffff81003860>();
     1.690 us [ 25464] |     <ffff81215420>();
     0.425 us [ 25464] |     <ffff81003620>();
     7.092 us [ 25464] |     <ffff810692b0>();
    16.544 us [ 25464] |   } /* puts */
  ...
```
This problem is related with The commit de7387f
("session: Don't create a map for main executable")

The commit excludes `[stack]` in a map, when skipping special
mappings like `[heap]`, however, `[stack]` is still needed
to get kernel base addr. If skipping `[stack]` mapping,
we aren't able to properly find kernel base addr at `set_kernel_base()`.
It is the reason that the above output cannot show kernel symbol name.

For information,
the second refactoring commit ("symbol: Refactor storing kernel base addr") is
related with d841004 by @iamwonseok 