### PR TITLE
gcov: Add a convenient way to generate code coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,7 @@ cscope.*
 *.sw[opn]
 *.patch
 *.orig
+*.gcda
+*.gcno
 misc/demangler
 misc/symbols

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,16 @@ endif
 ifeq ($(TRACE), 1)
   UFTRACE_CFLAGS += -pg -fno-omit-frame-pointer
   DEMANGLER_CFLAGS += -pg -fno-omit-frame-pointer
+  SYMBOLS_CFLAGS += -pg -fno-omit-frame-pointer
   TRACEEVENT_CFLAGS += -pg -fno-omit-frame-pointer
   # cannot add -pg to LIB_CFLAGS because mcount() is not reentrant
+endif
+
+ifeq ($(COVERAGE), 1)
+  UFTRACE_CFLAGS += -O0 -g -fprofile-arcs -ftest-coverage -U_FORTIFY_SOURCE
+  DEMANGLER_CFLAGS += -O0 -g -fprofile-arcs -ftest-coverage -U_FORTIFY_SOURCE
+  SYMBOLS_CFLAGS += -O0 -g -fprofile-arcs -ftest-coverage -U_FORTIFY_SOURCE
+  TRACEEVENT_CFLAGS += -O0 -g -fprofile-arcs -ftest-coverage -U_FORTIFY_SOURCE
 endif
 
 export UFTRACE_CFLAGS LIB_CFLAGS

--- a/Makefile
+++ b/Makefile
@@ -312,10 +312,16 @@ clean:
 	$(Q)$(RM) $(objdir)/utils/*.op $(objdir)/libmcount/*.op
 	$(Q)$(RM) $(objdir)/gmon.out $(srcdir)/scripts/*.pyc $(TARGETS)
 	$(Q)$(RM) $(objdir)/uftrace-*.tar.gz $(objdir)/version.h
+	$(Q)find -name "*\.gcda" -o -name "*\.gcno" | xargs $(RM)
+	$(Q)$(RM) coverage.info
 	@$(MAKE) -sC $(srcdir)/arch/$(ARCH) clean
 	@$(MAKE) -sC $(srcdir)/tests ARCH=$(ARCH) clean
 	@$(MAKE) -sC $(srcdir)/doc clean
 	@$(MAKE) -sC $(srcdir)/libtraceevent clean
+
+reset-coverage:
+	$(Q)find -name "*\.gcda" | xargs $(RM)
+	$(Q)$(RM) coverage.info
 
 ctags:
 	@find . -name "*\.[chS]" -o -path ./tests -prune -o -path ./check-deps -prune \

--- a/misc/run-lcov.sh
+++ b/misc/run-lcov.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+report_dir=coverage.html
+
+if [ $# -eq 1 ]; then
+  report_dir=$1
+fi
+
+which lcov > /dev/null
+lcov_test=$?
+if [ 0 -ne $lcov_test ]; then
+	echo "Error: cannot find 'lcov': Please install it first."
+	exit $lcov_test
+fi
+
+info_file=coverage.info
+lcov --capture --rc lcov_branch_coverage=1 --directory . --output-file $info_file
+genhtml $info_file --branch-coverage --output-directory $report_dir
+rm -f $info_file
+
+rmdir $report_dir 2> /dev/null
+
+if [ -d $report_dir ]; then
+  echo -e "\nThe code coverage report is normally generated in $report_dir\n"
+fi

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,6 +2,10 @@ TEST_CFLAGS  := -D_GNU_SOURCE -DUNIT_TEST -I$(srcdir) -I$(objdir) -I$(srcdir)/ar
 TEST_CFLAGS  += -include $(srcdir)/tests/unittest.h
 TEST_LDFLAGS := -L$(objdir)/libtraceevent -ltraceevent -lelf -pthread -lrt -ldl
 
+ifeq ($(COVERAGE), 1)
+  TEST_CFLAGS += -O0 -g -fprofile-arcs -ftest-coverage -U_FORTIFY_SOURCE
+endif
+
 UNIT_TEST_SRC := $(srcdir)/uftrace.c
 UNIT_TEST_SRC += $(wildcard $(srcdir)/cmds/*.c)
 UNIT_TEST_SRC += $(wildcard $(srcdir)/utils/*.c)


### PR DESCRIPTION
This PR provides a way to generate code coverage report using gcov and lcov.
It'd be useful to see the code coverage of uftrace itself for debugging purposes.
It also includes some scripts from lcov project.

The execution sequence is as follows:

1. build uftrace with gcov enabled
  $ make GCOV=1

2. run uftrace
  $ ./uftrace info

3. run a script to generate html report
  $ ./misc/run-lcov.sh

4. open `uftrace.html` in a browser