### PR TITLE
record: Do not read uftrace.data/info with --nop

### DIFF
--- a/cmds/record.c
+++ b/cmds/record.c
@@ -1764,15 +1764,18 @@ static void finish_writers(struct writer_data *wd, struct opts *opts)
 	int i;
 	char *elapsed_time = get_child_time(&wd->ts1, &wd->ts2);
 
-	if (fill_file_header(opts, wd->status, &wd->usage, elapsed_time) < 0)
-		pr_err("cannot generate data file");
-
 	if (opts->time) {
 		print_child_time(elapsed_time);
 		print_child_usage(&wd->usage);
 	}
 
 	free(elapsed_time);
+
+	if (opts->nop)
+		return;
+
+	if (fill_file_header(opts, wd->status, &wd->usage, elapsed_time) < 0)
+		pr_err("cannot generate data file");
 
 	if (shmem_lost_count)
 		pr_warn("LOST %d records\n", shmem_lost_count);


### PR DESCRIPTION
This fixes the below error message when --nop option is enabled.

    $ uftrace --nop -vvv abc
    uftrace: checking binary abc
    symbol: check trace functions in abc
    uftrace: creating 0 thread(s) for recording
    uftrace: using libmcount-nop.so library for tracing
    uftrace: all process/thread exited
    uftrace: child terminated with exit code: 0
    uftrace: fill header (metadata) info in /tmp/uftrace-live-1O7bAj/info
    uftrace: /home/honggyu/work/uftrace/cmds/record.c:377:fill_file_header
     ERROR: cannot open info file: No such file or directory

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>