### PR TITLE
gcov: Support code coverage for libmcount-*.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,9 @@ ifeq ($(TRACE), 1)
 endif
 
 ifeq ($(COVERAGE), 1)
-  UFTRACE_CFLAGS += -O0 -g -fprofile-arcs -ftest-coverage -U_FORTIFY_SOURCE
-  DEMANGLER_CFLAGS += -O0 -g -fprofile-arcs -ftest-coverage -U_FORTIFY_SOURCE
-  SYMBOLS_CFLAGS += -O0 -g -fprofile-arcs -ftest-coverage -U_FORTIFY_SOURCE
-  TRACEEVENT_CFLAGS += -O0 -g -fprofile-arcs -ftest-coverage -U_FORTIFY_SOURCE
+  COMMON_CFLAGS += -O0 -g --coverage -U_FORTIFY_SOURCE
+  LIB_CFLAGS += -O0 -g --coverage -U_FORTIFY_SOURCE
+  LIB_LDFLAGS += --coverage
 endif
 
 export UFTRACE_CFLAGS LIB_CFLAGS


### PR DESCRIPTION
This patch allows libmcount libraries to be compiled with code coverage
support option.

Since gcov related options are smart enough, the target program doesn't
have to be compiled with code coverage option but just with normal
tracable option such as -pg, -finstrument-functions or without such
flags.

The --coverage option is a synonym for -fprofile-arcs -ftest-coverage
(when compiling) and -lgcov (when linking) so it's used for simplicity.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>