### PR TITLE
utils: Make gray color to dark gray

### DIFF
--- a/utils/debug.c
+++ b/utils/debug.c
@@ -18,10 +18,10 @@
 #define TERM_COLOR_NORMAL	""
 #define TERM_COLOR_RESET	"\033[0m"
 #define TERM_COLOR_BOLD		"\033[1m"
-#define TERM_COLOR_RED		"\033[1;31m"  /* bright red */
+#define TERM_COLOR_RED		"\033[91m"    /* bright red */
 #define TERM_COLOR_GREEN	"\033[32m"
 #define TERM_COLOR_YELLOW	"\033[33m"
-#define TERM_COLOR_BLUE		"\033[1;34m"  /* bright blue */
+#define TERM_COLOR_BLUE		"\033[94m"    /* bright blue */
 #define TERM_COLOR_MAGENTA	"\033[35m"
 #define TERM_COLOR_CYAN		"\033[36m"
 #define TERM_COLOR_GRAY		"\033[90m"    /* bright black */

--- a/utils/debug.c
+++ b/utils/debug.c
@@ -24,7 +24,7 @@
 #define TERM_COLOR_BLUE		"\033[1;34m"  /* bright blue */
 #define TERM_COLOR_MAGENTA	"\033[35m"
 #define TERM_COLOR_CYAN		"\033[36m"
-#define TERM_COLOR_GRAY		"\033[2m"
+#define TERM_COLOR_GRAY		"\033[90m"    /* bright black */
 
 int debug;
 FILE *logfp;


### PR DESCRIPTION
The current gray color still looks same as normal text color in some
environments.  This patch makes the gray to dark gray.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>