### PR TITLE
doc: Add missing tui command in SYNOPSIS

### DIFF
--- a/doc/uftrace.md
+++ b/doc/uftrace.md
@@ -9,7 +9,7 @@ uftrace - Function graph tracer for userspace
 
 SYNOPSIS
 ========
-uftrace [*record*|*replay*|*live*|*report*|*info*|*dump*|*recv*|*graph*|*script*] [*options*] COMMAND [*command-options*]
+uftrace [*record*|*replay*|*live*|*report*|*info*|*dump*|*recv*|*graph*|*script*|*tui*] [*options*] COMMAND [*command-options*]
 
 
 DESCRIPTION


### PR DESCRIPTION
tui command is missing in SYNOPSIS of uftrace man page, so update it.