### PR TITLE
tui: Support to find longest executed child in tui graph

### DIFF
--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -2093,8 +2093,7 @@ static void tui_main_loop(struct opts *opts, struct ftrace_file_handle *handle)
 			break;
 		case KEY_ENTER:
 		case '\n':
-			if (tui_window_enter(win, win->curr))
-				full_redraw = true;
+			full_redraw = tui_window_enter(win, win->curr);
 
 			if (win == &session->win) {
 				struct tui_list_node *cmd = win->curr;
@@ -2168,12 +2167,10 @@ static void tui_main_loop(struct opts *opts, struct ftrace_file_handle *handle)
 			}
 			break;
 		case 'c':
-			if (tui_window_collapse(win))
-				full_redraw = true;
+			full_redraw = tui_window_collapse(win);
 			break;
 		case 'e':
-			if (tui_window_expand(win))
-				full_redraw = true;
+			full_redraw = tui_window_expand(win);
 			break;
 		case 'p':
 			tui_window_move_prev(win);
@@ -2297,7 +2294,7 @@ int command_tui(int argc, char *argv[], struct opts *opts)
 
 int command_tui(int argc, char *argv[], struct opts *opts)
 {
-	pr_warn("TUI is not implemented (libncursesw.so is missing)");
+	pr_warn("TUI is unsupported (libncursesw.so is missing)\n");
 	return 0;
 }
 

--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -1808,17 +1808,6 @@ static void tui_window_move_next(struct tui_window *win)
 		tui_window_move_down(win);
 }
 
-static void tui_window_move_parent(struct tui_window *win)
-{
-	void *parent = win->ops->parent(win, win->curr);
-
-	if (parent == NULL)
-		return;
-
-	while (win->curr != parent)
-		tui_window_move_up(win);
-}
-
 static void tui_window_display(struct tui_window *win, bool full_redraw,
 			       struct ftrace_file_handle *handle)
 {
@@ -2039,6 +2028,19 @@ static bool tui_window_expand(struct tui_window *win)
 	return win->ops->expand(win, win->curr, 1);
 }
 
+static bool tui_window_move_parent(struct tui_window *win)
+{
+	void *parent = win->ops->parent(win, win->curr);
+
+	if (parent == NULL)
+		return false;
+
+	while (win->curr != parent)
+		tui_window_move_up(win);
+
+	return tui_window_collapse(win);
+}
+
 static bool tui_window_longest_child(struct tui_window *win)
 {
 	if (win->ops->longest_child == NULL)
@@ -2213,7 +2215,7 @@ static void tui_main_loop(struct opts *opts, struct ftrace_file_handle *handle)
 			tui_window_move_next(win);
 			break;
 		case 'u':
-			tui_window_move_parent(win);
+			full_redraw = tui_window_move_parent(win);
 			break;
 		case 'l':
 			full_redraw = tui_window_longest_child(win);

--- a/doc/uftrace-tui.md
+++ b/doc/uftrace-tui.md
@@ -120,6 +120,7 @@ Following keys can be used in the TUI window:
  * `c`/`e`:               Collapse/Expand graph node
  * `n`/`p`:               Move to next/prev sibling (in graph mode)
  * `u`:                   Move up to parent (in graph mode)
+ * `l`:                   Move to the longest executed child (in graph mode)
  * `j`/`k`:               Move cursor up/down (like vi)
  * `/`:                   Start search
  * `<`/`P`:               Search previous match


### PR DESCRIPTION
In tui mode, 'c' key is very useful by collapsing nested children.
It'd also be very useful to provide a short key to find the child that
has longest execution time among all the other children.

The 'l' key for longest child performs as below:

  1. unfold the current node
  2. find a child that has the longest execution time
  3. collapse all the other children except for the longest child
  4. move to the longest child

It'd be useful when finding the performance critical execution path.

Resolved: #398

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>