### PR TITLE
build: Fix --without-libstdc++ option in configure

### DIFF
--- a/configure
+++ b/configure
@@ -126,13 +126,16 @@ make -siC ${srcdir}/check-deps check-build
 for dep in $IGNORE; do
     TARGET=
     case "$dep" in
-        libelf)      TARGET=libelf        ;;
-        libdw)       TARGET=libdw         ;;
-        libpython*)  TARGET=libpython2.7  ;;
-        libncurse*)  TARGET=libncurses    ;;
+        libelf)      TARGET=have_libelf        ;;
+        libdw)       TARGET=have_libdw         ;;
+        libpython*)  TARGET=have_libpython2.7  ;;
+        libncurse*)  TARGET=have_libncurses    ;;
+        libstdc++)   TARGET=cxa_demangle       ;;
         *)           ;;
     esac
-    rm -f ${srcdir}/check-deps/have_$TARGET
+    if [ ! -z "$TARGET" ]; then
+        rm -f ${srcdir}/check-deps/$TARGET
+    fi
 done
 
 cat >$output <<EOF


### PR DESCRIPTION
In configure script, --without-libstdc++ doesn't work as below:

    $ ./configure --without-libstdc++
    $ make
    $ ldd uftrace | grep libstdc++
            libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fa6df232000)

So this patch fixes the problem matching it to check-deps/cxa_demangle.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>