### PR TITLE
symbol: Fix a bug missing d_buf of Elf_Data

### DIFF
--- a/utils/symbol-libelf.h
+++ b/utils/symbol-libelf.h
@@ -115,8 +115,8 @@ struct uftrace_elf_iter {
 					       &(iter)->nhdr,		\
 					       (size_t*)&(iter)->note_name, \
 						(size_t*)&(iter)->note_desc)) && \
-		     ((iter)->note_name = (iter)->data + (size_t)(iter)->note_name) && \
-		     ((iter)->note_desc = (iter)->data + (size_t)(iter)->note_desc); \
+		     ((iter)->note_name = (iter)->data->d_buf + (size_t)(iter)->note_name) && \
+		     ((iter)->note_desc = (iter)->data->d_buf + (size_t)(iter)->note_desc); \
 	     (iter)->i = (iter)->nr)
 
 int elf_init(const char *filename, struct uftrace_elf_data *elf);


### PR DESCRIPTION
After the commit 60d013e ("symbol: Add
elf_for_each_nhdr() macro"), segfaults occurs
when using event options, so fix it.

Fixes: #403

Reported-by: Honggyu Kim <honggyu.kp@gmail.com>
Signed-off-by: Taeung Song <treeze.taeung@gmail.com>