### PR TITLE
tui: Apply various enhancements for tui command

### DIFF
--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -2332,7 +2332,21 @@ static void tui_main_loop(struct opts *opts, struct uftrace_data *handle)
 		case 'R':
 		case 'r':
 			if (tui_window_change(win, &report->win)) {
+				struct tui_report_node *func;
+				struct tui_graph_node *graph_curr = win->curr;
+
+				func = (void *)report_find_node(&report->name_tree,
+					       graph_curr->n.name);
+				if (func == NULL)
+					break;
+
+				/* change to report window */
 				win = &report->win;
+
+				/* move focus on the same function */
+				tui_window_move_home(win);
+				tui_window_set_middle_next(win, func);
+
 				full_redraw = true;
 			}
 			break;

--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -133,7 +133,7 @@ static const char *help[] = {
 	"ARROW         Navigation",
 	"PgUp/Dn",
 	"Home/End",
-	"Enter         Select/Fold",
+	"Enter         Fold/unfold graph or Select session",
 	"G             Show (full) call graph",
 	"g             Show call graph for this function",
 	"R             Show uftrace report",

--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -2219,6 +2219,12 @@ static void tui_window_help(void)
 	delwin(win);
 }
 
+static inline void cancel_search()
+{
+	free(tui_search);
+	tui_search = NULL;
+}
+
 static void tui_main_loop(struct opts *opts, struct uftrace_data *handle)
 {
 	int key = 0;
@@ -2250,22 +2256,28 @@ static void tui_main_loop(struct opts *opts, struct uftrace_data *handle)
 			break;
 		case KEY_UP:
 		case 'k':
+			cancel_search();
 			tui_window_move_up(win);
 			break;
 		case KEY_DOWN:
 		case 'j':
+			cancel_search();
 			tui_window_move_down(win);
 			break;
 		case KEY_PPAGE:
+			cancel_search();
 			tui_window_page_up(win);
 			break;
 		case KEY_NPAGE:
+			cancel_search();
 			tui_window_page_down(win);
 			break;
 		case KEY_HOME:
+			cancel_search();
 			tui_window_move_home(win);
 			break;
 		case KEY_END:
+			cancel_search();
 			tui_window_move_end(win);
 			break;
 		case KEY_ENTER:
@@ -2299,8 +2311,7 @@ static void tui_main_loop(struct opts *opts, struct uftrace_data *handle)
 			}
 			break;
 		case KEY_ESCAPE:
-			free(tui_search);  /* cancel search */
-			tui_search = NULL;
+			cancel_search();
 			break;
 		case 'G':
 			if (tui_window_change(win, &graph->win)) {

--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -137,6 +137,7 @@ static const char *help[] = {
 	"G             Show (full) call graph",
 	"g             Show call graph for this function",
 	"R             Show uftrace report",
+	"r             Show uftrace report for this function",
 	"I             Show uftrace info",
 	"S             Change session",
 	"O             Open editor",
@@ -2330,6 +2331,12 @@ static void tui_main_loop(struct opts *opts, struct uftrace_data *handle)
 			full_redraw = true;
 			break;
 		case 'R':
+			if (tui_window_change(win, &report->win)) {
+				win = &report->win;
+				tui_window_move_home(win);
+				full_redraw = true;
+			}
+			break;
 		case 'r':
 			if (tui_window_change(win, &report->win)) {
 				struct tui_report_node *func;

--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -2278,9 +2278,11 @@ static void tui_main_loop(struct opts *opts, struct uftrace_data *handle)
 				switch ((long)cmd->data) {
 				case TUI_SESS_REPORT:
 					win = &report->win;
+					tui_window_move_home(win);
 					break;
 				case TUI_SESS_INFO:
 					win = &info->win;
+					tui_window_move_home(win);
 					break;
 				case TUI_SESS_HELP:
 					tui_window_help();
@@ -2291,6 +2293,7 @@ static void tui_main_loop(struct opts *opts, struct uftrace_data *handle)
 					/* change window for the current graph */
 					graph = get_current_graph(win->curr, NULL);
 					win = &graph->win;
+					tui_window_move_home(win);
 					break;
 				}
 			}

--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -146,6 +146,7 @@ static const char *help[] = {
 	"u             Move up to parent",
 	"l             Move to the longest executed child",
 	"j/k           Move down/up",
+	"z             Set current line to the center of screen",
 	"/             Search",
 	"</>/N/P       Search next/prev",
 	"v             Show debug message",
@@ -1942,6 +1943,17 @@ static void tui_window_set_middle_next(struct tui_window *win, void *target)
 	}
 }
 
+static void tui_window_set_middle(struct tui_window *win)
+{
+	int offset_from_top = win->curr_index - win->top_index;
+	int offset_half = LINES / 2;
+
+	if (offset_from_top < offset_half - 2)
+		tui_window_set_middle_prev(win, win->curr);
+	else if (offset_from_top > offset_half + 1)
+		tui_window_set_middle_next(win, win->curr);
+}
+
 static bool tui_window_can_search(struct tui_window *win)
 {
 	return win->ops->search != NULL;
@@ -2403,6 +2415,9 @@ static void tui_main_loop(struct opts *opts, struct uftrace_data *handle)
 			break;
 		case 'l':
 			full_redraw = tui_window_longest_child(win);
+			break;
+		case 'z':
+			tui_window_set_middle(win);
 			break;
 		case '/':
 			if (tui_window_can_search(win)) {

--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -1274,10 +1274,20 @@ static void win_footer_report(struct tui_window *win, struct uftrace_data *handl
 			 tui_search, win->search_count, "use '<' and '>' keys to navigate");
 	}
 	else {
-		struct tui_report *report = (struct tui_report *)win;
+		struct debug_location *dloc;
 
-		snprintf(buf, COLS, "uftrace report: %s (%d sessions, %d functions)",
-			 handle->dirname, report->nr_sess, report->nr_func);
+		dloc = win->ops->location(win, win->curr);
+
+		if (dloc != NULL && dloc->file != NULL) {
+			snprintf(buf, COLS, "uftrace report: %s [line:%d]",
+				 dloc->file->name, dloc->line);
+		}
+		else {
+			struct tui_report *report = (struct tui_report *)win;
+
+			snprintf(buf, COLS, "uftrace report: %s (%d sessions, %d functions)",
+				 handle->dirname, report->nr_sess, report->nr_func);
+		}
 	}
 	buf[COLS] = '\0';
 

--- a/doc/uftrace-tui.md
+++ b/doc/uftrace-tui.md
@@ -114,7 +114,7 @@ Following keys can be used in the TUI window:
  * `Up`, `Down`:          Move cursor up/down
  * `PageUp`, `PageDown`:  Move page up/down
  * `Home`, `End`:         Move to the first/last entry
- * `Enter`:               Select.  Fold/Unfold current function (in graph mode)
+ * `Enter`:               Fold/unfold graph or Select session
  * `G`:                   Show full graph of the current session
  * `g`:                   Show backtrace and call graph of the current function
  * `R`:                   Show uftrace report

--- a/doc/uftrace-tui.md
+++ b/doc/uftrace-tui.md
@@ -118,6 +118,7 @@ Following keys can be used in the TUI window:
  * `G`:                   Show full graph of the current session
  * `g`:                   Show backtrace and call graph of the current function
  * `R`:                   Show uftrace report
+ * `r`:                   Show uftrace report of the current function
  * `I`:                   Show uftrace info
  * `S`:                   Show session list
  * `O`:                   Open editor for current function

--- a/doc/uftrace-tui.md
+++ b/doc/uftrace-tui.md
@@ -127,6 +127,7 @@ Following keys can be used in the TUI window:
  * `u`:                   Move up to parent (in graph mode)
  * `l`:                   Move to the longest executed child (in graph mode)
  * `j`/`k`:               Move cursor up/down (like vi)
+ * `z`:                   Set current line to the center of screen
  * `/`:                   Start search
  * `<`/`P`:               Search previous match
  * `>`/`N`:               Search next match

--- a/doc/uftrace.html
+++ b/doc/uftrace.html
@@ -2042,7 +2042,7 @@ class: tui
       0.630 us :  │ │ ARROW         Navigation                                     │
                :  │ │ PgUp/Dn                                                      │
       1.357 us :  │ │ Home/End                                                     │
-      0.860 us :  │ │ Enter         Select/Fold                                    │
+      0.860 us :  │ │ Enter         Fold/unfold graph or Select session            │
       0.230 us :  │ │ G             Show (full) call graph                         │
                :  │ │ g             Show call graph for this function              │
       0.153 us :  │ │ R             Show uftrace report                            │
@@ -2071,7 +2071,7 @@ class: tui
 </pre>
 ---
 class: tui
-.footnote[.red[Enter] - .red[Select]/Fold]
+.footnote[.red[Enter] - .red[Fold]/Unfold]
 <pre>
 <code class="plain">  <x-tui-blue-line>  TOTAL TIME : FUNCTION</x-tui-blue-line>
      20.914 us : (1) a.out
@@ -2113,7 +2113,7 @@ class: tui
 </pre>
 ---
 class: tui
-.footnote[.red[Enter] - Select/.red[Fold]]
+.footnote[.red[Enter] - Fold/.red[Unfold]]
 <pre>
 <code class="plain">  <x-tui-blue-line>  TOTAL TIME : FUNCTION</x-tui-blue-line>
      20.914 us : (1) a.out


### PR DESCRIPTION
This PR makes some changes on TUI as follows:

1. Set the focus on the current function when switching from graph to report window
2. Make 'R' to go to the top of report window
3. Set to the top when switched from session window
4. Cancel search when cursor moves
5. Add 'z' key to set current line to the center of screen
6. Update the description of Enter key
7. Show source location info in report footer

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>