### PR TITLE
uftrace: Remove recover trigger for simplicity

### DIFF
--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -242,7 +242,7 @@ The uftrace tool supports triggering actions on selected function calls with or 
     <trigger>    :=  <symbol> "@" <actions>
     <actions>    :=  <action>  | <action> "," <actions>
     <action>     :=  "depth="<num> | "backtrace" | "trace" | "trace_on" | "trace_off" |
-                     "recover" | "color="<color> | "time="<time_spec> | "read="<read_spec> |
+                     "color="<color> | "time="<time_spec> | "read="<read_spec> |
                      "finish" | "filter" | "notrace"
     <time_spec>  :=  <num> [ <time_unit> ]
     <time_unit>  :=  "ns" | "nsec" | "us" | "usec" | "ms" | "msec" | "s" | "sec" | "m" | "min"
@@ -266,8 +266,6 @@ The following example shows how triggers work.  The global filter maximum depth 
 The `backtrace` trigger is only meaningful in the replay command.
 
 The `traceon` and `traceoff` actions (the `_` can be omitted from `trace_on` and `trace_off`) control whether uftrace records the specified functions or not.
-
-The 'recover' trigger is for some corner cases in which the process accesses the callstack directly.  During tracing of the v8 javascript engine, for example, it kept getting segfaults in the garbage collection stage.  It was because v8 incorporates the return address into compiled code objects(?).  The `recover` trigger restores the original return address at the function entry point and resets to the uftrace return hook address again at function exit.  I was managed to work around the segfault by setting the `recover` trigger on the related function (specifically `ExitFrame::Iterate`).
 
 The 'time' trigger is to change time filter setting during execution of the function.  It can be used to apply different time filter for different functions.
 

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -237,7 +237,7 @@ The BNF for trigger specification is:
     <actions>    :=  <action>  | <action> "," <actions>
     <action>     :=  "depth="<num> | "trace" | "trace_on" | "trace_off" |
                      "time="<time_spec> | "read="<read_spec> | "finish" |
-                     "filter" | "notrace" | "recover"
+                     "filter" | "notrace"
     <time_spec>  :=  <num> [ <time_unit> ]
     <time_unit>  :=  "ns" | "us" | "ms" | "s"
     <read_spec>  :=  "proc/statm" | "page-fault" | "pmu-cycle" | "pmu-cache" |
@@ -264,15 +264,6 @@ The `backtrace` trigger is only meaningful in the replay command.
 
 The `traceon` and `traceoff` actions (the `_` can be omitted from `trace_on`
 and `trace_off`) control whether uftrace records the specified functions or not.
-
-The 'recover' trigger is for some corner cases in which the process accesses the
-callstack directly.  During tracing of the v8 javascript engine, for example, it
-kept getting segfaults in the garbage collection stage.  It was because v8
-incorporates the return address into compiled code objects(?).  The `recover`
-trigger restores the original return address at the function entry point and
-resets to the uftrace return hook address again at function exit.  I was managed
-to work around the segfault by setting the `recover` trigger on the related
-function (specifically `ExitFrame::Iterate`).
 
 The 'time' trigger is to change time filter setting during execution of the
 function.  It can be used to apply differernt time filter for different functions.

--- a/libmcount/mcount.h
+++ b/libmcount/mcount.h
@@ -30,7 +30,7 @@ enum mcount_rstack_flag {
 	MCOUNT_FL_VFORK		= (1U << 5),
 	MCOUNT_FL_WRITTEN	= (1U << 6),
 	MCOUNT_FL_DISABLED	= (1U << 7),
-	MCOUNT_FL_RECOVER	= (1U << 8),
+	MCOUNT_FL_RECOVER	= (1U << 8),	/* depreciated */
 	MCOUNT_FL_RETVAL	= (1U << 9),
 	MCOUNT_FL_TRACE		= (1U << 10),
 	MCOUNT_FL_ARGUMENT	= (1U << 11),

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -50,8 +50,6 @@ static void print_trigger(struct uftrace_trigger *tr)
 		pr_dbg("\ttrigger: trace_on\n");
 	if (tr->flags & TRIGGER_FL_TRACE_OFF)
 		pr_dbg("\ttrigger: trace_off\n");
-	if (tr->flags & TRIGGER_FL_RECOVER)
-		pr_dbg("\ttrigger: recover\n");
 	if (tr->flags & TRIGGER_FL_FINISH)
 		pr_dbg("\ttrigger: finish\n");
 
@@ -746,12 +744,6 @@ static int parse_backtrace_action(char *action, struct uftrace_trigger *tr)
 	return 0;
 }
 
-static int parse_recover_action(char *action, struct uftrace_trigger *tr)
-{
-	tr->flags |= TRIGGER_FL_RECOVER;
-	return 0;
-}
-
 static int parse_finish_action(char *action, struct uftrace_trigger *tr)
 {
 	tr->flags |= TRIGGER_FL_FINISH;
@@ -796,7 +788,6 @@ static const struct trigger_action_parser actions[] = {
 	{ "color=",    parse_color_action, },
 	{ "trace",     parse_trace_action, },
 	{ "backtrace", parse_backtrace_action, },
-	{ "recover",   parse_recover_action, },
 	{ "finish",    parse_finish_action, },
 	{ "auto-args", parse_auto_args_action, },
 };

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -24,7 +24,7 @@ enum trigger_flag {
 	TRIGGER_FL_TRACE_ON	= (1U << 4),
 	TRIGGER_FL_TRACE_OFF	= (1U << 5),
 	TRIGGER_FL_ARGUMENT	= (1U << 6),
-	TRIGGER_FL_RECOVER	= (1U << 7),
+	TRIGGER_FL_RECOVER	= (1U << 7),	/* depreciated */
 	TRIGGER_FL_RETVAL	= (1U << 8),
 	TRIGGER_FL_COLOR	= (1U << 9),
 	TRIGGER_FL_TIME_FILTER	= (1U << 10),


### PR DESCRIPTION
Since auto-recover is on by 00340e5(Merge branch 'auto-recover'),
'recover' trigger is no longer needed.

This patch removes the historic 'recover' trigger to make it simpler.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>