### PR TITLE
uftrace: Make -a option synonym for --auto-args

### DIFF
--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -43,7 +43,7 @@ OPTIONS
 -R *SPEC*, \--retval=*SPEC*
 :   Record function return value.  This option can be used more than once.  See *ARGUMENTS*.
 
-\--auto-args
+-a, \--auto-args
 :   Automatically record arguments and return values of known functions.
     These are usually functions in standard (C language or system) libraries
     but if debug info is available it includes functions in the user program.
@@ -377,7 +377,7 @@ For example, the above example can be written like below:
 Note that argument pattern (".") matches to any character so it recorded
 all (supported) functions.  It shows two arguments for "main" and a single
 string argument for "puts".  If you simply want to see all arguments and
-return values of every functions (if supported), use `--auto-args` option.
+return values of every functions (if supported), use `-a`/`--auto-args` option.
 
 
 FIELDS

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -78,7 +78,7 @@ OPTIONS
 -R *SPEC*, \--retval=*SPEC*
 :   Record function return values.  This option can be used more than once.  See *ARGUMENTS*.
 
-\--auto-args
+-a, \--auto-args
 :   Automatically record arguments and return values of known functions.
     These are usually functions in standard (C language or system) libraries
     but if debug info is available it includes functions in the user program.
@@ -391,7 +391,7 @@ For example, the above example can be written like below:
 Note that argument pattern (".") matches to any character so it recorded
 all (supported) functions.  It shows two arguments for "main" and a single
 string argument for "puts".  If you simply want to see all arguments and
-return values of every functions (if supported), use `--auto-args` option.
+return values of every functions (if supported), use `-a`/`--auto-args` option.
 
 
 DYNAMIC TRACING

--- a/uftrace.c
+++ b/uftrace.c
@@ -166,7 +166,7 @@ static struct argp_option uftrace_options[] = {
 	{ "event-full", OPT_event_full, 0, 0, "Show all events outside of function" },
 	{ "nest-libcall", OPT_nest_libcall, 0, 0, "Show nested library calls" },
 	{ "record", OPT_record, 0, 0, "Record a new trace data before running command" },
-	{ "auto-args", OPT_auto_args, 0, 0, "Show arguments and return value of known functions" },
+	{ "auto-args", 'a', 0, 0, "Show arguments and return value of known functions" },
 	{ "libname", OPT_libname, 0, 0, "Show libname name with symbol name" },
 	{ "match", OPT_match_type, "TYPE", 0, "Support pattern match: regex, glob (default: regex)" },
 	{ "no-randomize-addr", OPT_no_randomize_addr, 0, 0, "Disable ASLR (Address Space Layout Randomization)" },
@@ -456,6 +456,10 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 		opts->retval = opt_add_string(opts->retval, arg);
 		break;
 
+	case 'a':
+		opts->auto_args = true;
+		break;
+
 	case 'f':
 		opts->fields = arg;
 		break;
@@ -714,10 +718,6 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 
 	case OPT_record:
 		opts->record = true;
-		break;
-
-	case OPT_auto_args:
-		opts->auto_args = true;
 		break;
 
 	case OPT_libname:


### PR DESCRIPTION
It'd be better to provide a short option for --auto-args, so this patch
adds -g so that we can simply see arguments and return values.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>