### PR TITLE
misc: Add operator new and delete to auto-args

### DIFF
--- a/misc/gen-autoargs.py
+++ b/misc/gen-autoargs.py
@@ -262,6 +262,16 @@ if __name__ == "__main__":
     args_list = ""
     retvals_list = ""
 
+    # operator new and delete and their variations
+    args_list     = '\t\"_Znwm@arg1/u;\"\n'   \
+                  + '\t\"_Znam@arg1/u;\"\n'   \
+                  + '\t\"_ZdlPv@arg1/x;\"\n'  \
+                  + '\t\"_ZdaPv@arg1/x;\"\n'
+
+    # operator new and its variations
+    retvals_list  = '\t\"_Znwm@retval/x;\"\n' \
+                  + '\t\"_Znam@retval/x;\"\n'
+
     t = DECL_TYPE_NONE
     with open(prototype_file) as fin:
         for line in fin:

--- a/utils/auto-args.c
+++ b/utils/auto-args.c
@@ -102,7 +102,8 @@ static void build_auto_args(const char *args_str, struct rb_root *root,
 		 * it should be copied after setup_trigger_action() removed
 		 * '@' for the arg spec
 		 */
-		entry.name = xstrdup(name);
+		entry.name = demangle(name);
+
 		add_auto_args(root, &entry, &tr);
 
 next:

--- a/utils/auto-args.h
+++ b/utils/auto-args.h
@@ -22,6 +22,10 @@ static char *auto_enum_list =
 ;
 
 static char *auto_args_list =
+	"_Znwm@arg1/u;"
+	"_Znam@arg1/u;"
+	"_ZdlPv@arg1/x;"
+	"_ZdaPv@arg1/x;"
 	"malloc@arg1/u;"
 	"free@arg1/x;"
 	"calloc@arg1/u,arg2/u;"
@@ -158,6 +162,8 @@ static char *auto_args_list =
 ;
 
 static char *auto_retvals_list =
+	"_Znwm@retval/x;"
+	"_Znam@retval/x;"
 	"malloc@retval/x;"
 	"calloc@retval/x;"
 	"realloc@retval/x;"


### PR DESCRIPTION
operator new and operator delete are widely used in C++ programs so it'd
be better to add them to auto-args list.

operator new and delete has various prototypes including nothrow and
placement versions, but we only handles the basic forms.  For more
prototypes, '/usr/include/c++/5/new' file can be referenced.

This patch adds them to misc/prototypes.h and fixes misc/gen-autoargs.py
to handle them.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>