### PR TITLE
build: Display feature detect result of configure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ $(filter-out $(objdir)/uftrace.o,$(UFTRACE_OBJS)): $(objdir)/%.o: $(srcdir)/%.c 
 	$(QUIET_CC)$(CC) $(UFTRACE_CFLAGS) -c -o $@ $<
 
 $(objdir)/version.h: PHONY
-	@$(srcdir)/misc/version.sh $@ $(VERSION_GIT)
+	@$(srcdir)/misc/version.sh $@ $(VERSION_GIT) $(srcdir)
 
 $(srcdir)/utils/auto-args.h: $(srcdir)/misc/prototypes.h $(srcdir)/misc/gen-autoargs.py
 	$(QUIET_GEN)$(srcdir)/misc/gen-autoargs.py -i $< -o $@

--- a/configure
+++ b/configure
@@ -138,6 +138,38 @@ for dep in $IGNORE; do
     fi
 done
 
+echo "uftrace detected system features:"
+
+print_feature()
+{
+    item=$1
+    file=$2
+    description=$3
+
+    if [ -t 1 ]; then
+        # use colored output only when stdout is tty
+        if [ -f ${srcdir}/check-deps/${file} ]; then
+            onoff="\033[32mon \033[0m"
+        else
+            onoff="\033[91mOFF\033[0m"
+        fi
+    else
+        if [ -f ${srcdir}/check-deps/${file} ]; then
+            onoff="on "
+        else
+            onoff="OFF"
+        fi
+    fi
+    printf "...%15s: [ ${onoff} ] - %s\n" "${item}" "${description}"
+}
+
+printf "...%15s: %s\n" "prefix" "${prefix}"
+print_feature "libelf" "have_libelf" "more flexible ELF data handling"
+print_feature "libdw" "have_libdw" "DWARF debug info support"
+print_feature "libpython2.7" "have_libpython2.7" "python scripting support"
+print_feature "libncursesw" "have_libncurses" "TUI support"
+print_feature "cxa_demangle" "cxa_demangle" "full demangler support with libstdc++"
+
 cat >$output <<EOF
 # this file is generated automatically
 override prefix := $prefix

--- a/misc/version.sh
+++ b/misc/version.sh
@@ -2,14 +2,16 @@
 
 VERSION_FILE=$1
 
-if [ $# -ne 2 ]; then
-    echo "Usage: $0 <filename> <version>"
+if [ $# -ne 3 ]; then
+    echo "Usage: $0 <filename> <version> <srcdir>"
     exit 1
 fi
 
 CURR_VERSION=$2
 FILE_VERSION=
 GIT_VERSION=
+
+SRCDIR=$3
 
 if test -f ${VERSION_FILE}; then
     FILE_VERSION=$(cat ${VERSION_FILE} 2>/dev/null | cut -d'"' -f2)
@@ -26,9 +28,23 @@ if test -z "${GIT_VERSION}" -a -n "${FILE_VERSION}"; then
     exit 0
 fi
 
+DEPS=""
+if test -f ${SRCDIR}/check-deps/have_libdw; then
+    DEPS="${DEPS} dwarf"
+fi
+if test -f ${SRCDIR}/check-deps/have_libpython2.7; then
+    DEPS="${DEPS} python"
+fi
+if test -f ${SRCDIR}/check-deps/have_libncurses; then
+    DEPS="${DEPS} tui"
+fi
+if [ "x${DEPS}" != "x" ]; then
+    DEPS=" (${DEPS} )"
+fi
+
 if test -z "${FILE_VERSION}" -o "${CURR_VERSION}" != "${FILE_VERSION}"; then
     # update file version only if it's different
-    echo "#define UFTRACE_VERSION  \"${CURR_VERSION}\"" > ${VERSION_FILE}
+    echo "#define UFTRACE_VERSION  \"${CURR_VERSION}${DEPS}\"" > ${VERSION_FILE}
     echo "  GEN     " ${VERSION_FILE#${objdir}/}
     exit 0
 fi


### PR DESCRIPTION
It'd be better to display the result of feature detect when running
configure script.
```
  $ ./configure --prefix=$HOME/usr --without-libdw
  uftrace detected system features:
  ...                        prefix: /home/honggyu/usr
  ...                        libelf: [ on  ]
  ...                         libdw: [ OFF ]
  ...                  libpython2.7: [ on  ]
  ...                   libncursesw: [ on  ]
  ...                  cxa_demangle: [ on  ]
```
It shows the outlook almost same as Linux perf tool.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>