### PR TITLE
test: update tests that relate with dlopen

### DIFF
--- a/tests/s-dlopen.c
+++ b/tests/s-dlopen.c
@@ -11,12 +11,20 @@ int main(int argc, char *argv[])
 	if (argc > 1)
 		n = atoi(argv[1]);
 
-	handle = dlopen("libabc_test_lib.so", RTLD_LAZY);
+	handle = dlopen("./libabc_test_lib.so", RTLD_LAZY);
+
+	if (!handle)
+		return -1;
+
 	sym = dlsym(handle, "lib_a");
 	sym(n);
 	dlclose(handle);
 
-	handle = dlopen("libfoo.so", RTLD_LAZY);
+	handle = dlopen("./libfoo.so", RTLD_LAZY);
+
+	if (!handle)
+		return -1;
+
 	sym = dlsym(handle, "foo");
 	sym(n);
 	dlclose(handle);

--- a/tests/s-dlopen2.cpp
+++ b/tests/s-dlopen2.cpp
@@ -18,7 +18,11 @@ int main(int argc, char *argv[])
 	if (argc > 1)
 		n = atoi(argv[1]);
 
-	handle = dlopen("libbaz.so", RTLD_LAZY);
+	handle = dlopen("./libbaz.so", RTLD_LAZY);
+
+	if (!handle)
+		return -1;
+
 	creat = (Parent* (*)())dlsym(handle, "creat");
 	p = creat();
 	p->bar(n);

--- a/tests/t200_lib_dlopen2.py
+++ b/tests/t200_lib_dlopen2.py
@@ -28,3 +28,6 @@ class TestCase(TestBase):
             return TestBase.TEST_BUILD_FAIL
         return TestBase.build_libmain(self, name, 's-dlopen2.cpp', ['libdl.so'],
                                       cflags, ldflags)
+
+    def runcmd(self):
+        return 'LD_LIBRARY_PATH=. %s -F a %s' % (TestBase.uftrace_cmd, 't-dlopen2')


### PR DESCRIPTION
recently loader does not allow load shared object from unspecified path.
therefore, when load shared object by using dlopen then must specify the
path where to load shared object.

Fixed: #437

Signed-off-by: Hanbum Park <kese111@gmail.com>