### PR TITLE
doc: Prefer relative link than absolute link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The `dump` command shows raw output of each trace record.  You can see the resul
 in the chrome browser, once the data is processed with `uftrace dump --chrome`.
 Below is a trace of clang (LLVM) compiling a small C++ template metaprogram.
 
-![uftrace-chrome-dump](https://github.com/namhyung/uftrace/blob/master/doc/uftrace-chrome.png)
+![uftrace-chrome-dump](doc/uftrace-chrome.png)
 
 The `info` command shows system and program information when recorded.
 
@@ -240,7 +240,7 @@ installed like following:
     $ sudo make install
 
 For more advanced setup, please refer
-[INSTALL.md](https://github.com/namhyung/uftrace/blob/master/INSTALL.md) file.
+[INSTALL.md](INSTALL.md) file.
 
 
 Limitations


### PR DESCRIPTION
Currently, some links in README.md point things that are in 'master' branch of 'upstream' repository.
But, these links couldn't work as expected in different branch or forked repository.
So, I think that using relative link than absolute link is better.

Related Material: https://help.github.com/articles/about-readmes/#relative-links-and-image-paths-in-readme-files

Signed-off-by: Taeguk Kwon <xornrbboy@gmail.com>