### PR TITLE
script: Add missing argument in 'uftrace_begin'

### DIFF
--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -476,7 +476,7 @@ The uftrace tool supports script execution for each function entry and exit.  Th
 The user can write four functions. 'uftrace_entry' and 'uftrace_exit' are executed whenever each function is executed at the entry and exit.  However 'uftrace_begin' and 'uftrace_end' are only executed once when the target program begins and ends.
 
     $ cat scripts/simple.py
-    def uftrace_begin():
+    def uftrace_begin(ctx):
         print("program begins...")
 
     def uftrace_entry(ctx):

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -462,7 +462,7 @@ The uftrace tool supports script execution for each function entry and exit.  Th
 The user can write four functions. 'uftrace_entry' and 'uftrace_exit' are executed whenever each function is executed at the entry and exit.  However 'uftrace_begin' and 'uftrace_end' are only executed once when the target program begins and ends.
 
     $ cat scripts/simple.py
-    def uftrace_begin():
+    def uftrace_begin(ctx):
         print("program begins...")
 
     def uftrace_entry(ctx):

--- a/doc/uftrace-script.md
+++ b/doc/uftrace-script.md
@@ -57,7 +57,7 @@ The uftrace tool supports script execution for each function entry and exit.  Th
 The user can write four functions. 'uftrace_entry' and 'uftrace_exit' are executed whenever each function is executed at the entry and exit.  However 'uftrace_begin' and 'uftrace_end' are only executed once when the target program begins and ends.
 
     $ cat scripts/simple.py
-    def uftrace_begin():
+    def uftrace_begin(ctx):
         print("program begins...")
 
     def uftrace_entry(ctx):

--- a/scripts/count.py
+++ b/scripts/count.py
@@ -1,6 +1,6 @@
 count = 0
 
-def uftrace_begin():
+def uftrace_begin(args):
     pass
 
 def uftrace_entry(args):

--- a/scripts/replay.py
+++ b/scripts/replay.py
@@ -1,4 +1,4 @@
-def uftrace_begin():
+def uftrace_begin(ctx):
     print("# DURATION     TID     FUNCTION")
 
 def uftrace_entry(ctx):

--- a/scripts/report-libcall.py
+++ b/scripts/report-libcall.py
@@ -8,7 +8,7 @@ import os
 
 libcall_map = {}
 
-def uftrace_begin():
+def uftrace_begin(ctx):
     pass
 
 def uftrace_entry(ctx):

--- a/scripts/simple.py
+++ b/scripts/simple.py
@@ -1,4 +1,4 @@
-def uftrace_begin():
+def uftrace_begin(ctx):
     print("program begins...")
 
 def uftrace_entry(ctx):

--- a/scripts/trace-memcpy.py
+++ b/scripts/trace-memcpy.py
@@ -12,7 +12,7 @@ UFTRACE_FUNC = [ "memcpy" ]
 count = 0
 total_bytes = 0
 
-def uftrace_begin():
+def uftrace_begin(ctx):
     pass
 
 def uftrace_entry(ctx):


### PR DESCRIPTION
https://github.com/namhyung/uftrace/blob/419e65024ad19ac85d120f30123802be694a0967/utils/script-python.c#L508
As you can see above, ```uftrace_begin``` requires one argument.
But there are no arguments in ```uftrace_begin``` of some scripts and documents.
So, I add missing argument in 'uftrace_begin'.

Signed-off-by: Taeguk Kwon <xornrbboy@gmail.com>