### PR TITLE
Fix memory leak in Multiple functions

### DIFF
--- a/misc/symbols.c
+++ b/misc/symbols.c
@@ -159,6 +159,7 @@ static int read_session(struct uftrace_session_link *link, char *dirname)
 	if (count > 1)
 		needs_session = true;
 
+	free(line);
 	fclose(fp);
 	free(fname);
 	return 0;

--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -192,6 +192,7 @@ int read_task_txt_file(struct uftrace_session_link *sess, char *dirname,
 		}
 	}
 
+	free(line);
 	fclose(fp);
 	free(fname);
 	return 0;
@@ -245,6 +246,7 @@ int read_events_file(struct ftrace_file_handle *handle)
 		}
 	}
 
+	free(line);
 	fclose(fp);
 	free(fname);
 	return 0;

--- a/utils/dwarf.c
+++ b/utils/dwarf.c
@@ -1368,6 +1368,7 @@ out:
 		free_debug_entry(&dinfo->rets);
 	}
 
+	free(line);
 	fclose(fp);
 	free(pathname);
 	free(func);


### PR DESCRIPTION
Hello,

The memory allocated by getline() is not freed.

So, It should free the allocated memory.

Associated issue : #441

Thanks.