### PR TITLE
build: Check if 'pkg-config' is installed when performing 'make' for check-deps

### DIFF
--- a/check-deps/Makefile
+++ b/check-deps/Makefile
@@ -29,9 +29,14 @@ CFLAGS_cc_has_wstringop_truncation = -Wno-stringop-truncation
 CFLAGS_have_libdw  = $(shell pkg-config --cflags libdw 2> /dev/null)
 LDFLAGS_have_libdw = $(shell pkg-config --libs   libdw 2> /dev/null || echo "-ldw")
 
+HAVE_pkg-config := $(shell command -v pkg-config 2> /dev/null)
+
 check-build: check-tstamp $(CHECK_LIST)
 
 $(CHECK_LIST): %: __%.c
+ifndef HAVE_pkg-config
+	$(error "pkg-config is not available. please install pkg-config")
+endif
 	@$(CC) $(CHECK_CFLAGS) -o $@ $< $(CHECK_LDFLAGS) > /dev/null 2>&1
 
 check-tstamp: PHONY

--- a/configure
+++ b/configure
@@ -121,7 +121,7 @@ MAKEOVERRIDES=
 export CC CFLAGS LD LDFLAGS
 
 make -siC ${srcdir}/check-deps check-clean
-make -siC ${srcdir}/check-deps check-build
+make -siC ${srcdir}/check-deps check-build || exit 1
 
 for dep in $IGNORE; do
     TARGET=


### PR DESCRIPTION
If ```pkg-config``` is not installed in a system and performing ```make``` for check-deps, the ```make``` command runs with no errors but it couldn't run as expected.
So, add check if 'pkg-config' is installed in a system to the build target related to check-deps.

### before
```./configure``` runs with no errors, but it doesn't run as expected. (Expected Result : ON for libncursesw)
![image](https://user-images.githubusercontent.com/9107889/44407220-83d22700-a598-11e8-9141-34de411675ff.png)

### after
If 'pkg-config' is not installed in a system, the ```./configure``` and ```make``` fail with the message "pkg-config is not available. please install pkg-config".
![image](https://user-images.githubusercontent.com/9107889/44407450-183c8980-a599-11e8-984c-b32a1961114a.png)


Signed-off-by: Taeguk Kwon <xornrbboy@gmail.com>