### PR TITLE
record: Remove dead code in save_session_symbols()

### DIFF
--- a/cmds/record.c
+++ b/cmds/record.c
@@ -1362,10 +1362,9 @@ static void save_session_symbols(struct opts *opts)
 			.dirname  = opts->dirname,
 			.flags    = SYMTAB_FL_ADJ_OFFSET,
 		};
-		char sid[20] = { 0, };
+		char sid[20];
 
-		if (sid[0] == '\0')
-			sscanf(map_list[i]->d_name, "sid-%[^.].map", sid);
+		sscanf(map_list[i]->d_name, "sid-%[^.].map", sid);
 		free(map_list[i]);
 
 		pr_dbg2("reading symbols for session %s\n", sid);


### PR DESCRIPTION
A part of conditional expression is always true.
So, Remove dead Conditional expression code.

#442

Signed-off-by: GwanYeong Kim <gy741.kim@gmail.com>

Reference: https://cwe.mitre.org/data/definitions/571.html
                https://wiki.sei.cmu.edu/confluence/display/c/MSC07-C.+Detect+and+remove+dead+code