### PR TITLE
uftrace: Fix a typo in comment

### DIFF
--- a/cmds/report.c
+++ b/cmds/report.c
@@ -556,7 +556,7 @@ static int cmp_diff_entry(struct trace_entry *a, struct trace_entry *b,
 		entry_b = b;
 		break;
 	default:
-		/* this should not happend */
+		/* this should not happen */
 		assert(0);
 		break;
 	}

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -133,7 +133,7 @@ OPTIONS
 :   Retain same pid for traced program.  For some daemon processes, it is important to have same pid when forked.  Running under uftrace normally changes pid as it calls fork() again internally.  Note that it might corrupt terminal setting so it'd be better using it with `--no-pager` option.
 
 -S *SCRIPT_PATH*, \--script=*SCRIPT_PATH*
-:   Add a script to do addtional work at the entry and exit of function.  The type of script is detected by the postfix such as '.py' for python.
+:   Add a script to do additional work at the entry and exit of function.  The type of script is detected by the postfix such as '.py' for python.
 
 \--event-full
 :   Show all (user) events outside of user functions.

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -108,7 +108,7 @@ OPTIONS
 :   Retain same pid for traced program.  For some daemon processes, it is important to have same pid when forked.  Running under uftrace normally changes pid as it calls fork() again internally.
 
 -S *SCRIPT_PATH*, \--script=*SCRIPT_PATH*
-:   Add a script to do addtional work at the entry and exit of function.  The type of script is detected by the postfix such as '.py' for python.
+:   Add a script to do additional work at the entry and exit of function.  The type of script is detected by the postfix such as '.py' for python.
 
 --match=*TYPE*
 :   Use pattern match using TYPE.  Possible types are `regex` and `glob`.  Default is `regex`.

--- a/doc/uftrace-script.md
+++ b/doc/uftrace-script.md
@@ -41,7 +41,7 @@ OPTIONS
 :   Only show functions executed within the time RANGE.  The RANGE can be \<start\>~\<stop\> (separated by "~") and one of \<start\> and \<stop\> can be omitted.  The \<start\> and \<stop\> are timestamp or elapsed time if they have \<time_unit\> postfix, for example '100us'.  The timestamp or elapsed time can be shown with `-f time` or `-f elapsed` option respectively.
 
 -S *SCRIPT_PATH*, \--script=*SCRIPT_PATH*
-:   Add a script to do addtional work at the entry and exit of function.  The type of script is detected by the postfix such as '.py' for python.
+:   Add a script to do additional work at the entry and exit of function.  The type of script is detected by the postfix such as '.py' for python.
 
 \--record COMMAND [*command-options*]
 :   Record a new trace before running a given script.

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -715,7 +715,7 @@ unsigned long plthook_entry(unsigned long *ret_addr, unsigned long child_idx,
 	unsigned long special_flag = 0;
 	unsigned long real_addr = 0;
 
-	// if neccesary, implement it by architecture.
+	// if necessary, implement it by architecture.
 	child_idx = mcount_arch_child_idx(child_idx);
 	list_for_each_entry(pd, &plthook_modules, list) {
 		if (module_id == pd->module_id)

--- a/libtraceevent/event-parse.c
+++ b/libtraceevent/event-parse.c
@@ -5706,7 +5706,7 @@ int pevent_register_print_function(struct pevent *pevent,
  *
  * This function removes existing print handler for function @name.
  *
- * Returns 0 if the handler was removed successully, -1 otherwise.
+ * Returns 0 if the handler was removed successfully, -1 otherwise.
  */
 int pevent_unregister_print_function(struct pevent *pevent,
 				     pevent_func_handler func, char *name)


### PR DESCRIPTION
Hello.

I corrected the typos.

Thanks.

Changes:
```
/libmcount/plthook.c:718: neccesary -> "necessary"
/libtraceevent/event-parse.c:5709: successully -> "successfully"
/doc/uftrace-script.md:44: addtional -> "additional"
/doc/uftrace-record.md:111: addtional -> "additional"
/doc/uftrace-live.md:136: addtional -> "additional"
/cmds/report.c:559: happend -> "happened"
```

Signed-off-by: GwanYeong Kim <gy741.kim@gmail.com>