### PR TITLE
chrome: Properly escape non-ascii characters

### DIFF
--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -564,10 +564,24 @@ void get_argspec_string(struct ftrace_task_handle *task,
 
 			if (!memcmp(str, &null_str, sizeof(null_str)))
 				print_args("NULL");
-			else if (needs_escape)
-				/* quotation mark has to be escaped by backslash
-				   in chrome trace json format */
-				print_args("\\\"%.*s\\\"", slen + newline, str);
+			else if (needs_escape) {
+				char *p = str;
+				print_args("\\\"");
+				while (*p) {
+					char c = *p++;
+					if (c == '\n')
+						print_args("\\\\n");
+					else if (c == '\t')
+						print_args("\\\\t");
+					else if (c == '"')
+						print_args("\\\"");
+					else if (isprint(c))
+						print_args("%c", c);
+					else
+						print_args("\\\\x%02hhx", c);
+				}
+				print_args("\\\"");
+			}
 			else
 				print_args("\"%.*s\"", slen + newline, str);
 


### PR DESCRIPTION
This patch fixes an error while loading chrome trace viewer.  It's
because it doesn't allow to contain non-ascii characters inside json
format.

Fixed: #425

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>