### PR TITLE
doc: Add task and module fields to replay man page

### DIFF
--- a/doc/uftrace-replay.md
+++ b/doc/uftrace-replay.md
@@ -41,7 +41,7 @@ OPTIONS
 :   Set trace limit in nesting level.
 
 -f *FIELD*, \--output-fields=*FIELD*
-:   Customize field in the output.  Possible values are: duration, tid, time, delta, elapsed and addr.  Multiple fields can be set by using comma.  Special field of 'none' can be used (solely) to hide all fields.  Default is 'duration,tid'.  See *FIELDS*.
+:   Customize field in the output.  Possible values are: duration, tid, addr, time, delta, elapsed, task and module.  Multiple fields can be set by using comma.  Special field of 'none' can be used (solely) to hide all fields.  Default is 'duration,tid'.  See *FIELDS*.
 
 -r *RANGE*, \--time-range=*RANGE*
 :   Only show functions executed within the time RANGE.  The RANGE can be \<start\>~\<stop\> (separated by "~") and one of \<start\> and \<stop\> can be omitted.  The \<start\> and \<stop\> are timestamp or elapsed time if they have \<time_unit\> postfix, for example '100us'.  The timestamp or elapsed time can be shown with `-f time` or `-f elapsed` option respectively.


### PR DESCRIPTION
Since -f FIELD/--output-fields=FIELD option now supports to show
task-name with 'task' and module-name with 'module', so this adds them
to the man page of replay.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>