### PR TITLE
uftrace: Fix memory leaks and improve memory safety.

### DIFF
--- a/cmds/info.c
+++ b/cmds/info.c
@@ -498,6 +498,7 @@ static int fill_taskinfo(void *arg)
 	}
 	dprintf(fha->fd, "\n");
 
+	delete_sessions(&link);
 	free(tlist.tid);
 	return 0;
 }

--- a/utils/dwarf.c
+++ b/utils/dwarf.c
@@ -1147,7 +1147,10 @@ void finish_debug_info(struct symtabs *symtabs)
 
 	map = symtabs->maps;
 	while (map) {
-		release_debug_info(&map->dinfo);
+		if (strcmp(map->libname, symtabs->filename) &&
+		    strncmp(basename(map->libname), "libmcount", 9))
+			release_debug_info(&map->dinfo);
+
 		map = map->next;
 	}
 

--- a/utils/dwarf.c
+++ b/utils/dwarf.c
@@ -250,22 +250,11 @@ static int setup_dwarf_info(const char *filename, struct debug_info *dinfo,
 
 static void release_dwarf_info(struct debug_info *dinfo)
 {
-	struct debug_file *df, *tmp;
-
 	if (dinfo->dw == NULL)
 		return;
 
 	dwarf_end(dinfo->dw);
 	dinfo->dw = NULL;
-
-	list_for_each_entry_safe(df, tmp, &dinfo->files, list) {
-		list_del(&df->list);
-		free(df->name);
-		free(df);
-	}
-
-	free(dinfo->locs);
-	dinfo->locs = NULL;
 }
 
 struct type_data {
@@ -1042,9 +1031,20 @@ static int setup_debug_info(const char *filename, struct debug_info *dinfo,
 
 static void release_debug_info(struct debug_info *dinfo)
 {
+	struct debug_file *df, *tmp;
+
 	free_debug_entry(&dinfo->args);
 	free_debug_entry(&dinfo->rets);
 	release_enum_def(&dinfo->enums);
+
+	free(dinfo->locs);
+	dinfo->locs = NULL;
+
+	list_for_each_entry_safe(df, tmp, &dinfo->files, list) {
+		list_del(&df->list);
+		free(df->name);
+		free(df);
+	}
 
 	release_dwarf_info(dinfo);
 }

--- a/utils/session.c
+++ b/utils/session.c
@@ -339,6 +339,7 @@ void delete_session(struct uftrace_session *sess)
 		free(udl);
 	}
 
+	finish_debug_info(&sess->symtabs);
 	unload_symtabs(&sess->symtabs);
 	delete_session_map(&sess->symtabs);
 	free(sess);

--- a/utils/session.c
+++ b/utils/session.c
@@ -342,6 +342,8 @@ void delete_session(struct uftrace_session *sess)
 	finish_debug_info(&sess->symtabs);
 	unload_symtabs(&sess->symtabs);
 	delete_session_map(&sess->symtabs);
+	uftrace_cleanup_filter(&sess->filters);
+	uftrace_cleanup_filter(&sess->fixups);
 	free(sess);
 }
 

--- a/utils/session.c
+++ b/utils/session.c
@@ -99,6 +99,7 @@ void delete_session_map(struct symtabs *symtabs)
 	map = symtabs->maps;
 	while (map) {
 		tmp = map->next;
+		unload_symtab(&map->symtab);
 		free(map);
 		map = tmp;
 	}

--- a/utils/session.c
+++ b/utils/session.c
@@ -487,8 +487,10 @@ void create_task(struct uftrace_session_link *sessions,
 			t->tid, sizeof(t->comm), s ? t->comm : "unknown",
 			s ? s->sid : "unknown");
 	}
-	else
+	else {
+		memset(&t->sref, 0, sizeof(t->sref));
 		pr_dbg2("new task: tid = %d\n", t->tid);
+	}
 
 	rb_link_node(&t->node, parent, p);
 	rb_insert_color(&t->node, &sessions->tasks);

--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -133,7 +133,7 @@ int check_static_binary(const char *filename)
 	return ret;
 }
 
-static void __unload_symtab(struct symtab *symtab)
+void unload_symtab(struct symtab *symtab)
 {
 	size_t i;
 
@@ -153,8 +153,8 @@ static void __unload_symtab(struct symtab *symtab)
 void unload_symtabs(struct symtabs *symtabs)
 {
 	pr_dbg2("unload symbol tables\n");
-	__unload_symtab(&symtabs->symtab);
-	__unload_symtab(&symtabs->dsymtab);
+	unload_symtab(&symtabs->symtab);
+	unload_symtab(&symtabs->dsymtab);
 
 	symtabs->loaded = false;
 }
@@ -464,7 +464,7 @@ static int try_load_dynsymtab_bindnow(struct symtab *dsymtab,
 
 	if (arch_load_dynsymtab_bindnow(dsymtab, elf, offset, flags) < 0) {
 		pr_dbg("cannot load dynamic symbols for bind-now\n");
-		__unload_symtab(dsymtab);
+		unload_symtab(dsymtab);
 		return -1;
 	}
 

--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -626,6 +626,7 @@ static void merge_symtabs(struct symtab *left, struct symtab *right)
 		*left = *right;
 		right->nr_sym = 0;
 		right->sym = NULL;
+		right->sym_names = NULL;
 		return;
 	}
 

--- a/utils/symbol.h
+++ b/utils/symbol.h
@@ -109,6 +109,7 @@ struct sym * find_sym(struct symtab *symtab, uint64_t addr);
 struct sym * find_symname(struct symtab *symtab, const char *name);
 void load_symtabs(struct symtabs *symtabs, const char *dirname,
 		  const char *filename);
+void unload_symtab(struct symtab *symtab);
 void unload_symtabs(struct symtabs *symtabs);
 void print_symtabs(struct symtabs *symtabs);
 


### PR DESCRIPTION
With `valgrind`, I found some memory leaks and unsafe codes. And I fixed them.

I used the command: `valgrind --leak-check=full --show-leak-kinds=all --error-limit=no --track-origins=yes uftrace vector.out`
And `vector.out` is created from the simple source code:
```cpp
#include <vector>
int main() {
    std::vector<int> vec;
    vec.push_back(12);
}
```

I want your reviews because I'm still not familiar and not well-understanding to the codebase.

Signed-off-by: Taeguk Kwon <xornrbboy@gmail.com>