### PR TITLE
mcount: Remove dead code in is_arm_machine()

### DIFF
--- a/utils/filter.c
+++ b/utils/filter.c
@@ -384,13 +384,10 @@ const char * get_filter_pattern(enum uftrace_pattern_type ptype)
 static bool is_arm_machine(void)
 {
 	static char *mach = NULL;
+	struct utsname utsbuf;
 
-	if (mach == NULL) {
-		struct utsname utsbuf;
-
-		uname(&utsbuf);
-		mach = xstrdup(utsbuf.machine);
-	}
+	uname(&utsbuf);
+	mach = xstrdup(utsbuf.machine);
 
 	return mach[0] == 'a' && mach[1] == 'r' && mach[2] == 'm';
 }


### PR DESCRIPTION
Hello.

I think, the if conditional statement in utils/filter.c on line 388 is useless.

The if conditional statement is always true.

So, Remove dead Conditional expression code.

what do you think?

Thanks.

problem code:
https://github.com/namhyung/uftrace/blob/fc9ba76fcde0121af1fcc59307ca7ac13db2a69a/utils/filter.c#L384-L396

Signed-off-by: GwanYeong Kim <gy741.kim@gmail.com>