### PR TITLE
fstack: Remove invalid logic in __read_rstack()

### DIFF
--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -1906,7 +1906,6 @@ static int __read_rstack(struct ftrace_file_handle *handle,
 
 	if (has_perf_data(handle)) {
 		p = read_perf_data(handle);
-		perf = &handle->perf[p];
 
 		if (p < 0) {
 			static bool warn = false;
@@ -1916,7 +1915,10 @@ static int __read_rstack(struct ftrace_file_handle *handle,
 				warn = true;
 			}
 		}
-		else if (perf->time < min_timestamp) {
+
+		perf = &handle->perf[p];
+
+		if (perf->time < min_timestamp) {
 			min_timestamp = perf->time;
 			source = PERF;
 		}


### PR DESCRIPTION
Hello.

I think, incorrectly validates input that can affect the control flow or data flow of a program. 

In line 1909 the variable is used before checking.

So, I modified the logic.

what do you think?

Thanks.

problem code:
https://github.com/namhyung/uftrace/blob/55cef9f69f6e76ded39dac8e8d541c524e899b69/utils/fstack.c#L1907-L1923