### PR TITLE
plthook: Remove dead code in update_pltgot()

### DIFF
--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -681,11 +681,9 @@ static void update_pltgot(struct mcount_thread_data *mtdp,
 
 		pthread_mutex_lock(&resolver_mutex);
 #endif
-		if (!pd->resolved_addr[dyn_idx]) {
-			plthook_addr = mcount_arch_plthook_addr(pd, dyn_idx);
-			setup_pltgot(pd, 3 + dyn_idx, dyn_idx,
-				     (void *)plthook_addr);
-		}
+		plthook_addr = mcount_arch_plthook_addr(pd, dyn_idx);
+		setup_pltgot(pd, 3 + dyn_idx, dyn_idx,
+			     (void *)plthook_addr);
 
 #ifndef SINGLE_THREAD
 		pthread_mutex_unlock(&resolver_mutex);


### PR DESCRIPTION
Hello.

I think, the if conditional statement in line 684 is useless.

The if conditional statement is always true.

So, Remove dead Conditional expression code.

what do you think?

Thanks.

problem code:
https://github.com/namhyung/uftrace/blob/919dce7471951b39830b692042397e082fbe3aaa/libmcount/plthook.c#L677-L694