### PR TITLE
uftrace: Fix format string mismatch

### DIFF
--- a/cmds/info.c
+++ b/cmds/info.c
@@ -259,8 +259,8 @@ static int read_cmdline(void *arg)
 static int fill_cpuinfo(void *arg)
 {
 	struct fill_handler_arg *fha = arg;
-	long nr_possible;
-	long nr_online;
+	unsigned long nr_possible;
+	unsigned long nr_online;
 
 	nr_possible = sysconf(_SC_NPROCESSORS_CONF);
 	nr_online = sysconf(_SC_NPROCESSORS_ONLN);

--- a/misc/symbols.c
+++ b/misc/symbols.c
@@ -80,7 +80,7 @@ static int read_session(struct uftrace_session_link *link, char *dirname)
 	char *fname = NULL;
 	char *line = NULL;
 	size_t sz = 0;
-	long sec, nsec;
+	unsigned long sec, nsec;
 	struct uftrace_msg_task tmsg;
 	struct uftrace_msg_sess smsg;
 	struct uftrace_msg_dlopen dlop;

--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -111,7 +111,7 @@ int read_task_txt_file(struct uftrace_session_link *sess, char *dirname,
 	char *fname = NULL;
 	char *line = NULL;
 	size_t sz = 0;
-	long sec, nsec;
+	unsigned long sec, nsec;
 	struct uftrace_msg_task tmsg;
 	struct uftrace_msg_sess smsg;
 	struct uftrace_msg_dlopen dlop;

--- a/utils/symbol-rawelf.c
+++ b/utils/symbol-rawelf.c
@@ -20,7 +20,7 @@ int elf_validate(struct uftrace_elf_data *elf)
 {
 	Elf_Ehdr *ehdr;
 	int eclass, data, version;
-	long size, offset;
+	unsigned long size, offset;
 
 	ehdr = &elf->ehdr;
 	elf->has_shdr = false;


### PR DESCRIPTION
Hello.

In my opinion, The format string is mismatched.

"%lu" is the correct format for unsigned long.

So, I changed the variables to unsigned long data types.

what do you think?

Thanks.