### PR TITLE
test: Fix Reimport issue and unused python modules

### DIFF
--- a/gdb/uftrace/mcount.py
+++ b/gdb/uftrace/mcount.py
@@ -12,7 +12,6 @@
 #
 
 import gdb
-import os
 from uftrace import utils
 from uftrace import rbtree
 from uftrace import trigger

--- a/misc/gen-autoargs.py
+++ b/misc/gen-autoargs.py
@@ -9,7 +9,6 @@
 #
 
 from __future__ import print_function
-import os
 import sys
 import re
 

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -242,7 +242,6 @@ class TestBase:
     def dump_sort(self, output, ignored):
         """ This function post-processes output of the test to be compared .
             It ignores blank and comment (#) lines and remaining functions.  """
-        import re
 
         # A (raw) dump result consists of following data
         # <timestamp> <tid>: [<type>] <func>(<addr>) depth: <N>

--- a/tests/t003_thread.py
+++ b/tests/t003_thread.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import re
 from runtest import TestBase
 
 class TestCase(TestBase):

--- a/tests/t049_column_view.py
+++ b/tests/t049_column_view.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import re
 from runtest import TestBase
 
 class TestCase(TestBase):

--- a/tests/t050_no_pltbind.py
+++ b/tests/t050_no_pltbind.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import re
 from runtest import TestBase
 
 class TestCase(TestBase):

--- a/tests/t051_return.py
+++ b/tests/t051_return.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import re
 from runtest import TestBase
 
 class TestCase(TestBase):

--- a/tests/t052_nested_func.py
+++ b/tests/t052_nested_func.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import re
 from runtest import TestBase
 
 class TestCase(TestBase):

--- a/tests/t053_filter_time.py
+++ b/tests/t053_filter_time.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import re
 from runtest import TestBase
 
 class TestCase(TestBase):

--- a/tests/t055_filter_time_N.py
+++ b/tests/t055_filter_time_N.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import re
 from runtest import TestBase
 
 class TestCase(TestBase):

--- a/tests/t056_filter_time_T.py
+++ b/tests/t056_filter_time_T.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import re
 from runtest import TestBase
 
 class TestCase(TestBase):

--- a/tests/t057_filter_time_D.py
+++ b/tests/t057_filter_time_D.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import re
 from runtest import TestBase
 
 class TestCase(TestBase):

--- a/tests/t064_trigger_trace.py
+++ b/tests/t064_trigger_trace.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import re
 from runtest import TestBase
 
 class TestCase(TestBase):

--- a/tests/t084_arg_mixed.py
+++ b/tests/t084_arg_mixed.py
@@ -30,7 +30,6 @@ class TestCase(TestBase):
         argopt += '-A "mixed_div@arg1/i64,fparg1/80%stack+1" -R "mixed_div@retval/f80" '
         argopt += '-A "mixed_str@arg1/s,fparg1"              -R "mixed_str@retval/s"'
 
-        import platform
         if platform.machine().startswith('arm'):
             argopt = argopt.replace('fparg1/80%stack+1', 'fparg1/80')
         elif platform.machine().startswith('i686'):

--- a/tests/t176_arg_fptr.py
+++ b/tests/t176_arg_fptr.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import re
 from runtest import TestBase
 
 class TestCase(TestBase):

--- a/tests/t178_arg_auto1.py
+++ b/tests/t178_arg_auto1.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from runtest import TestBase
-import re
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t182_thread_exit.py
+++ b/tests/t182_thread_exit.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import re
 from runtest import TestBase
 
 class TestCase(TestBase):

--- a/tests/t190_trigger_autoargs.py
+++ b/tests/t190_trigger_autoargs.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from runtest import TestBase
-import re
 
 class TestCase(TestBase):
     def __init__(self):


### PR DESCRIPTION
Hello,

Resolved the Reimport problem, and removed unused python modules.

what do you think?

Thanks.


after test log:
```
./runtest.py 
Test case                 pg             finstrument-fu
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
003 thread              : OK OK OK OK OK OK OK OK OK OK
049 column_view         : OK OK OK OK OK OK OK OK OK OK
050 no_pltbind          : OK OK OK OK OK OK OK OK OK OK
051 return              : OK OK OK OK OK OK OK OK OK OK
052 nested_func         : OK OK OK OK OK NG NG NG NG NG
053 filter_time         : OK OK OK OK OK OK OK OK OK OK
055 filter_time_N       : OK OK OK OK OK OK OK OK OK OK
056 filter_time_T       : OK OK OK OK OK OK OK OK OK OK
057 filter_time_D       : OK OK OK OK OK OK OK OK OK OK
064 trigger_trace       : OK OK OK OK OK OK OK OK OK OK
084 arg_mixed           : OK OK OK OK OK SK SK SK SK SK
176 arg_fptr            : OK OK OK OK OK OK OK OK OK OK
178 arg_auto1           : OK OK OK OK OK OK OK OK OK OK
182 thread_exit         : OK OK OK OK OK OK OK OK OK OK
190 trigger_autoargs    : OK OK OK OK OK OK OK OK OK OK
```