### PR TITLE
utils: Check return value of write

### DIFF
--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -202,7 +202,8 @@ static int set_filter_file(const char *filter_file, struct list_head *filters)
 		free(pos);
 
 		/* separate filters by space */
-		write(fd, " ", 1);
+		if (write(fd, " ", 1) != 1)
+			goto out;
 	}
 	ret = 0;
 


### PR DESCRIPTION
This is to remove the following warning message.
  uftrace/utils/kernel.c:205:3: warning: ignoring return value of ‘write’

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>