### PR TITLE
graph: Fix memory leak

### DIFF
--- a/cmds/graph.c
+++ b/cmds/graph.c
@@ -646,6 +646,7 @@ int command_graph(int argc, char *argv[], struct opts *opts)
 	struct ftrace_file_handle handle;
 	struct session_graph *graph;
 	char *func;
+	struct graph_backtrace *bt, *btmp;
 
 	__fsetlocking(outfp, FSETLOCKING_BYCALLER);
 	__fsetlocking(logfp, FSETLOCKING_BYCALLER);
@@ -692,6 +693,11 @@ int command_graph(int argc, char *argv[], struct opts *opts)
 		graph = graph_list;
 		graph_list = graph->next;
 
+		free(graph->func);
+		list_for_each_entry_safe(bt, btmp, &graph->bt_list, list) {
+			list_del(&bt->list);
+			free(bt);
+		}
 		graph_destroy(&graph->ug);
 		free(graph);
 	}


### PR DESCRIPTION
Hello,

In the process of using the graph function, a memory leak occurs.

So, I modified the source code.

what do you think?

Thanks

Valgrind log:
```
==24087== 7 bytes in 1 blocks are definitely lost in loss record 1 of 3
==24087==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==24087==    by 0x613EC39: strdup (strdup.c:42)
==24087==    by 0x121BD3: create_graph (graph.c:137)
==24087==    by 0x12A468: walk_sessions (session.c:238)
==24087==    by 0x12251A: setup_graph_list (graph.c:154)
==24087==    by 0x12251A: build_graph (graph.c:486)
==24087==    by 0x12251A: command_graph (graph.c:677)
==24087==    by 0x111A6F: main (uftrace.c:1065)
==24087== 
==24087== 80 (40 direct, 40 indirect) bytes in 1 blocks are definitely lost in loss record 3 of 3
==24087==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==24087==    by 0x1220D7: save_backtrace_addr (graph.c:247)
==24087==    by 0x1220D7: start_graph.part.4 (graph.c:305)
==24087==    by 0x12225E: start_graph (graph.c:304)
==24087==    by 0x12225E: get_task_graph (graph.c:215)
==24087==    by 0x1222FE: build_graph_node (graph.c:446)
==24087==    by 0x1225F8: build_graph (graph.c:551)
==24087==    by 0x1225F8: command_graph (graph.c:677)
==24087==    by 0x111A6F: main (uftrace.c:1065)
```

