### PR TITLE
include dlfcn.h for RTLD_DEFAULT

### DIFF
--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -5,6 +5,7 @@
 #include <sys/mman.h>
 #include <pthread.h>
 #include <assert.h>
+#include <dlfcn.h>
 
 /* This should be defined before #include "utils.h" */
 #define PR_FMT     "mcount"


### PR DESCRIPTION
Fixes
plthook.c:128:41: error: use of undeclared identifier 'RTLD_DEFAULT'

Signed-off-by: Khem Raj <raj.khem@gmail.com>