### PR TITLE
tests: Fix dump --chrome output

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -278,8 +278,14 @@ class TestBase:
         for ln in o['traceEvents']:
             if ln['name'].startswith('__'):
                 continue
-            if ln['ph'] == "M" and ln['name'] == "process_name":
-                result.append("%s %s %s" % (ln['ph'], ln['name'], ln['args']))
+            if ln['ph'] == "M":
+                if ln['name'] == "process_name" or ln['name'] == "thread_name":
+                    args = ln['args']
+                    name = args['name']
+                    m = re.search(r'\[\d+\] (.*)', args['name'])
+                    if m:
+                        name = m.group(1)
+                    result.append("%s %s %s" % (ln['ph'], ln['name'], name))
             else:
                 result.append("%s %s" % (ln['ph'], ln['name']))
         return '\n'.join(result)

--- a/tests/t101_dump_chrome.py
+++ b/tests/t101_dump_chrome.py
@@ -9,8 +9,8 @@ class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'abc', """
 {"traceEvents":[
-{"ts":0,"ph":"M","pid":5231,"name":"process_name","args":{"name":"t-abc"}},
-{"ts":0,"ph":"M","pid":5231,"name":"thread_name","args":{"name":"t-abc"}},
+{"ts":0,"ph":"M","pid":5231,"name":"process_name","args":{"name":"[5231] t-abc"}},
+{"ts":0,"ph":"M","pid":5231,"name":"thread_name","args":{"name":"[5231] t-abc"}},
 {"ts":58348873444,"ph":"B","pid":5231,"name":"main"},
 {"ts":58348873444,"ph":"B","pid":5231,"name":"a"},
 {"ts":58348873445,"ph":"B","pid":5231,"name":"b"},

--- a/tests/t107_dump_time.py
+++ b/tests/t107_dump_time.py
@@ -9,8 +9,8 @@ class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'sleep', """
 {"traceEvents":[
-{"ts":0,"ph":"M","pid":32537,"name":"process_name","args":{"name":"t-sleep"}},
-{"ts":0,"ph":"M","pid":32537,"name":"thread_name","args":{"name":"t-sleep"}},
+{"ts":0,"ph":"M","pid":32537,"name":"process_name","args":{"name":"[32537] t-sleep"}},
+{"ts":0,"ph":"M","pid":32537,"name":"thread_name","args":{"name":"[32537] t-sleep"}},
 {"ts":56466448731,"ph":"B","pid":32537,"name":"main"},
 {"ts":56466448731,"ph":"B","pid":32537,"name":"foo"},
 {"ts":56466448742,"ph":"B","pid":32537,"name":"bar"},

--- a/tests/t166_dump_sched.py
+++ b/tests/t166_dump_sched.py
@@ -9,8 +9,8 @@ class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'sleep', """
 {"traceEvents":[
-{"ts":0,"ph":"M","pid":306,"name":"process_name","args":{"name":"t-sleep"}},
-{"ts":0,"ph":"M","pid":306,"name":"thread_name","args":{"name":"t-sleep"}},
+{"ts":0,"ph":"M","pid":306,"name":"process_name","args":{"name":"[306] t-sleep"}},
+{"ts":0,"ph":"M","pid":306,"name":"thread_name","args":{"name":"[306] t-sleep"}},
 {"ts":112150305218.363,"ph":"B","pid":306,"name":"__monstartup"},
 {"ts":112150305220.090,"ph":"E","pid":306,"name":"__monstartup"},
 {"ts":112150305224.313,"ph":"B","pid":306,"name":"__cxa_atexit"},

--- a/tests/t196_chrome_taskname.py
+++ b/tests/t196_chrome_taskname.py
@@ -9,21 +9,21 @@ class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'taskname', ldflags='-pthread', result="""
 {"traceEvents":[
-{"ts":0,"ph":"M","pid":4694,"name":"process_name","args":{"name":"t-taskname"}},
-{"ts":0,"ph":"M","pid":4694,"name":"thread_name","args":{"name":"t-taskname"}},
+{"ts":0,"ph":"M","pid":4694,"name":"process_name","args":{"name":"[4694] bar"}},
+{"ts":0,"ph":"M","pid":4694,"name":"thread_name","args":{"name":"[4694] bar"}},
 {"ts":13453314717.085,"ph":"B","pid":4694,"name":"main"},
 {"ts":13453314717.245,"ph":"B","pid":4694,"name":"task_name1"},
 {"ts":13453314717.814,"ph":"B","pid":4694,"name":"prctl"},
-{"ts":0,"ph":"M","pid":4694,"name":"process_name","args":{"name":"foo"}},
-{"ts":0,"ph":"M","pid":4694,"name":"thread_name","args":{"name":"foo"}},
+{"ts":0,"ph":"M","pid":4694,"name":"process_name","args":{"name":"[4694] foo"}},
+{"ts":0,"ph":"M","pid":4694,"name":"thread_name","args":{"name":"[4694] foo"}},
 {"ts":13453314720.072,"ph":"E","pid":4694,"name":"prctl"},
 {"ts":13453314720.665,"ph":"E","pid":4694,"name":"task_name1"},
 {"ts":13453314720.793,"ph":"B","pid":4694,"name":"task_name2"},
 {"ts":13453314720.920,"ph":"B","pid":4694,"name":"pthread_self"},
 {"ts":13453314721.080,"ph":"E","pid":4694,"name":"pthread_self"},
 {"ts":13453314721.264,"ph":"B","pid":4694,"name":"pthread_setname_np"},
-{"ts":0,"ph":"M","pid":4694,"name":"process_name","args":{"name":"bar"}},
-{"ts":0,"ph":"M","pid":4694,"name":"thread_name","args":{"name":"bar"}},
+{"ts":0,"ph":"M","pid":4694,"name":"process_name","args":{"name":"[4694] bar"}},
+{"ts":0,"ph":"M","pid":4694,"name":"thread_name","args":{"name":"[4694] bar"}},
 {"ts":13453314722.478,"ph":"E","pid":4694,"name":"pthread_setname_np"},
 {"ts":13453314722.631,"ph":"E","pid":4694,"name":"task_name2"},
 {"ts":13453314722.695,"ph":"E","pid":4694,"name":"main"}


### PR DESCRIPTION
Since process_name and thread_name fields have more information, the
tests have to be modified accordingly.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>