### PR TITLE
dwarf: Fix Null Pointer Dereference in load_debug_file()

### DIFF
--- a/utils/dwarf.c
+++ b/utils/dwarf.c
@@ -1337,6 +1337,9 @@ static int load_debug_file(struct debug_info *dinfo, struct symtab *symtab,
 		case 'R':
 			if (line[0] == 'R')
 				root = &dinfo->rets;
+			
+			if (func == NULL)
+				goto out;
 
 			if (add_debug_entry(root, func, offset, &line[3]) < 0)
 				goto out;


### PR DESCRIPTION
Sometimes it might be NULL. Protect it from segmentation fault.

Fixed: #490

Signed-off-by: GwanYeong Kim <gy741.kim@gmail.com>