### PR TITLE
live: Fix memory leak in reset_live_opts()

### DIFF
--- a/cmds/live.c
+++ b/cmds/live.c
@@ -30,6 +30,7 @@ static void reset_live_opts(struct opts *opts)
 	 * These options are handled in record and no need to do it in
 	 * replay again.
 	 */
+	free(opts->filter);
 	opts->filter	= NULL;
 	opts->depth	= MCOUNT_DEFAULT_DEPTH;
 	opts->disabled	= false;


### PR DESCRIPTION
Hello,

On line 33 of the reset_live_opts(), NULL pointer before "free" it, losing what it points to. 

So, Memory leakage occurs.

what do you think?

Thanks.

Problem code:
https://github.com/namhyung/uftrace/blob/3066f545a220f10df1f33ad184de01563fd3f877/cmds/live.c#L24-L37

valgrind log:
```
==4943== 4 bytes in 1 blocks are definitely lost in loss record 1 of 1
==4943==    at 0x4C2FA3F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4943==    by 0x4C31D84: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4943==    by 0x14776A: strjoin (utils.c:413)
==4943==    by 0x112740: opt_add_string (uftrace.c:212)
==4943==    by 0x112740: parse_option (uftrace.c:385)
==4943==    by 0x61CD255: group_parse (argp-parse.c:257)
==4943==    by 0x61CD255: parser_parse_opt (argp-parse.c:747)
==4943==    by 0x61CD255: parser_parse_next (argp-parse.c:867)
==4943==    by 0x61CD255: argp_parse (argp-parse.c:921)
==4943==    by 0x111629: main (uftrace.c:990)
==4943== 
==4943== LEAK SUMMARY:
==4943==    definitely lost: 4 bytes in 1 blocks
==4943==    indirectly lost: 0 bytes in 0 blocks
==4943==      possibly lost: 0 bytes in 0 blocks
==4943==    still reachable: 0 bytes in 0 blocks
==4943==         suppressed: 0 bytes in 0 blocks
==4943== 
==4943== For counts of detected and suppressed errors, rerun with: -v
==4943== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
