### PR TITLE
info: Avoid segfault when task.txt doesn't exist

### DIFF
--- a/cmds/info.c
+++ b/cmds/info.c
@@ -1033,7 +1033,8 @@ void process_uftrace_info(struct ftrace_file_handle *handle, struct opts *opts,
 			task = find_task(&handle->sessions, tid);
 
 			len = snprintf(p, sz, "%s%d(%s)",
-				       first ? "" : ", ", tid, task->comm);
+				       first ? "" : ", ", tid,
+				       task ? task->comm : "");
 			p  += len;
 			sz -= len;
 


### PR DESCRIPTION
Reported-by: GwanYeong Kim <gy741.kim@gmail.com>
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>