### PR TITLE
misc: Change debug.sh using custom command & argv

### DIFF
--- a/misc/debug-mcount.cmd
+++ b/misc/debug-mcount.cmd
@@ -9,5 +9,5 @@ commands
   continue
 end
 
-r record -L. -d xxx --keep-pid --force tests/t-abc
+r record -L. -d xxx --keep-pid --force argv
  

--- a/misc/debug.sh
+++ b/misc/debug.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
 
-gdb -x misc/debug-mcount.cmd
+TMP=$(mktemp)
+ARGV="${@:-tests/t-abc}"
+
+sed "s|argv|$ARGV|g" misc/debug-mcount.cmd > $TMP
+
+gdb -x $TMP
+
+rm -f $TMP
 


### PR DESCRIPTION
This commit allows using custom command & argv with debug.sh

Example:
    sh misc/debug.sh tests/t-fibonacci 5

If no arguments are passed to debug.sh, it defaults to tests/t-abc.

Fixed: #511

Signed-off-by: Daniel T. Lee <danieltimlee@gmail.com>