### PR TITLE
utils: Move the definition of `demangle_full()`

### DIFF
--- a/utils/demangle.c
+++ b/utils/demangle.c
@@ -1571,6 +1571,12 @@ static char *demangle_full(char *str)
 
 	return symname;
 }
+#else
+static inline char *demangle_full(char *str)
+{
+	pr_warn("full demangle is not supported\n");
+	return str;
+}
 #endif
 
 /**

--- a/utils/symbol.h
+++ b/utils/symbol.h
@@ -201,12 +201,6 @@ static inline bool support_full_demangle(void)
 {
 	return false;
 }
-
-static inline char *demangle_full(char *str)
-{
-	pr_warn("full demangle is not supported\n");
-	return str;
-}
 #endif /* HAVE_CXA_DEMANGLE */
 
 #endif /* UFTRACE_SYMBOL_H */


### PR DESCRIPTION
`demangle_full()` is only used in `utils/demangle.c`.  So, move the definition of `demangle_full()` from `utils/symbol.h` to `utils/demangle.c`.

Signed-off-by: Taeguk Kwon <xornrbboy@gmail.com>