### PR TITLE
tests: skip tests that treat normal output as an error.

### DIFF
--- a/tests/t203_arg_dwarf3.py
+++ b/tests/t203_arg_dwarf3.py
@@ -28,6 +28,9 @@ class TestCase(TestBase):
         if cflags.find('-finstrument-functions') >= 0:
             return TestBase.TEST_SKIP
 
+        if cflags.find('-O0') < 0 and cflags.find('-O1') < 0:
+            return TestBase.TEST_SKIP
+
         return TestBase.build(self, name, cflags, ldflags)
 
     def runcmd(self):


### PR DESCRIPTION
The t203_arg_dwarf3.py test fails at -pg -O2 or -O3, -Os, and I checked logs.

```
build command: g++ -o t-dwarf3 -fno-inline -fno-builtin -fno-ipa-cp -fno-omit-frame-pointer -D_FORTIFY_SOURCE=0 -g -pg -O2  s-dwarf3.cpp
test command: ../uftrace --no-pager --no-event -L.. -A . -R . -F main t-dwarf3
=========== original ===========
            [  6605] | main() {
            [  6605] |   C::C(0x7fff490ff5d0, 1, "debug info") {
   1.110 us [  6605] |     C::copy(0x7fff490ff5d0, 1, "debug info");
 331.385 us [  6605] |   } /* C::C */
            [  6605] |   C::C(0x7fff490ff5e0, 2, "<0x1234>") {
 251.001 us [  6605] |     C::copy(0x7fff490ff5e0, 2, "<0x1234>");
 505.909 us [  6605] |   } /* C::C */
            [  6605] |   C::C(0x7fff490ff600, 0x7fff490ff5d0) {
   0.450 us [  6605] |     C::copy(0x7fff490ff600, 1, "debug info");
   1.643 us [  6605] |   } /* C::C */
            [  6605] |   foo("passed by value", 0.001000, 1, 2) {
            [  6605] |     C::C(0x7fff490ff5f0, 3, "passed by value") {
   0.375 us [  6605] |       C::copy(0x7fff490ff5f0, 3, "passed by value");
   1.305 us [  6605] |     } /* C::C */
   2.279 us [  6605] |   } /* foo */
 843.691 us [  6605] | } = 0; /* main */

===========  result  ===========
 main() {
   C::C(0xADDR, 1, "debug info") {
     C::copy(0xADDR, 1, "debug info");
   } /* C::C */
   C::C(0xADDR, 2, "<0xADDR>") {
     C::copy(0xADDR, 2, "<0xADDR>");
   } /* C::C */
   C::C(0xADDR, 0xADDR) {
     C::copy(0xADDR, 1, "debug info");
   } /* C::C */
   foo("passed by value", 0.001000, 1, 2) {
     C::C(0xADDR, 3, "passed by value") {
       C::copy(0xADDR, 3, "passed by value");
     } /* C::C */
   } /* foo */
 } = 0; /* main */
=========== expected ===========
 main() {
   C::C(0xADDR, 1, "debug info") {
     C::construct(0xADDR, 1, "debug info");
   } /* C::C */
   C::C(0xADDR, 2, "<0xADDR>") {
     C::construct(0xADDR, 2, "<0xADDR>");
   } /* C::C */
   C::C(0xADDR, 0xADDR) {
     C::copy(0xADDR, 1, "debug info");
   } /* C::C */
   foo(0xADDR, 0xADDR, 0xADDR, 0.001000) {
     C::C(0xADDR, 3, "passed by value") {
       C::construct(0xADDR, 3, "passed by value");
     } /* C::C */
   } = 0xADDR; /* foo */
 } = 0; /* main */
```

I try to debug t_dwarf3 binary with gdb, and gdb interprets it as follows

```
Breakpoint 2, foo<int> (str=0x555555554b37 "passed by value", f=0.00100000005, c2=..., c1=...) at s-dwarf3.cpp:38
38              return C<T>(c1.val + c2.val + f, str);
(gdb)
```

t203_arg_dwarf3 seems to be checking the result when it is -O0 or -O1 as expected result.

I made tests with the -O2 or -O3, -Os option processed to skip.

```
Test case                 pg             finstrument-fu
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
203 arg_dwarf3          : OK OK SK SK SK SK SK SK SK SK
```

Signed-off-by: Ahn, Seung-rye <seungrye@gmail.com>