### PR TITLE
doc: Update index page's installation link.

### DIFF
--- a/doc/uftrace.html
+++ b/doc/uftrace.html
@@ -209,6 +209,7 @@ template: picture-layout
 <img src="https://raw.githubusercontent.com/namhyung/uftrace/master/doc/uftrace-live-demo.gif" class="center-image" width="680">
 
 ---
+name: installation
 ### Quick Installation
 .footnote[[INSTALL.md](https://github.com/namhyung/uftrace/blob/master/INSTALL.md)]
 <pre>


### PR DESCRIPTION
This commit update uftrace.github.io index page's installation link.

Fixed : #547

Signed-off-by: Claudia J. Kang <claudiajkang@gmail.com>