### PR TITLE
script : Add arg.py

### DIFF
--- a/scripts/arg.py
+++ b/scripts/arg.py
@@ -1,0 +1,10 @@
+def uftrace_entry(ctx):
+        if "args" in ctx:
+        	print(ctx["name"] + " has args")
+	        
+def uftrace_exit(ctx):
+	if "retval" in ctx:
+    		print(ctx["name"] + " has retval")
+
+				
+


### PR DESCRIPTION
This patch adds arg.py.

The output of this script is as follows : 

```
$ uftrace record -a -S scripts/arg.py tests/abc
main has args
foo has args
bar has args
strcmp has args
strcmp has retval
bar has retval
bar has args
strcmp has args
strcmp has retval
bar has retval
bar has args
strcmp has args
strcmp has retval
bar has retval
foo has retval
many has args
many has retval
pass has args
check has args
check has retval
pass has retval
main has retval
```

Signed-off-by: leeyeeun <dldpdms0229@duksung.ac.kr>