### PR TITLE
script: Add elapsed_time to script_info

### DIFF
--- a/cmds/script.c
+++ b/cmds/script.c
@@ -168,8 +168,7 @@ int command_script(int argc, char *argv[], struct opts *opts)
 
 	ret = open_data_file(opts, &handle);
 	uftrace_info = &handle.info;
-	info.elapsed_time = xstrdup(uftrace_info->elapsed_time);
-
+	info.elapsed_time = atof(uftrace_info->elapsed_time);
 	if (ret < 0) {
 		pr_warn("cannot open record data: %s: %m\n", opts->dirname);
 		return -1;

--- a/cmds/script.c
+++ b/cmds/script.c
@@ -134,6 +134,7 @@ int command_script(int argc, char *argv[], struct opts *opts)
 		.name           = opts->script_file,
 		.version        = UFTRACE_VERSION,
 	};
+	struct uftrace_info *uftrace_info;
 
 	if (!SCRIPT_ENABLED) {
 		pr_warn("script command is not supported due to missing libpython2.7.so\n");
@@ -166,6 +167,9 @@ int command_script(int argc, char *argv[], struct opts *opts)
 	__fsetlocking(logfp, FSETLOCKING_BYCALLER);
 
 	ret = open_data_file(opts, &handle);
+	uftrace_info = &handle.info;
+	info.elapsed_time = xstrdup(uftrace_info->elapsed_time);
+
 	if (ret < 0) {
 		pr_warn("cannot open record data: %s: %m\n", opts->dirname);
 		return -1;

--- a/scripts/info.py
+++ b/scripts/info.py
@@ -2,6 +2,7 @@ def uftrace_begin(ctx):
     print(ctx["record"])
     print(ctx["version"])
     print(ctx["cmds"])
+    print(ctx["elapsed_time"])
 
 def uftrace_entry(ctx):
     pass

--- a/utils/script-python.c
+++ b/utils/script-python.c
@@ -265,6 +265,9 @@ static void python_insert_dict(PyObject *dict, char type, const char *key,
 	case 'b':
 		obj = __PyBool_FromLong(val.l);
 		break;
+	case 'f':
+		obj = __PyFloat_FromDouble(val.f);
+		break;
 	default:
 		pr_warn("unsupported data type was added to dict\n");
 		obj = NULL;
@@ -315,6 +318,12 @@ static void insert_dict_string(PyObject *dict, const char *key, char *v)
 {
 	union python_val val = { .s = v, };
 	python_insert_dict(dict, 's', key, val);
+}
+
+static void insert_dict_double(PyObject *dict, const char *key, double v)
+{
+	union python_val val = { .f = v, };
+	python_insert_dict(dict, 'f', key, val);
 }
 
 static void insert_dict_bool(PyObject *dict, const char *key, bool v)
@@ -491,7 +500,7 @@ int python_uftrace_begin(struct script_info *info)
 
 	insert_dict_bool(dict, "record", info->record);
 	insert_dict_string(dict, "version", info->version);
-	insert_dict_string(dict, "elapsed_time", info->elapsed_time);
+	insert_dict_double(dict, "elapsed_time", info->elapsed_time);
 
 	int i;
 	char *s;

--- a/utils/script-python.c
+++ b/utils/script-python.c
@@ -491,6 +491,7 @@ int python_uftrace_begin(struct script_info *info)
 
 	insert_dict_bool(dict, "record", info->record);
 	insert_dict_string(dict, "version", info->version);
+	insert_dict_string(dict, "elapsed_time", info->elapsed_time);
 
 	int i;
 	char *s;

--- a/utils/script.h
+++ b/utils/script.h
@@ -24,6 +24,7 @@ struct script_info {
 	char			*version;
 	bool			record;
 	struct strv		cmds;
+	char			*elapsed_time;
 };
 
 /* context information passed to script */

--- a/utils/script.h
+++ b/utils/script.h
@@ -24,7 +24,7 @@ struct script_info {
 	char			*version;
 	bool			record;
 	struct strv		cmds;
-	char			*elapsed_time;
+	double			elapsed_time;
 };
 
 /* context information passed to script */


### PR DESCRIPTION
Current script_info is a bit lack of data, so I add elapsed_time
to script_info. And I add print(ctx["elapsed_time"]) to info.py.

Signed-off-by: pengin7384 <pengin7384@gmail.com>