### PR TITLE
test: parallel tests implementation with multiprocessing

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import random
 import os, sys
 import tempfile
 import glob, re
@@ -47,6 +48,9 @@ class TestBase:
     def pr_debug(self, msg):
         if self.debug:
             print(msg)
+
+    def gen_port(self):
+        self.port = random.randint(40000, 50000)
 
     def convert_abs_path(self, build_cmd):
         cmd = build_cmd.split()

--- a/tests/t141_recv_basic.py
+++ b/tests/t141_recv_basic.py
@@ -21,14 +21,15 @@ class TestCase(TestBase):
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
 """)
+        self.gen_port()
 
     recv_p = None
 
     def pre(self):
-        recv_cmd = '%s recv -d %s' % (TestBase.uftrace_cmd, TDIR)
+        recv_cmd = '%s recv -d %s --port %s' % (TestBase.uftrace_cmd, TDIR, self.port)
         self.recv_p = sp.Popen(recv_cmd.split())
 
-        record_cmd = '%s record -H %s %s' % (TestBase.uftrace_cmd, 'localhost', 't-abc')
+        record_cmd = '%s record -H %s --port %s %s' % (TestBase.uftrace_cmd, 'localhost', self.port, 't-abc')
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t142_recv_multi.py
+++ b/tests/t142_recv_multi.py
@@ -21,19 +21,20 @@ class TestCase(TestBase):
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
 """)
+        self.gen_port()
 
     recv_p = None
 
     def pre(self):
-        recv_cmd = '%s recv -d %s' % (TestBase.uftrace_cmd, TDIR)
+        recv_cmd = '%s recv -d %s --port %s' % (TestBase.uftrace_cmd, TDIR, self.port)
         self.recv_p = sp.Popen(recv_cmd.split())
 
         # recorded but not used
-        record_cmd = '%s record -H %s %s' % (TestBase.uftrace_cmd, 'localhost', 't-abc')
+        record_cmd = '%s record -H %s --port %s %s' % (TestBase.uftrace_cmd, 'localhost', self.port, 't-abc')
         sp.call(record_cmd.split())
 
         # use this
-        record_cmd = '%s record -H %s -d %s %s' % (TestBase.uftrace_cmd, 'localhost', TDIR2, 't-abc')
+        record_cmd = '%s record -H %s --port %s -d %s %s' % (TestBase.uftrace_cmd, 'localhost', self.port, TDIR2, 't-abc')
         sp.call(record_cmd.split())
 
         return TestBase.TEST_SUCCESS

--- a/tests/t143_recv_kernel.py
+++ b/tests/t143_recv_kernel.py
@@ -22,6 +22,7 @@ class TestCase(TestBase):
   37.325 us [18343] |   } /* fclose */
  128.387 us [18343] | } /* main */
 """)
+        self.gen_port()
 
     recv_p = None
 
@@ -34,10 +35,10 @@ class TestCase(TestBase):
         uftrace = TestBase.uftrace_cmd
         program = 't-' + self.name
 
-        recv_cmd = '%s recv -d %s' % (uftrace, TDIR)
+        recv_cmd = '%s recv -d %s --port %s' % (uftrace, TDIR, self.port)
         self.recv_p = sp.Popen(recv_cmd.split())
 
-        argument  = '-H %s -k -d %s' % ('localhost', TDIR2)
+        argument  = '-H %s -k -d %s --port %s' % ('localhost', TDIR2, self.port)
         argument += ' -N %s@kernel' % '_*do_page_fault'
 
         record_cmd = '%s record %s %s' % (uftrace, argument, program)

--- a/tests/t150_recv_event.py
+++ b/tests/t150_recv_event.py
@@ -18,17 +18,19 @@ class TestCase(TestBase):
    2.896 us [28141] |   } /* foo */
    3.017 us [28141] | } /* main */
 """)
+        self.gen_port()
 
     recv_p = None
 
     def pre(self):
-        recv_cmd = '%s recv -d %s' % (TestBase.uftrace_cmd, TDIR)
+        recv_cmd = '%s recv -d %s --port %s' % (TestBase.uftrace_cmd, TDIR, self.port)
         self.recv_p = sp.Popen(recv_cmd.split())
 
         server = '-H 127.0.0.1'
+        port   = '--port %s' % self.port
         option = '-E uftrace:event'
         prog   = 't-' + self.name
-        record_cmd = '%s record %s %s %s' % (TestBase.uftrace_cmd, server, option, prog)
+        record_cmd = '%s record %s %s %s %s' % (TestBase.uftrace_cmd, server, port, option, prog)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t151_recv_runcmd.py
+++ b/tests/t151_recv_runcmd.py
@@ -21,16 +21,18 @@ class TestCase(TestBase):
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
 """)
+        self.gen_port()
 
     recv_p = None
     file_p = None
 
     def pre(self):
         self.file_p = open(TMPF, 'w+')
-        recv_cmd = TestBase.uftrace_cmd.split() + ['recv', '-d', TDIR, '--run-cmd', TestBase.uftrace_cmd + ' replay']
+        recv_cmd = TestBase.uftrace_cmd.split() + \
+                   ['recv', '-d', TDIR, '--port', str(self.port), '--run-cmd', TestBase.uftrace_cmd + ' replay']
         self.recv_p = sp.Popen(recv_cmd, stdout=self.file_p, stderr=self.file_p)
 
-        record_cmd = '%s record -H %s %s' % (TestBase.uftrace_cmd, 'localhost', 't-' + self.name)
+        record_cmd = '%s record -H %s --port %s %s' % (TestBase.uftrace_cmd, 'localhost', self.port, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t157_script_python.py
+++ b/tests/t157_script_python.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
 
     def runcmd(self):
         uftrace = TestBase.uftrace_cmd
-        options = '-F main -S ../scripts/count.py'
+        options = '-F main -S %s/scripts/count.py' % self.basedir
         return '%s script -d %s %s' % (uftrace, TDIR, options)
 
     def sort(self, output):

--- a/tests/t167_recv_sched.py
+++ b/tests/t167_recv_sched.py
@@ -26,6 +26,7 @@ class TestCase(TestBase):
    2.120 ms [  395] |   } /* foo */
    2.121 ms [  395] | } /* main */
 """)
+        self.gen_port()
 
     recv_p = None
 
@@ -35,10 +36,10 @@ class TestCase(TestBase):
         if not TestBase.check_perf_paranoid(self):
             return TestBase.TEST_SKIP
 
-        recv_cmd = '%s recv -d %s' % (TestBase.uftrace_cmd, TDIR)
+        recv_cmd = '%s recv -d %s --port %s' % (TestBase.uftrace_cmd, TDIR, self.port)
         self.recv_p = sp.Popen(recv_cmd.split())
 
-        options = '-H %s -E %s' % ('localhost', 'linux:schedule')
+        options = '-H %s --port %s -E %s' % ('localhost', self.port, 'linux:schedule')
         record_cmd = '%s record %s %s' % (TestBase.uftrace_cmd, options, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS

--- a/tests/t199_script_info.py
+++ b/tests/t199_script_info.py
@@ -25,7 +25,7 @@ v0.8.3-10/gfbfac3
 
     def runcmd(self):
         uftrace = TestBase.uftrace_cmd
-        options = '-F main -S ../scripts/info.py foo bar'
+        options = '-F main -S %s/scripts/info.py foo bar' % self.basedir
         return '%s script -d %s %s' % (uftrace, TDIR, options)
 
     def sort(self, output):

--- a/tests/t207_dump_graphviz.py
+++ b/tests/t207_dump_graphviz.py
@@ -8,11 +8,7 @@ TDIR='xxx'
 
 class TestCase(TestBase):
     def __init__(self):
-        currentPath = os.path.dirname(os.path.abspath(__file__))
-        testPath = os.path.join(currentPath, "t-abc")
-        TestBase.__init__(self, 'abc',
-        "digraph \"" + testPath + "\" {" +
-        """
+        TestBase.__init__(self, 'abc', """digraph "%s" {
 
         # Attributes
         splines=ortho;
@@ -27,6 +23,7 @@ class TestCase(TestBase):
         "b" -> "c" [xlabel = "Calls : 1"]
         }
         """)
+        self.result = self.result % os.path.join(self.test_dir, "t-abc")
 
     def pre(self):
         record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)


### PR DESCRIPTION
The PR enables running parallel tests through multiprocessing pool.
Due to the concurrent test, the result won't be shown in an orderly manner.
So instead of showing result directly, the progress bar has been added.
After all, tests are done, the test result will be shown at once.

**Change log**
- Progress bar for visualizing current running tests
- build directory changed: `uftrace/tests` -> `/tmp/<temporarily_created>`
- build and test with absolute path
- test port randomization for not to conflict socket during a concurrent tests
 
```bash
$ export TESTARG='-j 8'; make test;
> ...
./runtest.py all
Start 211 tests with 8 worker
Progress [########################################] 211/211
Test case                 pg             finstrument-fu
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
001 basic               : OK OK OK OK OK OK OK OK OK OK
002 argument            : OK OK OK OK OK OK OK OK OK OK
> ...
```

Fixed: #569 

Signed-off-by: Daniel T. Lee <danieltimlee@gmail.com>