### PR TITLE
record: fix GCC8 string truncation warning

### DIFF
--- a/check-deps/Makefile
+++ b/check-deps/Makefile
@@ -8,7 +8,6 @@ CHECK_LIST += perf_clockid
 CHECK_LIST += perf_context_switch
 CHECK_LIST += arm_has_hardfp
 CHECK_LIST += have_libncurses
-CHECK_LIST += cc_has_wstringop_truncation
 CHECK_LIST += have_libdw
 
 #
@@ -25,7 +24,6 @@ CFLAGS_cc_has_mno_sse2 = -mno-sse2
 LDFLAGS_have_libpython2.7 = -lpython2.7
 CFLAGS_have_libncurses  = $(shell pkg-config --cflags ncursesw 2> /dev/null)
 LDFLAGS_have_libncurses = $(shell pkg-config --libs   ncursesw 2> /dev/null)
-CFLAGS_cc_has_wstringop_truncation = -Wno-stringop-truncation
 CFLAGS_have_libdw  = $(shell pkg-config --cflags libdw 2> /dev/null)
 LDFLAGS_have_libdw = $(shell pkg-config --libs   libdw 2> /dev/null || echo "-ldw")
 

--- a/check-deps/Makefile.check
+++ b/check-deps/Makefile.check
@@ -37,10 +37,6 @@ ifneq ($(wildcard $(srcdir)/check-deps/have_libncurses),)
   TEST_LDFLAGS    += $(shell pkg-config --libs ncursesw)
 endif
 
-ifneq ($(wildcard $(srcdir)/check-deps/cc_has_wstringop_truncation),)
-  COMMON_CFLAGS += -Wno-stringop-truncation
-endif
-
 ifneq ($(wildcard $(srcdir)/check-deps/have_libelf),)
   COMMON_CFLAGS  += -DHAVE_LIBELF
   COMMON_LDFLAGS += -lelf

--- a/check-deps/__cc_has_wstringop_truncation.c
+++ b/check-deps/__cc_has_wstringop_truncation.c
@@ -1,4 +1,0 @@
-int main(void)
-{
-	return 0;
-}

--- a/cmds/record.c
+++ b/cmds/record.c
@@ -904,7 +904,7 @@ static void unlink_shmem_list(void)
 		num = scandir("/dev/shm/", &shmem_bufs, filter_shmem, alphasort);
 		for (i = 0; i < num; i++) {
 			sid[0] = '/';
-			strncpy(&sid[1], shmem_bufs[i]->d_name, MSG_ID_SIZE);
+			memcpy(&sid[1], shmem_bufs[i]->d_name, MSG_ID_SIZE);
 			pr_dbg3("unlink %s\n", sid);
 			shm_unlink(sid);
 			free(shmem_bufs[i]);


### PR DESCRIPTION
This commit fixes the GCC8 string tuncation warning occured from strncpy.

Fixed: #571

Signed-off-by: Daniel T. Lee <danieltimlee@gmail.com>