### PR TITLE
replay: Change print format for --python option

### DIFF
--- a/utils/fstack.h
+++ b/utils/fstack.h
@@ -83,6 +83,7 @@ enum argspec_string_bits {
 	IS_RETVAL_BIT,
 	NEEDS_ASSIGNMENT_BIT,
 	NEEDS_ESCAPE_BIT,
+	IS_PYTHON_BIT,
 
 	/* bit mask */
 	NEEDS_PAREN		= (1U << NEEDS_PAREN_BIT),
@@ -91,6 +92,7 @@ enum argspec_string_bits {
 	IS_RETVAL		= (1U << IS_RETVAL_BIT),
 	NEEDS_ASSIGNMENT	= (1U << NEEDS_ASSIGNMENT_BIT),
 	NEEDS_ESCAPE		= (1U << NEEDS_ESCAPE_BIT),
+	IS_PYTHON		= (1U << IS_PYTHON_BIT),
 };
 
 extern bool fstack_enabled;


### PR DESCRIPTION
This PR makes print format change for --python option.
With --python option, it would be came out with this format.
```
# DURATION     TID     FUNCTION
            [  7101] | <module>():
            [  7101] |   fact():
            [  7101] |     fact():
            [  7101] |       fact():
            [  7101] |         fact():
   0.631 us [  7101] |           fact()
   2.312 us [  7101] |           /* fact */
   3.481 us [  7101] |         /* fact */
  32.984 us [  7101] |       /* fact */
  34.525 us [  7101] |     /* fact */
   0.621 us [  7101] |   add()
   0.682 us [  7101] |   Parent()
   0.904 us [  7101] |   Calculator()
   0.720 us [  7101] |   __init__()
            [  7101] |   mul():
   0.422 us [  7101] |     add()
   0.345 us [  7101] |     add()
   0.324 us [  7101] |     add()
   0.311 us [  7101] |     add()
   7.279 us [  7101] |     /* mul */
   0.416 us [  7101] |   getResult()
  65.687 us [  7101] |   /* <module> */
   3.269 us [  7101] | _remove()
   1.281 us [  7101] | _remove()
(END)
```