### PR TITLE
uftrace: Change option --no-comment to --comment=<value>

### DIFF
--- a/doc/uftrace-replay.md
+++ b/doc/uftrace-replay.md
@@ -88,8 +88,11 @@ OPTIONS
 :   Interleave a new line when task is changed.  This makes easy to distinguish
     functions in different tasks.
 
-\--no-comment
-:   Do not show comments of returned functions.
+\--comment=*VAL*
+:   Show comments when the function closed.  Possible values are
+    "yes"(= "true"|"1"|"on"), "no"(= "false"|"0"|"off") and "with-args".
+    When "with-args" value is used, show function name and arguments together.  
+    Default is 'yes'.
 
 -k, \--kernel
 :   Trace kernel functions (and events) as well as user functions (and events).

--- a/uftrace.h
+++ b/uftrace.h
@@ -214,6 +214,7 @@ struct opts {
 	int max_stack;
 	int port;
 	int color;
+	int comment;
 	int column_offset;
 	int sort_column;
 	int nr_thread;
@@ -240,7 +241,6 @@ struct opts {
 	bool want_bind_not;
 	bool task_newline;
 	bool chrome_trace;
-	bool comment;
 	bool flame_graph;
 	bool libmcount_single;
 	bool kernel;

--- a/utils/fstack.h
+++ b/utils/fstack.h
@@ -73,6 +73,7 @@ struct ftrace_task_handle {
 		unsigned long flags;
 		uint64_t total_time;
 		uint64_t child_time;
+		char args[1024];
 	} *func_stack;
 	struct fstack_arguments args;
 };

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -73,6 +73,13 @@ enum color_setting {
 	COLOR_ON,
 };
 
+enum comment_setting {
+	COMMENT_UNKNOWN = -1,
+	COMMENT_OFF,
+	COMMENT_ON,
+	COMMENT_WITH_ARGS
+};
+
 #define COLOR_CODE_RED      'R'
 #define COLOR_CODE_GREEN    'G'
 #define COLOR_CODE_BLUE     'B'


### PR DESCRIPTION
This PR is to change option --no-comment to --comment=\<value>

This patch makes it possible to see function names and arguments together.
To add this option, store arguments string in 'fstack' structure(utils/fstack.h). 

How do you think this?

Fixed: #533

Signed-off-by: bbchip0103 <bbchip13@gmail.com>