### PR TITLE
uftrace: Change option --no-comment to --comment=<value>

### DIFF
--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -716,7 +716,6 @@ static int print_graph_rstack(struct ftrace_file_handle *handle,
 	struct sym *sym = NULL;
 	enum argspec_string_bits str_mode = 0;
 	char *symname = NULL;
-	char args[1024];
 	char *libname = "";
 	struct uftrace_mmap *map = NULL;
 
@@ -781,9 +780,9 @@ static int print_graph_rstack(struct ftrace_file_handle *handle,
 
 		if (rstack->more)
 			str_mode |= HAS_MORE;
-		get_argspec_string(task, args, sizeof(args), str_mode);
 
 		fstack = &task->func_stack[task->stack_count - 1];
+		get_argspec_string(task, fstack->args, sizeof(fstack->args), str_mode);
 
 		if (!opts->no_merge)
 			next = fstack_skip(handle, task, rstack_depth,
@@ -810,12 +809,12 @@ static int print_graph_rstack(struct ftrace_file_handle *handle,
 				pr_color(tr.color, "%s", symname);
 				if (*libname)
 					pr_color(tr.color, "@%s", libname);
-				pr_out("%s%s\n", args, retval);
+				pr_out("%s%s\n", fstack->args, retval);
 			}
 			else {
 				pr_out("%s%s%s%s%s\n", symname,
 				       *libname ? "@" : "",
-				       libname, args, retval);
+				       libname, fstack->args, retval);
 			}
 
 			/* fstack_update() is not needed here */
@@ -830,11 +829,11 @@ static int print_graph_rstack(struct ftrace_file_handle *handle,
 				pr_color(tr.color, "%s", symname);
 				if (*libname)
 					pr_color(tr.color, "@%s", libname);
-				pr_out("%s {\n", args);
+				pr_out("%s {\n", fstack->args);
 			}
 			else {
 				pr_out("%s%s%s%s {\n", symname,
-				       *libname ? "@" : "", libname, args);
+				       *libname ? "@" : "", libname, fstack->args);
 			}
 
 			fstack_update(UFTRACE_ENTRY, task, fstack);
@@ -848,7 +847,7 @@ static int print_graph_rstack(struct ftrace_file_handle *handle,
 
 		if (!(fstack->flags & FSTACK_FL_NORECORD) && fstack_enabled) {
 			int depth = fstack_update(UFTRACE_EXIT, task, fstack);
-			char *retval = args;
+			char retval[1024];
 
 			depth += task_column_depth(task, opts);
 
@@ -858,7 +857,7 @@ static int print_graph_rstack(struct ftrace_file_handle *handle,
 				str_mode |= NEEDS_ASSIGNMENT;
 				str_mode |= NEEDS_SEMI_COLON;
 			}
-			get_argspec_string(task, retval, sizeof(args), str_mode);
+			get_argspec_string(task, retval, sizeof(retval), str_mode);
 
 			/* give a new line when tid is changed */
 			if (opts->task_newline)
@@ -866,9 +865,14 @@ static int print_graph_rstack(struct ftrace_file_handle *handle,
 
 			print_field(task, fstack, NULL);
 			pr_out("%*s}%s", depth * 2, "", retval);
-			if (opts->comment)
+
+			if (opts->comment == COMMENT_ON)
 				pr_gray(" /* %s%s%s */\n", symname,
 					*libname ? "@" : "", libname);
+			else if (opts->comment == COMMENT_WITH_ARGS){
+				pr_gray(" /* %s%s%s%s */ \n", symname,
+					*libname ? "@" : "", libname, fstack->args);
+			}
 			else
 				pr_gray("\n");
 		}

--- a/doc/uftrace-replay.md
+++ b/doc/uftrace-replay.md
@@ -88,8 +88,11 @@ OPTIONS
 :   Interleave a new line when task is changed.  This makes easy to distinguish
     functions in different tasks.
 
-\--no-comment
-:   Do not show comments of returned functions.
+\--comment=*VAL*
+:   Show comments when the function closed.  Possible values are
+    "yes"(= "true"|"1"|"on"), "no"(= "false"|"0"|"off") and "with-args".
+    When "with-args" value is used, show function name and arguments together.  
+    Default is 'yes'.
 
 -k, \--kernel
 :   Trace kernel functions (and events) as well as user functions (and events).

--- a/uftrace.h
+++ b/uftrace.h
@@ -214,6 +214,7 @@ struct opts {
 	int max_stack;
 	int port;
 	int color;
+	int comment;
 	int column_offset;
 	int sort_column;
 	int nr_thread;
@@ -240,7 +241,6 @@ struct opts {
 	bool want_bind_not;
 	bool task_newline;
 	bool chrome_trace;
-	bool comment;
 	bool flame_graph;
 	bool libmcount_single;
 	bool kernel;

--- a/utils/fstack.h
+++ b/utils/fstack.h
@@ -73,6 +73,7 @@ struct ftrace_task_handle {
 		unsigned long flags;
 		uint64_t total_time;
 		uint64_t child_time;
+		char args[1024];
 	} *func_stack;
 	struct fstack_arguments args;
 };

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -73,6 +73,13 @@ enum color_setting {
 	COLOR_ON,
 };
 
+enum comment_setting {
+	COMMENT_UNKNOWN = -1,
+	COMMENT_OFF,
+	COMMENT_ON,
+	COMMENT_WITH_ARGS
+};
+
 #define COLOR_CODE_RED      'R'
 #define COLOR_CODE_GREEN    'G'
 #define COLOR_CODE_BLUE     'B'


### PR DESCRIPTION
Hello, This PR is to change option --no-comment to --comment=\<value>

This patch makes it possible to see function names and arguments together.
It is more efficient to read recursive functions.
To add this option, I store arguments string in 'fstack' structure(utils/fstack.h).

How do you think this?

Fixed: #533

Signed-off-by: bbchip0103 <bbchip13@gmail.com>

```
$ uftrace -A .@Arg1 --comment=with-args tests/a.out
   1.324 us [ 32579] | __monstartup(0x400540);
   0.598 us [ 32579] | __cxa_atexit(0x7f3325a6b360);
            [ 32579] | main(1) {
            [ 32579] |   fib(5) {
            [ 32579] |     fib(4) {
            [ 32579] |       fib(3) {
   1.593 us [ 32579] |         fib(2);
   0.114 us [ 32579] |         fib(1);
   2.479 us [ 32579] |       } /* fib(3) */
   0.109 us [ 32579] |       fib(2);
   3.001 us [ 32579] |     } /* fib(4) */
            [ 32579] |     fib(3) {
   0.105 us [ 32579] |       fib(2);
   0.142 us [ 32579] |       fib(1);
   0.721 us [ 32579] |     } /* fib(3) */
   4.133 us [ 32579] |   } /* fib(5) */
   4.680 us [ 32579] | } /* main(1) */
```