### PR TITLE
utils: Fix data file open failure inside data dir

### DIFF
--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -449,6 +449,7 @@ int open_data_file(struct opts *opts, struct uftrace_data *handle)
 	goto out;
 
 ok:
+	saved_errno = 0;
 	handle->fp = fp;
 	handle->dirname = opts->dirname;
 	handle->depth = opts->depth;


### PR DESCRIPTION
There is an error when reading data file inside uftrace.data.
The problem is because of saved_errno is not recovered when data file is
normally opened inside uftrace.data directory.

This fixes the problem by recovering saved_errno when data file is
properly opened.

Fixed: #589

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>