### PR TITLE
uftrace: Add --no-args option to hide args/retval

### DIFF
--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -889,7 +889,7 @@ static int print_graph_rstack(struct uftrace_data *handle,
 
 		depth += task_column_depth(task, opts);
 
-		if (rstack->more)
+		if (rstack->more && opts->show_args)
 			str_mode |= HAS_MORE;
 		get_argspec_string(task, args, sizeof(args), str_mode);
 
@@ -907,7 +907,7 @@ static int print_graph_rstack(struct uftrace_data *handle,
 			fstack_consume(handle, next);
 
 			str_mode = IS_RETVAL | NEEDS_SEMI_COLON;
-			if (next->rstack->more) {
+			if (next->rstack->more && opts->show_args) {
 				str_mode |= HAS_MORE;
 				str_mode |= NEEDS_ASSIGNMENT;
 			}
@@ -969,7 +969,7 @@ static int print_graph_rstack(struct uftrace_data *handle,
 			depth += task_column_depth(task, opts);
 
 			str_mode = IS_RETVAL;
-			if (rstack->more) {
+			if (rstack->more && opts->show_args) {
 				str_mode |= HAS_MORE;
 				str_mode |= NEEDS_ASSIGNMENT;
 				str_mode |= NEEDS_SEMI_COLON;

--- a/cmds/script.c
+++ b/cmds/script.c
@@ -68,7 +68,7 @@ static int run_script_for_rstack(struct uftrace_data *handle,
 		sc_ctx.address   = rstack->addr;
 		sc_ctx.name      = symname;
 
-		if (tr.flags & TRIGGER_FL_ARGUMENT) {
+		if (tr.flags & TRIGGER_FL_ARGUMENT && opts->show_args) {
 			sc_ctx.argbuf  = task->args.data;
 			sc_ctx.arglen  = task->args.len;
 			sc_ctx.argspec = task->args.args;
@@ -104,7 +104,7 @@ static int run_script_for_rstack(struct uftrace_data *handle,
 			sc_ctx.address   = rstack->addr;
 			sc_ctx.name      = symname;
 
-			if (rstack->more) {
+			if (rstack->more && opts->show_args) {
 				sc_ctx.argbuf  = task->args.data;
 				sc_ctx.arglen  = task->args.len;
 				sc_ctx.argspec = task->args.args;

--- a/doc/uftrace-dump.md
+++ b/doc/uftrace-dump.md
@@ -42,6 +42,9 @@ DUMP OPTIONS
     ran less than the sampling time will be removed from the output and
     functions ran longer than the time will be shown as larger.
 
+\--no-args
+:   Do not show function arguments and return value.
+
 
 COMMON OPTIONS
 ==============

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -250,6 +250,9 @@ REPLAY OPTIONS
 \--libname
 :   Show library name along with function name.
 
+\--no-args
+:   Do not show function arguments and return value.
+
 
 COMMON ANALYSIS OPTIONS
 =======================

--- a/doc/uftrace-replay.md
+++ b/doc/uftrace-replay.md
@@ -51,6 +51,9 @@ REPLAY OPTIONS
 \--format=*TYPE*
 :   Show format style output. Currently, normal and html styles are supported.
 
+\--no-args
+:   Do not show function arguments and return value.
+
 
 COMMON OPTIONS
 ==============

--- a/doc/uftrace-script.md
+++ b/doc/uftrace-script.md
@@ -30,6 +30,9 @@ SCRIPT OPTIONS
 \--record COMMAND [*command-options*]
 :   Record a new trace before running a given script.
 
+\--no-args
+:   Do not show function arguments and return value.
+
 
 COMMON OPTIONS
 ==============

--- a/tests/t269_arg_no_args_replay.py
+++ b/tests/t269_arg_no_args_replay.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+import subprocess as sp
+
+from runtest import TestBase
+
+TDIR='xxx'
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'exp-str', result="""
+# DURATION     TID     FUNCTION
+   1.700 us [114150] | __monstartup();
+   0.980 us [114150] | __cxa_atexit();
+            [114150] | main() {
+ 311.089 us [114150] |   str_cpy();
+   0.734 us [114150] |   str_cpy();
+   0.597 us [114150] |   str_cat();
+   0.537 us [114150] |   str_cpy();
+   0.454 us [114150] |   str_cat();
+ 317.939 us [114150] | } /* main */
+""")
+
+    def build(self, name, cflags='', ldflags=''):
+        # cygprof doesn't support arguments now
+        if cflags.find('-finstrument-functions') >= 0:
+            return TestBase.TEST_SKIP
+
+        return TestBase.build(self, name, cflags, ldflags)
+
+    def prerun(self, timeout):
+        record_cmd = '%s record -d %s -A ^str_@arg1/s,arg2/s -R ^str_@retval/s %s' \
+                        % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
+        sp.call(record_cmd.split())
+        return TestBase.TEST_SUCCESS
+
+    def runcmd(self):
+        return '%s replay -d %s --no-args' % (TestBase.uftrace_cmd, TDIR)
+
+    def post(self, ret):
+        sp.call(['rm', '-rf', TDIR])
+        return ret

--- a/tests/t270_arg_no_args_dump.py
+++ b/tests/t270_arg_no_args_dump.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+import subprocess as sp
+
+from runtest import TestBase
+
+TDIR='xxx'
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'exp-str', result="""
+uftrace file header: magic         = 4674726163652100
+uftrace file header: version       = 4
+uftrace file header: header size   = 40
+uftrace file header: endian        = 1 (little)
+uftrace file header: class         = 2 (64 bit)
+uftrace file header: features      = 0x77b (PLTHOOK | TASK_SESSION | ARGUMENT | RETVAL | SYM_REL_ADDR | MAX_STACK | PERF_EVENT | AUTO_ARGS | DEBUG_INFO)
+uftrace file header: info          = 0x3fff
+
+reading 72944.dat
+108370.324774953  72944: [entry] __monstartup(aaaacc4c0750) depth: 0
+108370.324775495  72944: [exit ] __monstartup(aaaacc4c0750) depth: 0
+108370.324776370  72944: [entry] __cxa_atexit(aaaacc4c0720) depth: 0
+108370.324776453  72944: [exit ] __cxa_atexit(aaaacc4c0720) depth: 0
+108370.324777203  72944: [entry] main(aaaacc4c0a08) depth: 0
+108370.324777286  72944: [entry] str_cpy(aaaacc4c09a4) depth: 1
+108370.324850202  72944: [exit ] str_cpy(aaaacc4c09a4) depth: 1
+108370.324850910  72944: [entry] str_cpy(aaaacc4c09a4) depth: 1
+108370.324851243  72944: [exit ] str_cpy(aaaacc4c09a4) depth: 1
+108370.324851493  72944: [entry] str_cat(aaaacc4c0918) depth: 1
+108370.324851785  72944: [exit ] str_cat(aaaacc4c0918) depth: 1
+108370.324851993  72944: [entry] str_cpy(aaaacc4c09a4) depth: 1
+108370.324852243  72944: [exit ] str_cpy(aaaacc4c09a4) depth: 1
+108370.324852410  72944: [entry] str_cat(aaaacc4c0918) depth: 1
+108370.324852660  72944: [exit ] str_cat(aaaacc4c0918) depth: 1
+108370.324852827  72944: [exit ] main(aaaacc4c0a08) depth: 0
+""", sort='dump')
+
+    def build(self, name, cflags='', ldflags=''):
+        # cygprof doesn't support arguments now
+        if cflags.find('-finstrument-functions') >= 0:
+            return TestBase.TEST_SKIP
+
+        return TestBase.build(self, name, cflags, ldflags)
+
+    def prerun(self, timeout):
+        record_cmd = '%s record -d %s -A ^str_@arg1/s,arg2/s -R ^str_@retval/s %s' \
+                        % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
+        sp.call(record_cmd.split())
+        return TestBase.TEST_SUCCESS
+
+    def runcmd(self):
+        return '%s dump -d %s --no-args' % (TestBase.uftrace_cmd, TDIR)
+
+    def post(self, ret):
+        sp.call(['rm', '-rf', TDIR])
+        return ret

--- a/uftrace.c
+++ b/uftrace.c
@@ -95,6 +95,7 @@ enum options {
 	OPT_diff_policy,
 	OPT_event_full,
 	OPT_record,
+	OPT_no_args,
 	OPT_libname,
 	OPT_match_type,
 	OPT_no_randomize_addr,
@@ -179,6 +180,7 @@ __used static const char uftrace_help[] =
 "                             regex)\n"
 "      --max-stack=DEPTH      Set max stack depth to DEPTH (default: "
 	stringify(OPT_RSTACK_MAX) ")\n"
+"      --no-args              Do not show arguments and return value\n"
 "      --no-comment           Don't show comments of returned functions\n"
 "      --no-event             Disable (default) events\n"
 "      --no-sched             Disable schedule events\n"
@@ -250,6 +252,7 @@ static const struct option uftrace_options[] = {
 	REQ_ARG(argument, 'A'),
 	REQ_ARG(retval, 'R'),
 	NO_ARG(auto-args, 'a'),
+	NO_ARG(no-args, OPT_no_args),
 	REQ_ARG(patch, 'P'),
 	REQ_ARG(unpatch, 'U'),
 	REQ_ARG(size-filter, 'Z'),
@@ -953,6 +956,10 @@ static int parse_option(struct opts *opts, int key, char *arg)
 		opts->record = true;
 		break;
 
+	case OPT_no_args:
+		opts->show_args = false;
+		break;
+
 	case OPT_libname:
 		opts->libname = true;
 		break;
@@ -1312,6 +1319,7 @@ int main(int argc, char *argv[])
 		.sort_column	= OPT_SORT_COLUMN,
 		.event_skip_out = true,
 		.patt_type      = PATT_REGEX,
+		.show_args      = true,
 	};
 	int ret = -1;
 	char *pager = NULL;

--- a/uftrace.h
+++ b/uftrace.h
@@ -275,6 +275,7 @@ struct opts {
 	bool nest_libcall;
 	bool record;
 	bool auto_args;
+	bool show_args;
 	bool libname;
 	bool no_randomize_addr;
 	bool graphviz;


### PR DESCRIPTION
It needs to provide a way to hide args/retval to reduce the amount of
dump output.  It has to be implemented for replay command later on.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>