### PR TITLE
replay: Make arguments and retvals colorful

### DIFF
--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -482,9 +482,9 @@ void get_argspec_string(struct uftrace_task_reader *task,
 	assert(arg_list && !list_empty(arg_list));
 
 	if (needs_paren)
-		print_args("(");
+		print_args("%s(%s", color_bold, color_reset);
 	else if (needs_assignment)
-		print_args(" = ");
+		print_args("%s = %s", color_bold, color_reset);
 
 	list_for_each_entry(spec, arg_list, list) {
 		char fmtstr[16];
@@ -498,7 +498,7 @@ void get_argspec_string(struct uftrace_task_reader *task,
 			continue;
 
 		if (i > 0)
-			print_args(", ");
+			print_args("%s, %s", color_bold, color_reset);
 
 		memset(val.v, 0, sizeof(val));
 		fmt = ARG_SPEC_CHARS[spec->fmt];
@@ -583,8 +583,11 @@ void get_argspec_string(struct uftrace_task_reader *task,
 				}
 				print_args("\\\"");
 			}
-			else
+			else {
+				print_args("%s", color_string);
 				print_args("\"%.*s\"", slen + newline, str);
+				print_args("%s", color_reset);
+			}
 
 			/* std::string can be represented as "TEXT"s from C++14 */
 			if (spec->fmt == ARG_FMT_STD_STRING)
@@ -597,8 +600,11 @@ void get_argspec_string(struct uftrace_task_reader *task,
 			char c;
 
 			memcpy(&c, data, 1);
-			if (isprint(c))
+			if (isprint(c)) {
+				print_args("%s", color_string);
 				print_args("'%c'", c);
+				print_args("%s", color_reset);
+			}
 			else
 				print_args("'\\x%02hhx'", c);
 			size = 1;
@@ -637,8 +643,11 @@ void get_argspec_string(struct uftrace_task_reader *task,
 						 task->rstack->time,
 						 (uint64_t)val.i);
 
-			if (sym)
+			if (sym) {
+				print_args("%s", color_fptr);
 				print_args("&%s", sym->name);
+				print_args("%s", color_reset);
+			}
 			else
 				print_args("%p", val.p);
 		}
@@ -660,10 +669,12 @@ void get_argspec_string(struct uftrace_task_reader *task,
 
 			memcpy(val.v, data, spec->size);
 			estr = get_enum_string(&dinfo->enums, spec->enum_str, val.i);
+			print_args("%s", color_enum);
 			if (strlen(estr) >= len)
 				print_args("<ENUM>");
 			else
 				print_args("%s", estr);
+			print_args("%s", color_reset);
 			free(estr);
 		}
 		else {
@@ -693,8 +704,7 @@ void get_argspec_string(struct uftrace_task_reader *task,
 	}
 
 	if (needs_paren) {
-		args[n] = ')';
-		args[n+1] = '\0';
+		print_args("%s)%s", color_bold, color_reset);
 	} else {
 		if (needs_semi_colon)
 			args[n++] = ';';

--- a/utils/auto-args.c
+++ b/utils/auto-args.c
@@ -511,7 +511,7 @@ char * convert_enum_val(struct enum_def *e_def, long val)
 	list_for_each_entry(e_val, &e_def->vals, list) {
 		if (e_val->val <= val) {
 			val -= e_val->val;
-			str = strjoin(str, e_val->str, "|");
+			str = strjoin(str, e_val->str, color_enum_or);
 		}
 
 		if (val == 0)

--- a/utils/debug.c
+++ b/utils/debug.c
@@ -33,6 +33,14 @@ enum color_setting log_color;
 enum color_setting out_color;
 int dbg_domain[DBG_DOMAIN_MAX];
 
+/* colored output for argspec display */
+const char *color_reset   = TERM_COLOR_RESET;
+const char *color_bold    = TERM_COLOR_BOLD;
+const char *color_string  = TERM_COLOR_MAGENTA;
+const char *color_fptr    = TERM_COLOR_CYAN;
+const char *color_enum    = TERM_COLOR_BLUE;
+const char *color_enum_or = TERM_COLOR_RESET TERM_COLOR_BOLD "|" TERM_COLOR_BLUE;
+
 static const struct color_code {
 	char		code;
 	const char	*color;
@@ -84,6 +92,15 @@ void setup_color(enum color_setting color)
 	else {
 		log_color = color;
 		out_color = color;
+	}
+
+	if (out_color != COLOR_ON) {
+		color_reset   = "";
+		color_bold    = "";
+		color_string  = "";
+		color_fptr    = "";
+		color_enum    = "";
+		color_enum_or = "|";
 	}
 }
 

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -48,6 +48,14 @@ extern int debug;
 extern FILE *logfp;
 extern FILE *outfp;
 
+/* colored output for argspec display */
+extern const char *color_reset;
+extern const char *color_bold;
+extern const char *color_string;
+extern const char *color_fptr;
+extern const char *color_enum;
+extern const char *color_enum_or;
+
 /* must change DBG_DOMAIN_STR (in mcount.h) as well */
 enum debug_domain {
 	DBG_UFTRACE	= 0,


### PR DESCRIPTION
Automatic argument display is great but it sometimes looks too verbose
with too many arguments and return values.

This patch makes arguments and return values more colorful if they are
some special types.  The color scheme is as follows:

  - string types     : magenta
  - char types       : magenta
  - enum types       : blue
  - function pointer : cyan
  - parens and comma : bold

This would make users more comfortable to identify those values.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>