### PR TITLE
tests: Fix watch_cpu test with -F main

### DIFF
--- a/tests/t208_watch_cpu.py
+++ b/tests/t208_watch_cpu.py
@@ -24,7 +24,7 @@ class TestCase(TestBase):
 
     def runcmd(self):
         uftrace = TestBase.uftrace_cmd
-        options = '-W cpu -E "linux:*"'
+        options = '-F main -W cpu -E "linux:*"'
         program = 't-' + self.name
         return '%s %s %s' % (uftrace, options, program)
 


### PR DESCRIPTION
This patch fixes the below test failure.
```
  $ ./runtest.py -dp -O1 208
  Test case                 pg
  ------------------------: O1
  t208_watch_cpu: diff result of -pg -O1
  --- expect      2018-11-20 12:33:26.146855841 +0900
  +++ result      2018-11-20 12:33:26.146855841 +0900
  @@ -1,3 +1,6 @@
  - main() {
  + __monstartup() {
      /* watch:cpu (cpu=N) */
  + } /* __monstartup */
  + __cxa_atexit();
  + main() {
      sysconf();

  208 watch_cpu           : NG
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>