### PR TITLE
test: Turn off color before running unittest

### DIFF
--- a/tests/unittest.c
+++ b/tests/unittest.c
@@ -218,6 +218,8 @@ int main(int argc, char *argv[])
 	size_t i, test_num = 0;
 	int c;
 
+	setup_color(COLOR_OFF);
+
 	if (setup_unit_test(&test_cases, &test_num) < 0) {
 		printf("Cannot run unit tests - failed to load test cases\n");
 		return -1;


### PR DESCRIPTION
Some unittests might be failed because of color settings, so it'd be
better to turn off color before running unittest.

Fixed: #606

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>