### PR TITLE
test: Add -pg and -g flags to tests/Makefile

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,5 @@
 TEST_CFLAGS  += -include $(srcdir)/tests/unittest.h -Wno-sign-compare
+TEST_CFLAGS  += -pg -g
 
 UNIT_TEST_SRC := $(srcdir)/uftrace.c
 UNIT_TEST_SRC += $(wildcard $(srcdir)/cmds/*.c)


### PR DESCRIPTION
unittest is a useful tool to be a target of uftrace itself, so it'd be
useful to be compiled with -pg and -g flags unconditionally so that it
can be directly traced to understand uftrace internal.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>