### PR TITLE
test: pass worker count by MAKEFLAGS -j argument

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,12 +9,14 @@ UNIT_TEST_SRC += $(wildcard $(srcdir)/libmcount/*.c)
 UNIT_TEST_OBJ := $(patsubst %.c,%.ot,$(UNIT_TEST_SRC))
 UNIT_TEST_OBJ := $(filter-out %-nop.ot,$(UNIT_TEST_OBJ))
 
+WORKER = $(filter -j%, $(MAKEFLAGS))
+
 include $(srcdir)/Makefile.include
 
 test: test_unit test_run
 
 test_run:
-	./runtest.py $(TESTARG)
+	./runtest.py $(WORKER) $(TESTARG)
 
 test_unit: unittest
 	./unittest $(TESTARG)


### PR DESCRIPTION
Modified tests/Makefile to pass worker count by MAKEFLAGS -j argument.

before:
    $ make test TESTARG=-j8

after:
    $ make test -j 2
    ...
    ./runtest.py -j2
    Start 211 tests with 2 worker

Signed-off-by: Daniel T. Lee <danieltimlee@gmail.com>