### PR TITLE
mcount: rename ambiguous argument name

### DIFF
--- a/libmcount/record.c
+++ b/libmcount/record.c
@@ -23,25 +23,25 @@
 
 #define ARG_STR_MAX	98
 
-static struct mcount_shmem_buffer *allocate_shmem_buffer(char *buf, size_t size,
+static struct mcount_shmem_buffer *allocate_shmem_buffer(char *sess_id, size_t size,
 							 int tid, int idx)
 {
 	int fd;
 	int saved_errno = 0;
 	struct mcount_shmem_buffer *buffer = NULL;
 
-	snprintf(buf, size, SHMEM_SESSION_FMT, mcount_session_name(), tid, idx);
+	snprintf(sess_id, size, SHMEM_SESSION_FMT, mcount_session_name(), tid, idx);
 
-	fd = shm_open(buf, O_RDWR | O_CREAT | O_TRUNC, 0600);
+	fd = shm_open(sess_id, O_RDWR | O_CREAT | O_TRUNC, 0600);
 	if (fd < 0) {
 		saved_errno = errno;
-		pr_dbg("failed to open shmem buffer: %s\n", buf);
+		pr_dbg("failed to open shmem buffer: %s\n", sess_id);
 		goto out;
 	}
 
 	if (ftruncate(fd, shmem_bufsize) < 0) {
 		saved_errno = errno;
-		pr_dbg("failed to resizing shmem buffer: %s\n", buf);
+		pr_dbg("failed to resizing shmem buffer: %s\n", sess_id);
 		goto out;
 	}
 
@@ -49,7 +49,7 @@ static struct mcount_shmem_buffer *allocate_shmem_buffer(char *buf, size_t size,
 		      MAP_SHARED, fd, 0);
 	if (buffer == MAP_FAILED) {
 		saved_errno = errno;
-		pr_dbg("failed to mmap shmem buffer: %s\n", buf);
+		pr_dbg("failed to mmap shmem buffer: %s\n", sess_id);
 		buffer = NULL;
 		goto out;
 	}


### PR DESCRIPTION
Function allocate_shmem_buffer() first argument's name "buf"
seems pretty ambiguous.

Paired to cmds/record.c's record_mmap_file(), both of the function
uses shared memory by leveraging mmap() through sess_id.

static void record_mmap_file(const char *dirname, char *sess_id, int bufsize)

And from this viewpoint, since it doesn't mean anything,
argument name "buf" seems meaningless.

Signed-off-by: Daniel T. Lee <danieltimlee@gmail.com>