### PR TITLE
utils: enable @k as an abbreviated form of @kernel

### DIFF
--- a/libmcount/event.c
+++ b/libmcount/event.c
@@ -160,7 +160,7 @@ int mcount_setup_events(char *dirname, char *event_str,
 		if (sep) {
 			*sep++ = '\0';
 
-			kernel = strstr(sep, "@kernel");
+			kernel = has_kernel_filter(sep);
 			if (kernel)
 				continue;
 

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -960,7 +960,7 @@ static void setup_trigger(char *filter_str, struct symtabs *symtabs,
 			goto next;
 
 		/* skip unintended kernel symbols */
-		if (module && !strcasecmp(module, "kernel") &&
+		if (module && has_kernel_opt(module) &&
 		    !setting->allow_kernel)
 			goto next;
 
@@ -997,7 +997,7 @@ static void setup_trigger(char *filter_str, struct symtabs *symtabs,
 							&symtabs->dinfo,
 							setting);
 			}
-			else if (!strcasecmp(module, "kernel")) {
+			else if (has_kernel_opt(module)) {
 				ret = add_trigger_entry(root, get_kernel_symtab(),
 							&patt, &tr,
 							&symtabs->dinfo,
@@ -1195,13 +1195,13 @@ char * uftrace_clear_kernel(char *filter_str)
 	if (filter_str == NULL)
 		return NULL;
 
-	if (strstr(filter_str, "@kernel") == NULL)
+	if (has_kernel_filter(filter_str) == NULL)
 		return xstrdup(filter_str);
 
 	strv_split(&filters, filter_str, ";");
 
 	strv_for_each(&filters, pos, j) {
-		if (strstr(pos, "@kernel") == NULL)
+		if (has_kernel_filter(pos) == NULL)
 			ret = strjoin(ret, pos, ";");
 	}
 	strv_free(&filters);

--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -339,7 +339,7 @@ static void build_kernel_filter(struct uftrace_kernel_writer *kernel,
 	strv_for_each(&strv, name, j) {
 		struct uftrace_pattern patt;
 
-		pos = strstr(name, "@kernel");
+		pos = has_kernel_filter(name);
 		if (pos == NULL)
 			continue;
 		*pos = '\0';
@@ -430,7 +430,7 @@ static void build_kernel_event(struct uftrace_kernel_writer *kernel,
 	strv_for_each(&strv, name, j) {
 		struct uftrace_pattern patt;
 
-		pos = strstr(name, "@kernel");
+		pos = has_kernel_filter(name);
 		if (pos == NULL)
 			continue;
 		*pos = '\0';

--- a/utils/kernel.h
+++ b/utils/kernel.h
@@ -2,6 +2,7 @@
 #define UFTRACE_KERNEL_H
 
 #include "libtraceevent/event-parse.h"
+#include "utils/utils.h"
 
 #define KERNEL_NOP_TRACER    "nop"
 #define KERNEL_GRAPH_TRACER  "function_graph"
@@ -76,7 +77,7 @@ static inline bool has_kernel_data(struct uftrace_kernel_reader *kernel)
 
 static inline bool has_kernel_event(char *events)
 {
-	return events && strstr(events, "@kernel");
+	return events && has_kernel_filter(events);
 }
 
 bool check_kernel_pid_filter(void);

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -263,6 +263,31 @@ static inline bool host_is_lp64(void)
 	return get_elf_class() == ELFCLASS64;
 }
 
+static inline char* has_kernel_opt(char *buf)
+{
+	int idx = 0;
+
+	if (!strncasecmp(buf, "kernel", 6))
+		idx = 6;
+	else if (!strncasecmp(buf, "k", 1))
+		idx = 1;
+
+	if (idx && (buf[idx] == '\0' || buf[idx] == ','))
+		return buf;
+
+	return NULL;
+}
+
+static inline char* has_kernel_filter(char *buf)
+{
+	char *opt = strchr(buf, '@');
+
+	if (opt && has_kernel_opt(opt + 1))
+		return opt;
+
+	return NULL;
+}
+
 struct uftrace_time_range {
 	uint64_t first;
 	uint64_t start;


### PR DESCRIPTION
this commit allows passing '@k' for kernel option as an abbreviated form of '@kernel'

created a util function for strstr(buf, '@k')

// before
$uftrace -K 2 -F sys_openat@kernel --force ./echo-sync
// after
$uftrace -K 2 -F sys_openat@k --force ./echo-sync

Signed-off-by: Daniel T. Lee <danieltimlee@gmail.com>