### PR TITLE
tui: Add C/E keys for nested collapse/expand

### DIFF
--- a/doc/uftrace-tui.md
+++ b/doc/uftrace-tui.md
@@ -122,7 +122,8 @@ Following keys can be used in the TUI window:
  * `I`:                   Show uftrace info
  * `S`:                   Show session list
  * `O`:                   Open editor for current function
- * `c`/`e`:               Collapse/Expand graph node
+ * `c`/`e`:               Collapse/Expand direct children graph node
+ * `C`/`E`:               Collapse/Expand all descendant graph node
  * `n`/`p`:               Move to next/prev sibling (in graph mode)
  * `u`:                   Move up to parent (in graph mode)
  * `l`:                   Move to the longest executed child (in graph mode)


### PR DESCRIPTION
Current c/e works for collapse/expand its direct children, but it
doesn't fold/unfold in a nested manner.

This patch adds C/E keys for nested collapse/expand.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>