### PR TITLE
uftrace: Apply --no-libcall to analysis commands

### DIFF
--- a/cmds/script.c
+++ b/cmds/script.c
@@ -33,6 +33,10 @@ static int run_script_for_rstack(struct uftrace_data *handle,
 	sym = task_find_sym(sessions, task, rstack);
 	symname = symbol_getname(sym, rstack->addr);
 
+	/* skip it if --no-libcall is given */
+	if (!opts->libcall && sym && sym->type == ST_PLT_FUNC)
+		goto out;
+
 	task->timestamp_last = task->timestamp;
 	task->timestamp = rstack->time;
 

--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -388,7 +388,8 @@ static void update_report_node(struct uftrace_task_reader *task, char *symname,
 }
 
 static int build_tui_node(struct uftrace_task_reader *task,
-			  struct uftrace_record *rec)
+			  struct uftrace_record *rec,
+			  struct opts *opts)
 {
 	struct uftrace_task_graph *tg;
 	struct uftrace_graph *graph;
@@ -415,6 +416,11 @@ static int build_tui_node(struct uftrace_task_reader *task,
 	if (rec->type == UFTRACE_ENTRY || rec->type == UFTRACE_EXIT) {
 		sym = task_find_sym_addr(&task->h->sessions,
 					 task, rec->time, addr);
+
+		/* skip it if --no-libcall is given */
+		if (!opts->libcall && sym && sym->type == ST_PLT_FUNC)
+			return 0;
+
 		name = symbol_getname(sym, addr);
 
 		if (rec->type == UFTRACE_EXIT)
@@ -2545,7 +2551,7 @@ int command_tui(int argc, char *argv[], struct opts *opts)
 		if (!fstack_check_filter(task))
 			continue;
 
-		ret = build_tui_node(task, rec);
+		ret = build_tui_node(task, rec, opts);
 		if (ret)
 			break;
 	}

--- a/tests/t215_no_libcall_replay.py
+++ b/tests/t215_no_libcall_replay.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+import subprocess as sp
+
+TDIR='xxx'
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'signal', """
+# DURATION     TID     FUNCTION
+            [ 73755] | main() {
+   0.236 us [ 73755] |   foo();
+            [ 73755] |   sighandler() {
+   0.144 us [ 73755] |     bar();
+   0.734 us [ 73755] |   } /* sighandler */
+   0.117 us [ 73755] |   foo();
+  18.227 us [ 73755] | } /* main */
+""")
+
+    def pre(self):
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
+        sp.call(record_cmd.split())
+        return TestBase.TEST_SUCCESS
+
+    def runcmd(self):
+        return '%s replay --no-libcall -d %s' % (TestBase.uftrace_cmd, TDIR)
+
+    def post(self, ret):
+        sp.call(['rm', '-rf', TDIR])
+        return ret

--- a/tests/t216_no_libcall_report.py
+++ b/tests/t216_no_libcall_report.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+import subprocess as sp
+
+TDIR='xxx'
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'signal', """
+  Total time   Self time       Calls  Function
+  ==========  ==========  ==========  ====================
+   18.227 us    1.991 us           1  main
+    0.734 us    0.590 us           1  sighandler
+    0.353 us    0.353 us           2  foo
+    0.144 us    0.144 us           1  bar
+""", sort='report')
+
+    def pre(self):
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
+        sp.call(record_cmd.split())
+        return TestBase.TEST_SUCCESS
+
+    def runcmd(self):
+        return '%s report --no-libcall -d %s' % (TestBase.uftrace_cmd, TDIR)
+
+    def post(self, ret):
+        sp.call(['rm', '-rf', TDIR])
+        return ret

--- a/tests/t217_no_libcall_dump.py
+++ b/tests/t217_no_libcall_dump.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+import subprocess as sp
+
+TDIR='xxx'
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'signal', """
+uftrace file header: magic         = 4674726163652100
+uftrace file header: version       = 4
+uftrace file header: header size   = 40
+uftrace file header: endian        = 1 (little)
+uftrace file header: class         = 2 (64 bit)
+uftrace file header: features      = 0x363 (PLTHOOK | TASK_SESSION | SYM_REL_ADDR | MAX_STACK | PERF_EVENT | AUTO_ARGS)
+uftrace file header: info          = 0x3bff
+
+reading 73755.dat
+50895.869952000  73755: [entry] main(400787) depth: 0
+50895.869952297  73755: [entry] foo(40071f) depth: 1
+50895.869952533  73755: [exit ] foo(40071f) depth: 1
+50895.869966333  73755: [entry] sighandler(400750) depth: 2
+50895.869966473  73755: [entry] bar(400734) depth: 3
+50895.869966617  73755: [exit ] bar(400734) depth: 3
+50895.869967067  73755: [exit ] sighandler(400750) depth: 2
+50895.869969790  73755: [entry] foo(40071f) depth: 1
+50895.869969907  73755: [exit ] foo(40071f) depth: 1
+50895.869970227  73755: [exit ] main(400787) depth: 0
+""", sort='dump')
+
+    def pre(self):
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
+        sp.call(record_cmd.split())
+        return TestBase.TEST_SUCCESS
+
+    def runcmd(self):
+        return '%s dump --no-libcall -d %s' % (TestBase.uftrace_cmd, TDIR)
+
+    def post(self, ret):
+        sp.call(['rm', '-rf', TDIR])
+        return ret

--- a/tests/t218_no_libcall_graph.py
+++ b/tests/t218_no_libcall_graph.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+import subprocess as sp
+
+TDIR='xxx'
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'signal', """
+# Function Call Graph for 't-signal' (session: 0fa6f0e678964bde)
+========== FUNCTION CALL GRAPH ==========
+# TOTAL TIME   FUNCTION
+   18.227 us : (1) t-signal
+   18.227 us : (1) main
+    0.353 us :  +-(2) foo
+             :  | 
+    0.734 us :  +-(1) sighandler
+    0.144 us :    (1) bar
+""", sort='graph')
+
+    def pre(self):
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
+        sp.call(record_cmd.split())
+        return TestBase.TEST_SUCCESS
+
+    def runcmd(self):
+        return '%s graph --no-libcall -d %s' % (TestBase.uftrace_cmd, TDIR)
+
+    def post(self, ret):
+        sp.call(['rm', '-rf', TDIR])
+        return ret

--- a/tests/t219_no_libcall_script.py
+++ b/tests/t219_no_libcall_script.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+import subprocess as sp
+
+TDIR='xxx'
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'signal', """
+uftrace_begin(ctx)
+  record  : False
+  version : v0.9.1-161-g13755 ( dwarf python tui perf sched )
+  cmds    :
+
+50895.869952000  73755: [entry] main(400787) depth: 0
+50895.869952297  73755: [entry] foo(40071f) depth: 1
+50895.869952533  73755: [exit ] foo(40071f) depth: 1
+50895.869966333  73755: [entry] sighandler(400750) depth: 1
+50895.869966473  73755: [entry] bar(400734) depth: 2
+50895.869966617  73755: [exit ] bar(400734) depth: 2
+50895.869967067  73755: [exit ] sighandler(400750) depth: 1
+50895.869969790  73755: [entry] foo(40071f) depth: 1
+50895.869969907  73755: [exit ] foo(40071f) depth: 1
+50895.869970227  73755: [exit ] main(400787) depth: 0
+
+uftrace_end()
+""", sort='dump')
+
+    def pre(self):
+        record_cmd = '%s record -d %s %s' % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
+        sp.call(record_cmd.split())
+        return TestBase.TEST_SUCCESS
+
+    def runcmd(self):
+        return '%s script -S %s/scripts/dump.py --no-libcall -d %s' % \
+               (TestBase.uftrace_cmd, TestBase.basedir, TDIR)
+
+    def post(self, ret):
+        sp.call(['rm', '-rf', TDIR])
+        return ret

--- a/utils/fstack.h
+++ b/utils/fstack.h
@@ -146,7 +146,7 @@ int fstack_update(int type, struct uftrace_task_reader *task,
 		  struct fstack *fstack);
 struct uftrace_task_reader *fstack_skip(struct uftrace_data *handle,
 				       struct uftrace_task_reader *task,
-				       int curr_depth, bool event_skip_out);
+				       int curr_depth, struct opts *opts);
 bool fstack_check_filter(struct uftrace_task_reader *task);
 bool fstack_check_opts(struct uftrace_task_reader *task, struct opts *opts);
 


### PR DESCRIPTION
Since the option --no-libcall only work for record command, it'd be
better to apply it to other analysis commands including replay, report,
dump, graph, tui, and script.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>