### PR TITLE
uftrace: Fix missing changes of --no-libcall apply

### DIFF
--- a/cmds/report.c
+++ b/cmds/report.c
@@ -485,6 +485,7 @@ static void report_diff(struct uftrace_data *handle, struct opts *opts)
 		.dirname = opts->diff,
 		.kernel  = opts->kernel,
 		.depth   = opts->depth,
+		.libcall = opts->libcall,
 	};
 	struct diff_data data = {
 		.dirname = opts->diff,

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -2275,6 +2275,10 @@ TEST_CASE(fstack_skip)
 	struct uftrace_data *handle = &fstack_test_handle;
 	struct uftrace_task_reader *task;
 	struct uftrace_trigger tr = { 0, };
+	struct opts opts = {
+		.event_skip_out = true,
+		.libcall        = true,
+	};
 
 	TEST_EQ(fstack_test_setup_file(handle, 1), 0);
 
@@ -2290,7 +2294,7 @@ TEST_CASE(fstack_skip)
 	TEST_EQ((uint64_t)task->rstack->addr,  (uint64_t)test_record[0][0].addr);
 
 	/* skip filtered records (due to depth) */
-	TEST_EQ(fstack_skip(handle, task, task->rstack->depth, true), task);
+	TEST_EQ(fstack_skip(handle, task, task->rstack->depth, &opts), task);
 	TEST_EQ(task->tid, test_tids[0]);
 	TEST_EQ((uint64_t)task->rstack->type,  (uint64_t)test_record[0][3].type);
 	TEST_EQ((uint64_t)task->rstack->depth, (uint64_t)test_record[0][3].depth);


### PR DESCRIPTION
Some features are not well tested after applying --no-libcall to
analysis commands.  This is a fixup patch for that.

Before:
```
  $ make test
  [039] fstack_skip                   : SIG
      ...
  067 report_diff         : NG NG NG NG NG NG NG NG NG NG
  158 report_diff_policy1 : NG NG NG NG NG NG NG NG NG NG
  159 report_diff_policy2 : NG NG NG NG NG NG NG NG NG NG
  160 report_diff_policy3 : NG NG NG NG NG NG NG NG NG NG
  177 report_diff_policy4 : NG NG NG NG NG NG NG NG NG NG
```
After:
```
  $ make test
  [039] fstack_skip                   : PASS
      ...
  067 report_diff         : OK OK OK OK OK OK OK OK OK OK
  158 report_diff_policy1 : OK OK OK OK OK OK OK OK OK OK
  159 report_diff_policy2 : OK OK OK OK OK OK OK OK OK OK
  160 report_diff_policy3 : OK OK OK OK OK OK OK OK OK OK
  177 report_diff_policy4 : OK OK OK OK OK OK OK OK OK OK
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>