### PR TITLE
tui: Add a loading message before main screen shown

### DIFF
--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -2518,6 +2518,16 @@ out:
 	tui_session_finish();
 }
 
+static void display_loading_msg()
+{
+	char *tuimsg = "Building graph for TUI...";
+	int row, col;
+
+	getmaxyx(stdscr, row, col);
+	mvprintw(row / 2, (col - strlen(tuimsg)) / 2, "%s", tuimsg);
+	refresh();
+}
+
 int command_tui(int argc, char *argv[], struct opts *opts)
 {
 	int ret;
@@ -2538,6 +2548,9 @@ int command_tui(int argc, char *argv[], struct opts *opts)
 	noecho();
 
 	atexit(tui_cleanup);
+
+	/* Print a message before main screen is launched. */
+	display_loading_msg();
 
 	tui_setup(&handle, opts);
 	fstack_setup_filters(opts, &handle);


### PR DESCRIPTION
Since it may take some time to build graph when tui is launched, users
may get confused if it's currently working or just stuck.

To inform that tui is working, this patch adds a kind message at the
center of screen showing "Building graph for TUI...".

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>