### PR TITLE
doc: Add --no-libcall to man pages of analysis commands

### DIFF
--- a/doc/uftrace-dump.md
+++ b/doc/uftrace-dump.md
@@ -92,6 +92,9 @@ OPTIONS
 \--no-event
 :   Do not show any events.
 
+\--no-libcall
+:   Do not show library calls.
+
 \--demangle=*TYPE*
 :   Use demangled C++ symbol names for filters, triggers, arguments and/or
     return values.  Possible values are "full", "simple" and "no".  Default

--- a/doc/uftrace-graph.md
+++ b/doc/uftrace-graph.md
@@ -86,6 +86,9 @@ OPTIONS
 \--no-event
 :   Do not show any events.
 
+\--no-libcall
+:   Do not show library calls.
+
 \--demangle=*TYPE*
 :   Use demangled C++ symbol names for filters, triggers, arguments and/or
     return values.  Possible values are "full", "simple" and "no".  Default

--- a/doc/uftrace-replay.md
+++ b/doc/uftrace-replay.md
@@ -115,6 +115,9 @@ OPTIONS
 \--no-event
 :   Do not show any events.
 
+\--no-libcall
+:   Do not show library calls.
+
 \--libname
 :   Show libname name along with function name.
 

--- a/doc/uftrace-report.md
+++ b/doc/uftrace-report.md
@@ -109,6 +109,9 @@ OPTIONS
 \--no-event
 :   Do not show any events.
 
+\--no-libcall
+:   Do not show library calls.
+
 \--demangle=*TYPE*
 :   Use demangled C++ symbol names for filters, triggers, arguments and/or
     return values.  Possible values are "full", "simple" and "no".  Default

--- a/doc/uftrace-script.md
+++ b/doc/uftrace-script.md
@@ -33,9 +33,9 @@ OPTIONS
     See 'uftrace-replay' for details.
 
 -t *TIME*, \--time-filter=*TIME*
-:   Do not show functions which run under the time threshold.  If some functions
-    explicitly have the 'trace' trigger applied, those are always traced
-    regardless of execution time.
+:   Do not run script for functions which run under the time threshold.  If some
+    functions explicitly have the 'trace' trigger applied, those are always
+    traced regardless of execution time.
 
 \--tid=*TID*[,*TID*,...]
 :   Only print functions called by the given threads.  To see the list of
@@ -46,11 +46,10 @@ OPTIONS
 :   Set trace limit in nesting level.
 
 -r *RANGE*, \--time-range=*RANGE*
-:   Only show functions executed within the time RANGE.  The RANGE can be
-    \<start\>~\<stop\> (separated by "~") and one of \<start\> and \<stop\> can
-    be omitted.  The \<start\> and \<stop\> are timestamp or elapsed time if
-    they have \<time_unit\> postfix, for example '100us'.  The timestamp or
-    elapsed time can be shown with `-f time` or `-f elapsed` option respectively.
+:   Only run script for functions executed within the time RANGE.  The RANGE can
+    be \<start\>~\<stop\> (separated by "~") and one of \<start\> and \<stop\>
+    can be omitted.  The \<start\> and \<stop\> are timestamp or elapsed time if
+    they have \<time_unit\> postfix, for example '100us'.
 
 -S *SCRIPT_PATH*, \--script=*SCRIPT_PATH*
 :   Add a script to do additional work at the entry and exit of function.
@@ -62,6 +61,9 @@ OPTIONS
 \--match=*TYPE*
 :   Use pattern match using TYPE.  Possible types are `regex` and `glob`.
     Default is `regex`.
+
+\--no-libcall
+:   Do not run script for library calls.
 
 
 EXAMPLES

--- a/doc/uftrace-tui.md
+++ b/doc/uftrace-tui.md
@@ -68,6 +68,9 @@ OPTIONS
 \--no-event
 :   Do not show any events.
 
+\--no-libcall
+:   Do not show library calls.
+
 
 OUTLINE
 =======


### PR DESCRIPTION
The option --no-libcall is added to many analysis commands, but didn't
update the man pages.  This patch adds the explanation to each analysis
command.

It also updates some description in script command because the meaning
of "show" doesn't make sence for script execution.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>