### PR TITLE
symbol: Display data symbol with offset

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -391,18 +391,22 @@ static void pr_args(struct fstack_arguments *args)
 		else {
 			struct sym *sym;
 			long long val = 0;
+			uint64_t addr;
 
 			memcpy(&val, ptr, spec->size);
 
+			addr = val;
 			sym = task_find_sym_addr(sessions, task,
-						 task->rstack->time,
-						 (uint64_t)val);
+						 task->rstack->time, addr);
 
 			pr_out("  args[%d] %c%d: 0x%0*llx", i,
 			       ARG_SPEC_CHARS[spec->fmt], spec->size * 8,
 			       spec->size * 2, val);
-			if (sym)
-				pr_out(" (&%s)", sym->name);
+			if (sym) {
+				char *name = symbol_getname_offset(sym, addr);
+				pr_out(" (&%s)", name);
+				free(name);
+			}
 			pr_out("\n");
 
 			size = spec->size;

--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -694,6 +694,7 @@ void get_argspec_string(struct uftrace_task_reader *task,
 			struct uftrace_session_link *sessions = &task->h->sessions;
 			struct uftrace_session *s;
 			struct sym *sym;
+			uint64_t addr;
 
 			if (spec->fmt != ARG_FMT_AUTO)
 				memcpy(val.v, data, spec->size);
@@ -701,12 +702,15 @@ void get_argspec_string(struct uftrace_task_reader *task,
 			s = find_task_session(sessions, task->t,
 					      task->rstack->time);
 
-			sym = find_symtabs(&s->symtabs, val.ll);
+			addr = val.ll;
+			sym = find_symtabs(&s->symtabs, addr);
 
 			if (sym) {
+				char *name = symbol_getname_offset(sym, addr);
 				print_args("%s", color_symbol);
-				print_args("&%s", sym->name);
+				print_args("&%s", name);
 				print_args("%s", color_reset);
+				free(name);
 			}
 			else {
 				assert(idx < ARRAY_SIZE(len_mod));

--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -1663,6 +1663,21 @@ void symbol_putname(struct sym *sym, char *name)
 	free(name);
 }
 
+char *symbol_getname_offset(struct sym *sym, uint64_t addr)
+{
+	char *name;
+
+	if (addr == sym->addr)
+		name = xstrdup(sym->name);
+	else if (sym->addr < addr && addr < sym->addr + sym->size)
+		xasprintf(&name, "%s+%"PRIu64, sym->name, addr - sym->addr);
+	else
+		name = xstrdup("<unknown>");
+
+	/* the return string has to be free-ed after use. */
+	return name;
+}
+
 void print_symtabs(struct symtabs *symtabs)
 {
 	size_t i;

--- a/utils/symbol.h
+++ b/utils/symbol.h
@@ -167,6 +167,8 @@ void save_symbol_file(struct symtabs *symtabs, const char *dirname,
 char *symbol_getname(struct sym *sym, uint64_t addr);
 void symbol_putname(struct sym *sym, char *name);
 
+char *symbol_getname_offset(struct sym *sym, uint64_t addr);
+
 struct dynsym_idxlist {
 	unsigned *idx;
 	unsigned count;


### PR DESCRIPTION
The symbol address search is done based on ranged comparison.  It may be
useful for finding functions, but it'd be better to show its offset when
it comes to data symbols.

Source:
```
  int a[] = { 1, 2, 3, 4 };
  void foo(int *a, int *b, int *c, int *d) { }
  int main()
  {
      foo(&a[0], &a[1], &a[2], &a[3]);
      return 0;
  }
```
Before:
```
  $ uftrace -a a.out
  # DURATION     TID     FUNCTION
     1.867 us [ 40216] | __monstartup();
     1.080 us [ 40216] | __cxa_atexit();
              [ 40216] | main() {
     1.766 us [ 40216] |   foo(&a, &a, &a, &a);
     3.096 us [ 40216] | } = 0; /* main */
```
After:
```
  $ uftrace -a a.out
  # DURATION     TID     FUNCTION
     1.867 us [ 40216] | __monstartup();
     1.080 us [ 40216] | __cxa_atexit();
              [ 40216] | main() {
     1.766 us [ 40216] |   foo(&a, &a+4, &a+8, &a+12);
     3.096 us [ 40216] | } = 0; /* main */
```
The change is applied to replay and dump commands.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>