### PR TITLE
build: Fix a build error for i386 in x86_64 machine

### DIFF
--- a/arch/i386/Makefile
+++ b/arch/i386/Makefile
@@ -1,4 +1,4 @@
-LINKFLAGS := -r
+LINKFLAGS := -r -m elf_i386
 
 sdir := $(srcdir)/arch/i386
 odir := $(objdir)/arch/i386


### PR DESCRIPTION
This patch is to fix a build error for i386 in x86_64 machine.
```
  $ ARCH=i386 CFLAGS=-m32 LDFLAGS=-m32 ./configure
  uftrace detected system features:
  ...         prefix: /usr/local
  ...         libelf: [ on  ] - more flexible ELF data handling
  ...          libdw: [ on  ] - DWARF debug info support
  ...   libpython2.7: [ OFF ] - python scripting support
  ...    libncursesw: [ OFF ] - TUI support
  ...   cxa_demangle: [ on  ] - full demangler support with libstdc++
  ...     perf_event: [ on  ] - perf (PMU) event support
  ...       schedule: [ on  ] - scheduler event support

  $ make
    CC       arch/i386/cpuinfo.o
    LINK     arch/i386/uftrace.o
  ld: Relocatable linking with relocations from format elf32-i386
      (/home/uftrace/arch/i386/cpuinfo.o) to format elf64-x86-64
      (/home/uftrace/arch/i386/uftrace.o) is not supported
  Makefile:23: recipe for target '/home/uftrace/arch/i386/uftrace.o' failed
  make[1]: *** [/home/uftrace/arch/i386/uftrace.o] Error 1
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>