### PR TITLE
info: Show signal string for exit status

### DIFF
--- a/cmds/info.c
+++ b/cmds/info.c
@@ -1105,8 +1105,8 @@ void process_uftrace_info(struct uftrace_data *handle, struct opts *opts,
 				 WEXITSTATUS(status));
 		}
 		else if (WIFSIGNALED(status)) {
-			snprintf(buf, sizeof(buf), "terminated by signal: %d",
-				 WTERMSIG(status));
+			snprintf(buf, sizeof(buf), "terminated by signal: %d (%s)",
+				 WTERMSIG(status), strsignal(WTERMSIG(status)));
 		}
 		else {
 			snprintf(buf, sizeof(buf), "unknown exit status: %d",


### PR DESCRIPTION
It'd be more readable for users to show signal string of exit status in
uftrace info output.

Here are the example outputs:
```
  # exit status         : exited with code: 0
  # exit status         : terminated by signal: 7 (Bus error)
  # exit status         : terminated by signal: 11 (Segmentation fault)
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>