### PR TITLE
arm: Handle struct return type by keeping more regs on stack

### DIFF
--- a/arch/arm/mcount.S
+++ b/arch/arm/mcount.S
@@ -62,18 +62,18 @@ END(__gnu_mcount_nc)
 
 
 ENTRY(mcount_return)
-	push 	{r0-r1, lr, pc}  /* ensure 8-byte alignment */
+	push 	{r0-r3, lr, pc}  /* ensure 8-byte alignment */
 	mov	r0, sp
 #ifdef HAVE_ARM_HARDFP
-	vpush	{d0}
+	vpush	{d0-d1}
 #endif
 
 	bl 	mcount_exit
 
 #if HAVE_ARM_HARDFP
-	vpop	{d0}
+	vpop	{d0-d1}
 #endif
 	/* update return address (pc) in the stack */
-	str 	r0, [sp, #12]
-	pop 	{r0-r1, lr, pc}
+	str 	r0, [sp, #20]
+	pop 	{r0-r3, lr, pc}
 END(mcount_return)

--- a/arch/arm/plthook.S
+++ b/arch/arm/plthook.S
@@ -54,18 +54,18 @@ END(plt_hooker)
 
 
 ENTRY(plthook_return)
-	push {r0-r1, lr, pc}  /* ensure 8-byte alignment */
+	push {r0-r3, lr, pc}  /* ensure 8-byte alignment */
 	mov r0, sp
 #ifdef HAVE_ARM_HARDFP
-	vpush {d0}
+	vpush {d0-d1}
 #endif
 
 	bl plthook_exit
 
 #ifdef HAVE_ARM_HARDFP
-	vpop {d0}
+	vpop {d0-d1}
 #endif
 	/* update return address (pc) in the stack */
-	str r0, [sp, #12]
-	pop {r0-r1, lr, pc}
+	str r0, [sp, #20]
+	pop {r0-r3, lr, pc}
 END(plthook_return)


### PR DESCRIPTION
Current implementation for mcount_return and plthook_return only reserve
r0 and r1 registers assuming the size of return value is enough with 8
bytes.

But some functions may have a return type in struct and its size is more
than 8 bytes as following example:
```
  struct { int64_t quot, int64_t rem}
         __aeabi_ldivmod(int64_t numerator, int64_t denominator) {
    int64_t rem, quot;
    quot = __divmoddi4(numerator, denominator, &rem);
    return {quot, rem};
  }
```
In this case, we might partially lose return values because the return
value is stored in r0, r1, r2, and r3 registers to keep 16 bytes in
the return type of struct { int64_t quot, int64_t rem}.

So this patch fixes to keep r0-r3 registers to prevent such problems.

Fixed: #679

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>