### PR TITLE
mcount: Fix a few bugs in libmcount

### DIFF
--- a/arch/arm/mcount-support.c
+++ b/arch/arm/mcount-support.c
@@ -297,7 +297,7 @@ int check_float_abi_cb(struct dl_phdr_info *info, size_t size, void *data)
 		const Elf32_Phdr *phdr = info->dlpi_phdr + i;
 
 		if (phdr->p_type == PT_LOAD) {
-			Elf32_Ehdr *ehdr = (void *)phdr->p_vaddr;
+			Elf32_Ehdr *ehdr = (void *)info->dlpi_addr + phdr->p_vaddr;
 			use_hard_float = ehdr->e_flags & EF_ARM_ABI_FLOAT_HARD;
 			break;
 		}

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -447,15 +447,15 @@ static int setup_mod_plthook_data(struct dl_phdr_info *info, size_t sz, void *ar
 		"libmcount-fast-single.so",
 		/* system base libraries */
 		"libc.so.6",
-		"libc-2.*.so"
+		"libc-2.*.so",
 		"libgcc_s.so.1",
 		"libpthread.so.0",
-		"libpthread-2.*.so"
+		"libpthread-2.*.so",
 		"linux-vdso.so.1",
 		"linux-gate.so.1",
 		"ld-linux-*.so.*",
 		"libdl.so.2",
-		"libdl-2.*.so"
+		"libdl-2.*.so",
 	};
 	size_t k;
 	static bool exe_once = true;


### PR DESCRIPTION
This PR contains some bug fixes in libmcount as follows:
- Fix to properly add SINGLE_THREAD macros
- Fix mtd access before mcount_prepare()
- Fix missing comma in skip_libs
- Fix a segfault while checking hard float in arm

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>