### PR TITLE
test: broken regex arg addr replace to 0XADDR

### DIFF
--- a/tests/t184_arg_enum.py
+++ b/tests/t184_arg_enum.py
@@ -29,6 +29,7 @@ class TestCase(TestBase):
                 continue
             line = ln.split('|', 1)[-1]
             func = re.sub(r'0x[0-9a-f]+', '0xADDR', line)
+            func = re.sub(r'&[_a-z]+\+[0-9]+', '0xADDR', func)
             result.append(func)
 
         return '\n'.join(result)


### PR DESCRIPTION
Currently, replacing the argument address only works
when the address format is in hexadecimal address.

But in several cases, the address is printed in &<variable>+offset.
This commit adds additional regex replace to fix this problem. 

===========  result  ===========
mmap(0, 4096, PROT_READ, MAP_ANON|MAP_PRIVATE, 4, 0) = &_dl_catch_error+1999680;
mprotect(&_dl_catch_error+1999680, 4096, PROT_NONE) = 0;
munmap(&_dl_catch_error+1999680, 4096) = 0;
=========== expected ===========
mmap(0, 4096, PROT_READ, MAP_ANON|MAP_PRIVATE, 4, 0) = 0xADDR;
mprotect(0xADDR, 4096, PROT_NONE) = 0;
munmap(0xADDR, 4096) = 0;

184 arg_enum            : NG

Signed-off-by: Daniel T. Lee <danieltimlee@gmail.com>