### PR TITLE
test: fix sys_open replace exact match

### DIFF
--- a/tests/t079_replay_kernel_D.py
+++ b/tests/t079_replay_kernel_D.py
@@ -56,4 +56,4 @@ class TestCase(TestBase):
            int(major) >= 4 and int(minor) >= 17:
             result = result.replace('sys_', '__x64_sys_')
 
-        return result.replace('sys_open', 'sys_openat')
+        return result.replace(' sys_open', ' sys_openat')

--- a/tests/t081_kernel_depth.py
+++ b/tests/t081_kernel_depth.py
@@ -49,4 +49,4 @@ class TestCase(TestBase):
            int(major) >= 4 and int(minor) >= 17:
             result = result.replace(' sys_', ' __x64_sys_')
 
-        return result.replace('sys_open', 'sys_openat')
+        return result.replace(' sys_open', ' sys_openat')

--- a/tests/t132_trigger_kernel.py
+++ b/tests/t132_trigger_kernel.py
@@ -49,4 +49,4 @@ class TestCase(TestBase):
            int(major) >= 4 and int(minor) >= 17:
             result = result.replace('sys_', '__x64_sys_')
 
-        return result.replace('sys_open', 'sys_openat')
+        return result.replace(' sys_open', ' sys_openat')

--- a/tests/t137_kernel_tid_update.py
+++ b/tests/t137_kernel_tid_update.py
@@ -49,7 +49,7 @@ class TestCase(TestBase):
     def fixup(self, cflags, result):
         uname = os.uname()
 
-        result = result.replace('sys_open', 'sys_openat')
+        result = result.replace(' sys_open', ' sys_openat')
 
         # Linux v4.17 (x86_64) changed syscall routines
         major, minor, release = uname[2].split('.')

--- a/tests/t138_kernel_dynamic.py
+++ b/tests/t138_kernel_dynamic.py
@@ -38,7 +38,7 @@ class TestCase(TestBase):
     def fixup(self, cflags, result):
         uname = os.uname()
 
-        result = result.replace('sys_open', 'sys_openat')
+        result = result.replace(' sys_open', ' sys_openat')
 
         # Linux v4.17 (x86_64) changed syscall routines
         major, minor, release = uname[2].split('.')

--- a/tests/t139_kernel_dynamic2.py
+++ b/tests/t139_kernel_dynamic2.py
@@ -35,6 +35,6 @@ class TestCase(TestBase):
         major, minor, release = uname[2].split('.')
         if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
            int(major) >= 4 and int(minor) >= 17:
-            return result.replace('sys_open', '__x64_sys_openat')
+            return result.replace(' sys_open', ' __x64_sys_openat')
         else:
-            return result.replace('sys_open', 'sys_openat')
+            return result.replace(' sys_open', ' sys_openat')

--- a/tests/t143_recv_kernel.py
+++ b/tests/t143_recv_kernel.py
@@ -62,4 +62,4 @@ class TestCase(TestBase):
            int(major) >= 4 and int(minor) >= 17:
             result = result.replace('sys_', '__x64_sys_')
 
-        return result.replace('sys_open', 'sys_openat')
+        return result.replace(' sys_open', ' sys_openat')

--- a/tests/t174_replay_filter_kernel.py
+++ b/tests/t174_replay_filter_kernel.py
@@ -55,4 +55,4 @@ class TestCase(TestBase):
            int(major) >= 4 and int(minor) >= 17:
             result = result.replace('sys_', '__x64_sys_')
 
-        return result.replace('sys_open', 'sys_openat')
+        return result.replace(' sys_open', ' sys_openat')


### PR DESCRIPTION
replacing 'sys_open' to 'sys_openat' has replaced
other function rather than 'sys_open'

    # At t081_kernel_depth.py
    return result.replace('sys_open', 'sys_openat')

by this line, not only 'sys_open', but also 'do_sys_open'
has been replaced to 'do_sys_openat' which is misbehavior
because it doesn't exist in kernel symbol.

```
t081_kernel_depth: diff result of -pg -O0
--- expect	2019-03-12 23:23:20.943082509 +0900
+++ result	2019-03-12 23:23:20.943082509 +0900
@@ -3,3 +3,3 @@
      sys_openat() {
-       do_sys_openat();
+       do_sys_open();
      } /* sys_openat */

081 kernel_depth        : NG
```

Signed-off-by: Daniel T. Lee <danieltimlee@gmail.com>