### PR TITLE
test: broken test due to missing notrace filter

### DIFF
--- a/tests/t143_recv_kernel.py
+++ b/tests/t143_recv_kernel.py
@@ -39,6 +39,7 @@ class TestCase(TestBase):
         self.recv_p = sp.Popen(recv_cmd.split())
 
         argument  = '-H %s -k -d %s --port %s' % ('localhost', TDIR2, self.port)
+        argument += ' -N %s@kernel' % 'exit_to_usermode_loop'
         argument += ' -N %s@kernel' % '_*do_page_fault'
 
         record_cmd = '%s record %s %s' % (uftrace, argument, program)


### PR DESCRIPTION
Test t143 is broken due to missing filter at previous commit.

From commit b4812a, kernel function 'exit_to_usermode_loop'
had been removed from the result, and added to --notrace option.

Seems this one is missing at t143.

Signed-off-by: Daniel T. Lee <danieltimlee@gmail.com>