### PR TITLE
test: serialized test implemented

### DIFF
--- a/tests/t022_filter_kernel.py
+++ b/tests/t022_filter_kernel.py
@@ -5,7 +5,7 @@ import os
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'getids', """
+        TestBase.__init__(self, 'getids', serial=True, result="""
 # DURATION    TID     FUNCTION
             [20769] | main() {
    0.925 us [20769] |   getpid();

--- a/tests/t079_replay_kernel_D.py
+++ b/tests/t079_replay_kernel_D.py
@@ -8,7 +8,7 @@ TDIR='xxx'
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', """
+        TestBase.__init__(self, 'openclose', serial=True, result="""
 # DURATION    TID     FUNCTION
    1.088 us [18343] | __monstartup();
    0.640 us [18343] | __cxa_atexit();

--- a/tests/t080_replay_kernel_D2.py
+++ b/tests/t080_replay_kernel_D2.py
@@ -9,7 +9,7 @@ TDIR='xxx'
 # there was a problem applying depth filter if it contains kernel functions
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', """
+        TestBase.__init__(self, 'openclose', serial=True, result="""
 # DURATION    TID     FUNCTION
    1.088 us [18343] | __monstartup();
    0.640 us [18343] | __cxa_atexit();

--- a/tests/t081_kernel_depth.py
+++ b/tests/t081_kernel_depth.py
@@ -5,7 +5,7 @@ import os
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', """
+        TestBase.__init__(self, 'openclose', serial=True, result="""
 # DURATION    TID     FUNCTION
    1.540 us [27711] | __monstartup();
    1.089 us [27711] | __cxa_atexit();

--- a/tests/t103_dump_kernel.py
+++ b/tests/t103_dump_kernel.py
@@ -8,7 +8,7 @@ TDIR='xxx'
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'getids', """
+        TestBase.__init__(self, 'getids', serial=True, result="""
 {"traceEvents":[
 {"ts":14510734170,"ph":"M","pid":32687,"name":"process_name","args":{'name': 't-getids'}},
 {"ts":14510734170,"ph":"M","pid":32687,"name":"thread_name","args":{'name': 't-getids'}},

--- a/tests/t104_graph_kernel.py
+++ b/tests/t104_graph_kernel.py
@@ -9,7 +9,7 @@ FUNC='main'
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'getids', result="""
+        TestBase.__init__(self, 'getids', serial=True, result="""
 # Function Call Graph for 'main' (session: 59268c360e3c1bd6)
 =============== BACKTRACE ===============
  backtrace #0: hit 1, time  24.837 us

--- a/tests/t111_kernel_tid.py
+++ b/tests/t111_kernel_tid.py
@@ -8,7 +8,7 @@ TDIR='xxx'
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', """
+        TestBase.__init__(self, 'fork', serial=True, result="""
 # DURATION    TID     FUNCTION
             [ 1661] | main() {
             [ 1661] |   fork() {

--- a/tests/t132_trigger_kernel.py
+++ b/tests/t132_trigger_kernel.py
@@ -6,7 +6,7 @@ import os
 # there was a problem applying depth filter if it contains kernel functions
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', """
+        TestBase.__init__(self, 'openclose', serial=True, result="""
 # DURATION    TID     FUNCTION
    0.714 us [ 4435] | __monstartup();
    0.349 us [ 4435] | __cxa_atexit();

--- a/tests/t137_kernel_tid_update.py
+++ b/tests/t137_kernel_tid_update.py
@@ -5,7 +5,7 @@ import os
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork2', """
+        TestBase.__init__(self, 'fork2', serial=True, result="""
 # DURATION    TID     FUNCTION
             [19227] | main() {
  328.451 us [19227] |   fork();

--- a/tests/t138_kernel_dynamic.py
+++ b/tests/t138_kernel_dynamic.py
@@ -5,7 +5,7 @@ import os
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', """
+        TestBase.__init__(self, 'openclose', serial=True, result="""
 # DURATION    TID     FUNCTION
             [ 9875] | main() {
             [ 9875] |   fopen() {

--- a/tests/t139_kernel_dynamic2.py
+++ b/tests/t139_kernel_dynamic2.py
@@ -5,7 +5,7 @@ import os
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', """
+        TestBase.__init__(self, 'openclose', serial=True, result="""
 # DURATION    TID     FUNCTION
             [ 9875] | main() {
             [ 9875] |   fopen() {

--- a/tests/t143_recv_kernel.py
+++ b/tests/t143_recv_kernel.py
@@ -9,7 +9,7 @@ TDIR2 = 'yyy'
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', """
+        TestBase.__init__(self, 'openclose', serial=True, result="""
 # DURATION    TID     FUNCTION
    1.088 us [18343] | __monstartup();
    0.640 us [18343] | __cxa_atexit();

--- a/tests/t148_event_kernel.py
+++ b/tests/t148_event_kernel.py
@@ -5,7 +5,7 @@ import os
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', """
+        TestBase.__init__(self, 'sleep', serial=True, result="""
 # DURATION    TID     FUNCTION
             [24464] | main() {
             [24464] |   foo() {

--- a/tests/t149_event_kernel2.py
+++ b/tests/t149_event_kernel2.py
@@ -5,7 +5,7 @@ import os
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', """
+        TestBase.__init__(self, 'fork', serial=True, result="""
 # DURATION    TID     FUNCTION
             [ 6532] | /* sched:sched_process_exec (filename=t-fork pid=6532 old_pid=6532) */
             [ 6532] | main() {

--- a/tests/t163_event_sched.py
+++ b/tests/t163_event_sched.py
@@ -4,7 +4,7 @@ from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', """
+        TestBase.__init__(self, 'sleep', serial=True, result="""
 # DURATION    TID     FUNCTION
             [  395] | main() {
             [  395] |   foo() {

--- a/tests/t164_report_sched.py
+++ b/tests/t164_report_sched.py
@@ -7,7 +7,7 @@ TDIR='xxx'
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sort', """
+        TestBase.__init__(self, 'sort', serial=True, result="""
   Total time   Self time       Calls  Function
   ==========  ==========  ==========  ====================================
     1.152 ms   71.683 us           1  main

--- a/tests/t165_graph_sched.py
+++ b/tests/t165_graph_sched.py
@@ -8,7 +8,7 @@ FUNC='main'
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sort', result="""
+        TestBase.__init__(self, 'sort', serial=True, result="""
 # Function Call Graph for 'main' (session: 54047ea45c46ad91)
 =============== BACKTRACE ===============
  backtrace #0: hit 1, time  10.329 ms

--- a/tests/t166_dump_sched.py
+++ b/tests/t166_dump_sched.py
@@ -7,7 +7,7 @@ TDIR='xxx'
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', """
+        TestBase.__init__(self, 'sleep', serial=True, result="""
 {"traceEvents":[
 {"ts":0,"ph":"M","pid":306,"name":"process_name","args":{"name":"[306] t-sleep"}},
 {"ts":0,"ph":"M","pid":306,"name":"thread_name","args":{"name":"[306] t-sleep"}},

--- a/tests/t167_recv_sched.py
+++ b/tests/t167_recv_sched.py
@@ -8,7 +8,7 @@ TDIR2 = 'xxx/uftrace.data'
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', """
+        TestBase.__init__(self, 'sleep', serial=True, result="""
 # DURATION    TID     FUNCTION
             [  395] | main() {
             [  395] |   foo() {

--- a/tests/t174_replay_filter_kernel.py
+++ b/tests/t174_replay_filter_kernel.py
@@ -8,7 +8,7 @@ TDIR='xxx'
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', """
+        TestBase.__init__(self, 'openclose', serial=True, result="""
 # DURATION    TID     FUNCTION
             [18343] | main() {
             [18343] |   fopen() {

--- a/tests/t189_replay_field2.py
+++ b/tests/t189_replay_field2.py
@@ -7,7 +7,7 @@ TDIR='xxx'
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'taskname', ldflags='-pthread', result="""
+        TestBase.__init__(self, 'taskname', ldflags='-pthread', serial=True, result="""
 #      TASK NAME   FUNCTION
       t-taskname | main() {
       t-taskname |   task_name1() {

--- a/tests/t196_chrome_taskname.py
+++ b/tests/t196_chrome_taskname.py
@@ -7,7 +7,7 @@ TDIR='xxx'
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'taskname', ldflags='-pthread', result="""
+        TestBase.__init__(self, 'taskname', ldflags='-pthread', serial=True, result="""
 {"traceEvents":[
 {"ts":0,"ph":"M","pid":4694,"name":"process_name","args":{"name":"[4694] bar"}},
 {"ts":0,"ph":"M","pid":4694,"name":"thread_name","args":{"name":"[4694] bar"}},

--- a/tests/t208_watch_cpu.py
+++ b/tests/t208_watch_cpu.py
@@ -5,7 +5,7 @@ import re
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'chcpu', result="""
+        TestBase.__init__(self, 'chcpu', serial=True, result="""
 # DURATION     TID     FUNCTION
             [ 19611] | main() {
             [ 19611] |   /* watch:cpu (cpu=6) */

--- a/tests/t221_taskname_time.py
+++ b/tests/t221_taskname_time.py
@@ -6,7 +6,7 @@ TDIR='xxx'
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'taskname', ldflags='-pthread', result="""
+        TestBase.__init__(self, 'taskname', ldflags='-pthread', serial=True, result="""
 #      TASK NAME   FUNCTION
         taskname | main() {
         taskname |   task_name1() {


### PR DESCRIPTION
New multiprocessing.Pool(1) for serial tests added.

By adding extra 'serial' attribute to TestBase,
all the serial testcases will be executed in new worker.

Since serialized tests, has been implemented, 
test case results might be showing up slow (ongoing tests)

Fixed: #620

Signed-off-by: Daniel T. Lee <danieltimlee@gmail.com>