### PR TITLE
script: Add script/strings.py to print runtime strings

### DIFF
--- a/scripts/strings.py
+++ b/scripts/strings.py
@@ -1,0 +1,32 @@
+#
+# strings.py - print the unique strings of runtime function arguments and return values.
+#
+# uftrace-option: --nest-libcall --auto-args
+#
+
+strset = set()
+
+def uftrace_entry(ctx):
+    global strset
+    if "args" in ctx:
+        args = ctx["args"]
+        for arg in args:
+            if isinstance(arg, str):
+                arg = arg.strip()
+                if arg is not "":
+                    strset.add(arg)
+
+def uftrace_exit(ctx):
+    global strset
+    if "retval" in ctx:
+        ret = ctx["retval"]
+        if isinstance(ret, str):
+            ret = ret.strip()
+            if ret is not "":
+                strset.add(ret)
+
+def uftrace_end():
+    global strset
+    for strval in strset:
+        print('"%s"' % strval)
+        print("---")


### PR DESCRIPTION
argstr.py is to display unique string collected from arguments and
return values.

It displays all the strings collected at runtime as follows:
```
  $ uftrace script -S scripts/strings.py --record /usr/bin/uptime
   00:05:01 up 37 days, 13:16, 12 users,  load average: 4.94, 4.85, 4.90
  "procps-ng"
  ---
  "C"
  ---
  "phsV"
  ---
  "/proc/uptime"
  ---
  "00:05:01 up 37 days, 13:16, 12 users,  load average: 4.94, 4.85, 4.90"
  ---
  "en_US.UTF-8"
  ---
  "NULL"
  ---
  "/usr/share/locale"
  ---
  "/proc/loadavg"
  ---
```
In many cases, same strings are repeatedly collected during funtion
tracing so this tool can be useful when observing their unique set.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>