### PR TITLE
record: Add the missed returnning code

### DIFF
--- a/cmds/record.c
+++ b/cmds/record.c
@@ -132,8 +132,13 @@ char * get_libmcount_path(struct opts *opts)
 
 #ifdef INSTALL_LIB_PATH
 	snprintf(lib, PATH_MAX, "%s/%s", INSTALL_LIB_PATH, libmcount);
-	if (access(lib, F_OK) != 0 && errno == ENOENT)
+	if (access(lib, F_OK) == 0)
+		return lib;
+
+	if (errno == ENOENT)
 		pr_warn("Didn't you run 'make install' ?\n");
+
+	/* fall through */
 #endif
 	strcpy(lib, libmcount);
 	return lib;


### PR DESCRIPTION
This code seems to have attempted to return the full installation path.
However, the return code is missing. If it does not return here, strcpy
will only return the name of libmcount only from below line. therefore,
added returning code.

Signed-off-by: Hanbum Park <kese111@gmail.com>