### PR TITLE
mcount: Add code to store the errno from each entry

### DIFF
--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -1184,8 +1184,8 @@ mcount_arch_parent_location(struct symtabs *symtabs, unsigned long *parent_loc,
 }
 #endif
 
-int mcount_entry(unsigned long *parent_loc, unsigned long child,
-		 struct mcount_regs *regs)
+static int __mcount_entry(unsigned long *parent_loc, unsigned long child,
+			  struct mcount_regs *regs)
 {
 	enum filter_result filtered;
 	struct mcount_thread_data *mtdp;
@@ -1253,7 +1253,17 @@ int mcount_entry(unsigned long *parent_loc, unsigned long child,
 	return 0;
 }
 
-unsigned long mcount_exit(long *retval)
+int mcount_entry(unsigned long *parent_loc, unsigned long child,
+		 struct mcount_regs *regs)
+{
+	int saved_errno = errno;
+	int ret = __mcount_entry(parent_loc, child, regs);
+
+	errno = saved_errno;
+	return ret;
+}
+
+static unsigned long __mcount_exit(long *retval)
 {
 	struct mcount_thread_data *mtdp;
 	struct mcount_ret_stack *rstack;
@@ -1302,7 +1312,16 @@ unsigned long mcount_exit(long *retval)
 	return retaddr;
 }
 
-static int cygprof_entry(unsigned long parent, unsigned long child)
+unsigned long mcount_exit(long *retval)
+{
+	int saved_errno = errno;
+	unsigned long ret = __mcount_exit(retval);
+
+	errno = saved_errno;
+	return ret;
+}
+
+static int __cygprof_entry(unsigned long parent, unsigned long child)
 {
 	enum filter_result filtered;
 	struct mcount_thread_data *mtdp;
@@ -1380,7 +1399,16 @@ static int cygprof_entry(unsigned long parent, unsigned long child)
 	return 0;
 }
 
-static void cygprof_exit(unsigned long parent, unsigned long child)
+static int cygprof_entry(unsigned long parent, unsigned long child)
+{
+	int saved_errno = errno;
+	int ret = __cygprof_entry(parent, child);
+
+	errno = saved_errno;
+	return ret;
+}
+
+static void __cygprof_exit(unsigned long parent, unsigned long child)
 {
 	struct mcount_thread_data *mtdp;
 	struct mcount_ret_stack *rstack;
@@ -1415,8 +1443,16 @@ out:
 	mtdp->idx--;
 }
 
-void xray_entry(unsigned long parent, unsigned long child,
-		struct mcount_regs *regs)
+static void cygprof_exit(unsigned long parent, unsigned long child)
+{
+	int saved_errno = errno;
+
+	__cygprof_exit(parent, child);
+	errno = saved_errno;
+}
+
+static void _xray_entry(unsigned long parent, unsigned long child,
+			struct mcount_regs *regs)
 {
 	enum filter_result filtered;
 	struct mcount_thread_data *mtdp;
@@ -1481,7 +1517,16 @@ void xray_entry(unsigned long parent, unsigned long child,
 	mcount_unguard_recursion(mtdp);
 }
 
-void xray_exit(long *retval)
+void xray_entry(unsigned long parent, unsigned long child,
+		struct mcount_regs *regs)
+{
+	int saved_errno = errno;
+
+	_xray_entry(parent, child, regs);
+	errno = saved_errno;
+}
+
+static void _xray_exit(long *retval)
 {
 	struct mcount_thread_data *mtdp;
 	struct mcount_ret_stack *rstack;
@@ -1514,6 +1559,14 @@ out:
 	compiler_barrier();
 
 	mtdp->idx--;
+}
+
+void xray_exit(long *retval)
+{
+	int saved_errno = errno;
+
+	_xray_exit(retval);
+	errno = saved_errno;
 }
 
 static void atfork_prepare_handler(void)

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -711,8 +711,10 @@ __weak unsigned long mcount_arch_child_idx(unsigned long child_idx)
 	return child_idx;
 }
 
-unsigned long plthook_entry(unsigned long *ret_addr, unsigned long child_idx,
-			    unsigned long module_id, struct mcount_regs *regs)
+static unsigned long __plthook_entry(unsigned long *ret_addr,
+				     unsigned long child_idx,
+				     unsigned long module_id,
+				     struct mcount_regs *regs)
 {
 	struct sym *sym;
 	struct mcount_thread_data *mtdp = NULL;
@@ -850,9 +852,21 @@ out:
 	return real_addr;
 }
 
+unsigned long plthook_entry(unsigned long *ret_addr, unsigned long child_idx,
+			    unsigned long module_id, struct mcount_regs *regs)
+{
+	int saved_errno = errno;
+	unsigned long ret;
+
+	ret = __plthook_entry(ret_addr, child_idx, module_id, regs);
+	errno = saved_errno;
+	return ret;
+}
+
+
 void mtd_dtor(void *arg);
 
-unsigned long plthook_exit(long *retval)
+static unsigned long __plthook_exit(long *retval)
 {
 	unsigned dyn_idx;
 	struct mcount_thread_data *mtdp;
@@ -953,4 +967,13 @@ again:
 
 	mtdp->idx--;
 	return ret_addr;
+}
+
+unsigned long plthook_exit(long *retval)
+{
+	int saved_errno = errno;
+	unsigned long ret = __plthook_exit(retval);
+
+	errno = saved_errno;
+	return ret;
 }


### PR DESCRIPTION
Currently, each entry function changes the value of errno when
initializing mcount thread data. The problem is that since errno is
shared with the target program, it affects the execution of the target
program. therefore, added some code to solve this problem and to prevent
this happening never again.

Signed-off-by: Hanbum Park <kese111@gmail.com>