### PR TITLE
mcount: change TLS model to 'initial-exec'

### DIFF
--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -715,7 +715,7 @@ unsigned long plthook_entry(unsigned long *ret_addr, unsigned long child_idx,
 			goto out;
 	}
 	else {
-		if (!mcount_guard_recursion(mtdp))
+		if (!mcount_guard_recursion())
 			goto out;
 	}
 
@@ -812,7 +812,7 @@ out:
 		real_addr = pd->resolved_addr[child_idx];
 
 	if (!recursion)
-		mcount_unguard_recursion(mtdp);
+		mcount_unguard_recursion();
 
 	return real_addr;
 }
@@ -863,7 +863,7 @@ again:
 		     dyn_idx >= rstack->pd->dsymtab.nr_sym))
 		pr_err_ns("<%d> invalid dynsym idx: %d\n", mtdp->idx, dyn_idx);
 
-	if (!ARCH_CAN_RESTORE_PLTHOOK && unlikely(mtdp->dead)) {
+	if (!ARCH_CAN_RESTORE_PLTHOOK && unlikely(__mcount_check_dead(mtdp))) {
 		ret_addr = rstack->parent_ip;
 
 		/* make sure it doesn't have plthook below */

--- a/libmcount/wrap.c
+++ b/libmcount/wrap.c
@@ -414,14 +414,14 @@ __visible_default void * dlopen(const char *filename, int flags)
 			return ret;
 	}
 	else {
-		if (!mcount_guard_recursion(mtdp))
+		if (!mcount_guard_recursion())
 			return ret;
 	}
 
 	data.mtdp = mtdp;
 	dl_iterate_phdr(dlopen_base_callback, &data);
 
-	mcount_unguard_recursion(mtdp);
+	mcount_unguard_recursion();
 	return ret;
 }
 


### PR DESCRIPTION
Currently uftrace utilizes TLS variable mcount thread_data type mtd.
Each entry function calls the mcount_prepare function, which prepares
mcount_thread_data. The mcount_prepare function has the following code:

```
struct mcount_thread_data * mtdp = & mtd;
```

The compiler translates this code as follows:
```
data16 lea 0x2d6d7 (% rip),% rdi # 35f98 <.got + 0x8>
data16 data16 callq 6400 <__ tls_get_addr @ plt>
```

The __tls_get_addr@plt function is called to reference the TLS variable
mtd. which in some cases calls malloc@plt or the free@plt function
internally. And in this case it will re-enter plthook_entry. In other
words, infinite recursion occurs.

This is because every action that attempts to access mtd with a
mechanism caused by the TLS model is made by a call to
__tls_get_addr@plt.

For this reason, changed the model of the TLS variable mtd to
initial-exec. The initial-exec model solves the problem of infinite
recursion because it is a way to refer to variables by adding or
subtracting offsets from static TLS blocks.

```
mov 0x2d6a6 (% rip),% rax # 35fc8 <.got + 0x38>
mov% fs: (% rax),% rbx
```

For more information on this, please see the following link:
https://www.fsfla.org/~lxoliva/writeups/TLS/RFC-TLSDESC-x86.txt

If it change to the initial-exec model, it can expect some improvement
in performance compared to the existing one. Please refer to the
following link for more details.
https://die4taoam.tistory.com/37

Signed-off-by: Hanbum Park <kese111@gmail.com>