### PR TITLE
plthook: Add some comments and refine debug msg

### DIFF
--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -294,8 +294,8 @@ struct plthook_data {
 	unsigned long			base_addr;
 	unsigned long			plt_addr;
 	struct symtab			dsymtab;
-	unsigned long			*pltgot_ptr;
-	unsigned long			*resolved_addr;
+	unsigned long			*pltgot_ptr;	/* address of GOT[0] */
+	unsigned long			*resolved_addr;	/* starts from GOT[3] */
 	struct plthook_special_func	*special_funcs;
 	int				nr_special;
 };

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -649,6 +649,24 @@ static struct mcount_ret_stack * restore_vfork(struct mcount_thread_data *mtdp,
 	return rstack;
 }
 
+/*
+ * mcount_arch_plthook_addr() returns the address of GOT entry.
+ * The initial value for each GOT entry redirects the execution to
+ * the runtime resolver. (_dl_runtime_resolve in ld-linux.so)
+ *
+ * The GOT entry is updated by the runtime resolver to the resolved address of
+ * the target library function for later reference.
+ *
+ * However, uftrace gets this address to update it back to the initial value.
+ * Even if the GOT entry is resolved by runtime resolver, uftrace restores the
+ * address back to the initial value to watch library function calls.
+ *
+ * Before doing this work, GOT[2] is updated from the address of runtime
+ * resolver(_dl_runtime_resolve) to uftrace hooking routine(plt_hooker).
+ *
+ * This address depends on the PLT structure of each architecture so this
+ * function is implemented differently for each architecture.
+ */
 __weak unsigned long mcount_arch_plthook_addr(struct plthook_data *pd, int idx)
 {
 	struct sym *sym;

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -223,8 +223,8 @@ static int find_got(struct uftrace_elf_data *elf,
 	pd->base_addr  = offset;
 	pd->plt_addr   = plt_addr;
 
-	pr_dbg2("module: %s (id: %lx), addr = %lx, PLTGOT = %p\n",
-		pd->mod_name, pd->module_id, pd->base_addr, pd->pltgot_ptr);
+	pr_dbg2("\"%s\" is loaded at %#lx\n",
+		basename(pd->mod_name), pd->base_addr);
 
 	memset(&pd->dsymtab, 0, sizeof(pd->dsymtab));
 	load_elf_dynsymtab(&pd->dsymtab, elf, pd->base_addr, SYMTAB_FL_DEMANGLE);
@@ -245,8 +245,10 @@ static int find_got(struct uftrace_elf_data *elf,
 			pd->module_id = (unsigned long)pd;
 		}
 
-		pr_dbg2("found GOT at %p (PLT resolver: %#lx)\n",
-			pd->pltgot_ptr, plthook_resolver_addr);
+		pr_dbg2("found GOT at %p (base_addr + %#lx)\n", pd->pltgot_ptr,
+			(unsigned long)pd->pltgot_ptr - pd->base_addr);
+		pr_dbg2("module id = %#lx, PLT resolver = %#lx\n",
+			pd->module_id, plthook_resolver_addr);
 
 		restore_plt_functions(pd);
 	}


### PR DESCRIPTION
Since GOT section is not well explained in the code, it might be
difficult to read and understand the code by general developers.

This PR adds some useful explanation for GOT section for better
understanding and it also changes the cryptic index number to got_idx.

It also refines some debug messages in plthook.