### PR TITLE
uftrace: Fix segfault when --opt-file is used

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -1102,7 +1102,7 @@ int main(int argc, char *argv[])
 		fclose(logfp);
 
 	if (opts.opt_file)
-		free_parsed_cmdline(argv);
+		free_parsed_cmdline(argv - opts.idx);
 
 	free_opts(&opts);
 	return ret;


### PR DESCRIPTION
This patch is to fix segfault in --opt-file as follows:
```
  $ cat opts
  --no-pager -D 3 t-abc

  $ uftrace --opt-file opts
  # DURATION     TID     FUNCTION
     2.193 us [ 56595] | __monstartup();
     1.176 us [ 56595] | __cxa_atexit();
              [ 56595] | main() {
              [ 56595] |   a() {
     2.137 us [ 56595] |     b();
     3.663 us [ 56595] |   } /* a */
     4.653 us [ 56595] | } /* main */
  WARN: Segmentation fault
  Segmentation fault (core dumped)
```
Fixed: #709

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>