### PR TITLE
mcount: Fix mtdp assertion failure in plthook_exit

### DIFF
--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -1751,8 +1751,16 @@ static void mcount_cleanup(void)
 	mcount_finish();
 	destroy_dynsym_indexes();
 
+#if 0
+	/*
+	 * This mtd_key deletion sometimes makes other thread get crashed
+	 * because they may try to get mtdp based on this mtd_key after being
+	 * deleted.  Since this key deletion is not mandatory, it'd be better
+	 * not to delete it until we find a better solution.
+	 */
 	pthread_key_delete(mtd_key);
 	mtd_key = -1;
+#endif
 
 	mcount_filter_finish();
 


### PR DESCRIPTION
The mtd_key deletion in mcount_cleanup() sometimes makes other thread
get crashed because they may try to get mtdp based on this mtd_key after
being deleted.  The error message is as follows:

    plthook_exit: Assertion `!check_thread_data(mtdp)' failed.

The expected behavior is to call mcount_cleanup() after all the other
threads are destoryed, but it doesn't work as expected in some cases.

Since this key deletion is not that important, it'd be better not to do
it until we find a better solution.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>