### PR TITLE
plthook: Skip dlsym to avoid infinite loop

### DIFF
--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -323,6 +323,7 @@ static const char *skip_syms[] = {
 	"__cxa_end_catch",
 	"__cxa_finalize",
 	"_Unwind_Resume",
+	"dlsym",
 };
 
 static const char *setjmp_syms[] = {


### PR DESCRIPTION
In some cases, it's tricky to avoid infinite loop if dlsym is hooked
by libmcount.so.  Here is the problematic condition.

1. dlsym is invoked in a library. Let's say "libxxx.so".
2. dlsym is called to get the address of "foo". - dlsym(RTLD_NEXT, "foo")
3. The actual implementation of "foo" is inside "libfoo.so".
4. Inside the library "libxxx.so", "foo" is defined to override it.
5. The execution sequence is "foo@libxxx.so", then "foo@libfoo.so".

If "libmcount.so" is preloaded in this case, it hooks "foo@libxxx.so"
and executes "dlsym" instead of "libxxx.so".

The problem is that the return address of dlsym(RTLD_NEXT, "foo") is
expected the address of "foo@libfoo.so", but it returns "foo@libxxx.so".

If the subsequent call is made based on this return address, then
"foo@libxxx.so" recursively calls itself and never finished.

Since I don't have any better solution to make dlsym to find second next
"foo" in the order of dynamic library list, this patch simply skips
dlsym to avoid the such problem.

This problem is happened when --nest-libcall is used.

Fixed: #714

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>