### PR TITLE
restores all registers after calling dentry 

### DIFF
--- a/arch/x86_64/dynamic.S
+++ b/arch/x86_64/dynamic.S
@@ -42,9 +42,16 @@
 
 GLOBAL(__dentry__)
 	.cfi_startproc
-	sub $48, %rsp
+	sub $104, %rsp
 	.cfi_adjust_cfa_offset 48
 
+	movq %r15, 96(%rsp)
+	movq %r14, 88(%rsp)
+	movq %r13, 80(%rsp)
+	movq %r12, 72(%rsp)
+	movq %r11, 64(%rsp)
+	movq %r10, 56(%rsp)
+	movq %rbx, 48(%rsp)
 	movq %rdi, 40(%rsp)
 	movq %rsi, 32(%rsp)
 	movq %rdx, 24(%rsp)
@@ -53,10 +60,10 @@ GLOBAL(__dentry__)
 	movq %r9,   0(%rsp)
 
 	/* child addr */
-	movq 48(%rsp), %rsi
+	movq 104(%rsp), %rsi
 
 	/* parent location */
-	lea 56(%rsp), %rdi
+	lea 112(%rsp), %rdi
 
 	/* mcount_args */
 	movq %rsp, %rdx
@@ -75,7 +82,7 @@ GLOBAL(__dentry__)
 	movq 8(%rsp), %rdx
 
 	/* child addr */
-	movq 48(%rdx), %rdi
+	movq 104(%rdx), %rdi
 
 	/* find location that has the original code */
 	call mcount_find_code
@@ -84,7 +91,7 @@ GLOBAL(__dentry__)
 	movq 8(%rsp), %rdx
 
 	/* overwrite return address */
-	movq %rax, 48(%rdx)
+	movq %rax, 104(%rdx)
 
 	pop  %rax
 
@@ -97,8 +104,15 @@ GLOBAL(__dentry__)
 	movq 24(%rsp), %rdx
 	movq 32(%rsp), %rsi
 	movq 40(%rsp), %rdi
+	movq 48(%rsp), %rbx
+	movq 56(%rsp), %r10
+	movq 64(%rsp), %r11
+	movq 72(%rsp), %r12
+	movq 80(%rsp), %r13
+	movq 88(%rsp), %r14
+	movq 96(%rsp), %r15
 
-	add $48, %rsp
+	add $104, %rsp
 	.cfi_adjust_cfa_offset -48
 
 	retq

--- a/arch/x86_64/mcount.S
+++ b/arch/x86_64/mcount.S
@@ -84,9 +84,21 @@ END(mcount)
 
 ENTRY(mcount_return)
 	.cfi_startproc
-	sub $48, %rsp
+	sub $144, %rsp
 	.cfi_def_cfa_offset 48
 
+	movq   %r15,  128(%rsp)
+	movq   %r14,  120(%rsp)
+	movq   %r13,  112(%rsp)
+	movq   %r12,  104(%rsp)
+	movq   %r11,  96(%rsp)
+	movq   %r10,  88(%rsp)
+	movq   %r9,   80(%rsp)
+	movq   %r8,   72(%rsp)
+	movq   %rdi,  64(%rsp)
+	movq   %rsi,  56(%rsp)
+	movq   %rcx,  48(%rsp)
+	movq   %rbx,  40(%rsp)
 	movdqu %xmm0, 16(%rsp)
 	movq   %rdx,   8(%rsp)
 	movq   %rax,   0(%rsp)
@@ -96,13 +108,25 @@ ENTRY(mcount_return)
 
 	/* returns original parent address */
 	call mcount_exit
-	movq %rax, 40(%rsp)
+	movq %rax, 136(%rsp)
 
 	movq    0(%rsp), %rax
 	movq    8(%rsp), %rdx
 	movdqu 16(%rsp), %xmm0
+	movq   40(%rsp), %rbx
+	movq   48(%rsp), %rcx
+	movq   56(%rsp), %rsi
+	movq   64(%rsp), %rdi
+	movq   72(%rsp), %r8
+	movq   80(%rsp), %r9
+	movq   88(%rsp), %r10
+	movq   96(%rsp), %r11
+	movq   104(%rsp), %r12
+	movq   112(%rsp), %r13
+	movq   120(%rsp), %r14
+	movq   128(%rsp), %r15
 
-	add $40, %rsp
+	add $136, %rsp
 	.cfi_def_cfa_offset 8
 	retq
 	.cfi_endproc

--- a/tests/s-dynamic-save-register.c
+++ b/tests/s-dynamic-save-register.c
@@ -1,0 +1,39 @@
+/* Testing -fipa-ra optimization option.  */
+#include <assert.h>
+
+int __attribute__((noinline)) bar(int a, int b, int c, int d, int e, int f)
+{
+	asm("nopl   (%ebx,%ebx,1)");
+	asm("nopl   (%ebx,%ebx,1)");
+	return a + b + c + d + e + f + 3;
+}
+
+int __attribute__((noinline)) foo(int a, int b, int c, int d, int e, int f)
+{
+	asm("nopl   (%ebx,%ebx,1)");
+	asm("nopl   (%ebx,%ebx,1)");
+
+	int a_dup = a;
+	int b_dup = b;
+	int c_dup = c;
+	int d_dup = d;
+	int e_dup = e;
+	int f_dup = f;
+	a_dup += bar(a,b,c,d,e,f);
+	b_dup += bar(a,b,c,d,e,f);
+	c_dup += bar(a,b,c,d,e,f);
+	d_dup += bar(a,b,c,d,e,f);
+	e_dup += bar(a,b,c,d,e,f);
+	f_dup += bar(a,b,c,d,e,f);
+
+	return bar(a_dup,b_dup,c_dup,d_dup,e_dup,f_dup);
+}
+
+int main (void)
+{
+	asm("nopl   (%ebx,%ebx,1)");
+	asm("nopl   (%ebx,%ebx,1)");
+
+	assert(foo(1,1,1,1,1,1) == 63);
+	return 0;
+}

--- a/tests/t223_dynamic_save_register.py
+++ b/tests/t223_dynamic_save_register.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+import platform
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'dynamic-save-register', """
+
+# DURATION     TID     FUNCTION
+             [ 91012] | main() {
+             [ 91012] |   foo() {
+    0.159 us [ 91012] |     bar();
+    0.053 us [ 91012] |     bar();
+    0.050 us [ 91012] |     bar();
+    0.051 us [ 91012] |     bar();
+    0.051 us [ 91012] |     bar();
+    0.052 us [ 91012] |     bar();
+    0.058 us [ 91012] |     bar();
+    1.584 us [ 91012] |   } /* foo */
+    2.388 us [ 91012] | } /* main */
+""")
+
+    def pre(self):
+        if platform.machine().startswith('arm'):
+            return TestBase.TEST_SKIP
+        return TestBase.TEST_SUCCESS
+
+    def build(self, name, cflags='', ldflags=''):
+        cflags = cflags.replace('-pg', '')
+        cflags = cflags.replace('-finstrument-functions', '')
+        cflags += ' -fno-plt'  # workaround of build failure
+        cflags += ' -fipa-ra'
+        return TestBase.build(self, name, cflags, ldflags)
+
+    def runcmd(self):
+        uftrace = TestBase.uftrace_cmd
+        options = '-P main -P foo -P bar --no-libcall'
+        program = 't-' + self.name
+        return '%s %s %s' % (uftrace, options, program)


### PR DESCRIPTION

previously, only some registers were restored when calling dentry
according to the calling convence. however, if an option such as '-pg'
or '-finstrument-function' is not specified, compiler uses registers
that are not used by the called function.

if do not restore the register in this situation, it has the same effect
as changing the register used as a variable in the callee function. in
other words, unintentionally changing variables in the callee function.

