### PR TITLE
record: Set writer thread name to "WriterThread"

### DIFF
--- a/cmds/record.c
+++ b/cmds/record.c
@@ -653,6 +653,8 @@ void *writer_thread(void *arg)
 	int i, dummy;
 	sigset_t sigset;
 
+	pthread_setname_np(pthread_self(), "WriterThread");
+
 	if (opts->rt_prio) {
 		struct sched_param param = {
 			.sched_priority = opts->rt_prio,


### PR DESCRIPTION
It'd be better to have a task name for writer threads.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>