### PR TITLE
record: Use absolute path of uftrace data directory when tracing (shell) scripts

### DIFF
--- a/cmds/record.c
+++ b/cmds/record.c
@@ -2012,6 +2012,7 @@ int do_child_exec(int ready, struct opts *opts,
 {
 	uint64_t dummy;
 	char *shebang;
+	char fullpath[PATH_MAX];
 	struct strv new_args = STRV_INIT;
 
 	if (opts->no_randomize_addr) {
@@ -2019,6 +2020,13 @@ int do_child_exec(int ready, struct opts *opts,
 		if (personality(ADDR_NO_RANDOMIZE) < 0)
 			pr_dbg("disabling ASLR failed\n");
 	}
+
+	/*
+	 * The current working directory can be changed by calling chdir.
+	 * So dirname has to be converted to an absolute path to avoid unexpected problems.
+	 */
+	if (realpath(opts->dirname, fullpath) != NULL)
+		opts->dirname = fullpath;
 
 	shebang = check_script_file(argv[0]);
 	if (shebang) {


### PR DESCRIPTION
Current working directory can be changed during (shell) scripts execution
due to internal chdir() inside scripts.
If it is changed, the problem that uftrace.data can't be found can occur:

```
  $ uftrace record --force ./configure
  mcount: /home/honggyu/work/uftrace/libmcount/record.c:1093:record_proc_maps
   ERROR: cannot open for writing maps file: No such file or directory
```

Because of trying to create "uftrace.data/sid-xxxxx.map" of which the prefix
is a relative path. So convert uftrace data directory path that can be
relative to an absolute path in tracing (shell) scripts case.

Fixed: #745