### PR TITLE
mcount: Fix incorrect mtdp recursion handling

### DIFF
--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -1554,9 +1554,6 @@ static void atfork_child_handler(void)
 
 	mtdp = get_thread_data();
 	if (unlikely(check_thread_data(mtdp))) {
-		/* we need it even if in a recursion */
-		mtdp->recursion_marker = false;
-
 		mtdp = mcount_prepare();
 		if (mtdp == NULL)
 			return;


### PR DESCRIPTION
It seems that there was a mistake when refactoring mtdp recursion guard.
It makes a segfault in many big programs because mtdp->recursion_guard
is accessed when mtdp is NULL.

Since recursion guard can be properly managed inside mcount_prepare(),
this patch simply removes the problematic code.

Fixed: #753 #638 #752

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>