### PR TITLE
i386: Fix a build error in mcount_patch_func

### DIFF
--- a/arch/i386/mcount-dynamic.c
+++ b/arch/i386/mcount-dynamic.c
@@ -102,7 +102,8 @@ static int patch_fentry_func(struct mcount_dynamic_info *mdi, struct sym *sym)
 	return 0;
 }
 
-int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym)
+int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym,
+		      struct mcount_disasm_engine *disasm)
 {
 	return patch_fentry_func(mdi, sym);
 }


### PR DESCRIPTION
This patch is to fix the following build error.
```
  arch/i386/mcount-dynamic.c:105:5: error: conflicting types for ‘mcount_patch_func’
   int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym)
       ^
  In file included from arch/i386/mcount-dynamic.c:9:0:
  libmcount/internal.h:431:5: note: previous declaration of ‘mcount_patch_func’ was here
   int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym,
                         struct mcount_disasm_engine *disasm)
       ^
  Makefile:28: recipe for target 'arch/i386/mcount-dynamic.op' failed
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>