### PR TITLE
kernel: Fix caller filter with time filter

### DIFF
--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -1655,7 +1655,7 @@ static int read_kernel_cpu(struct uftrace_data *handle, int cpu)
 				filtered = true;
 
 			if (handle->caller_filter)
-				filtered = !(tr.flags & TRIGGER_FL_CALLER);
+				filtered |= !(tr.flags & TRIGGER_FL_CALLER);
 
 			if (filtered) {
 				/* also delete matching entry (at the last) */


### PR DESCRIPTION
It was missing to update the fix for caller filter with time filter as
written in the following commit.

  7dc6915 fstack: Fix caller filter with time filter

Fixed: #622

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>