### PR TITLE
build: Do not set stack memory as executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ export ARCH CC AR LD RM srcdir objdir LDFLAGS
 COMMON_CFLAGS := -D_GNU_SOURCE $(CFLAGS) $(CPPFLAGS)
 COMMON_CFLAGS += -iquote $(srcdir) -iquote $(objdir) -iquote $(srcdir)/arch/$(ARCH)
 #CFLAGS-DEBUG = -g -D_GNU_SOURCE $(CFLAGS_$@)
-COMMON_LDFLAGS := -lrt -ldl -pthread $(LDFLAGS)
+COMMON_LDFLAGS := -lrt -ldl -pthread -Wl,-z,noexecstack $(LDFLAGS)
 ifneq ($(elfdir),)
   COMMON_CFLAGS  += -I$(elfdir)/include
   COMMON_LDFLAGS += -L$(elfdir)/lib


### PR DESCRIPTION
libmcount*.so don't need to have executable permission on its stack.
It can make some difference in the original programs by having
executable permission on its stack.

For example, there is a failed unittest in chrome because of it.

    $ uftrace record ./base_unittests --gtest_filter=ProcMapsTest.ReadProcMaps

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>