### PR TITLE
build: Fix a few warnings in clang build

### DIFF
--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -369,7 +369,7 @@ static int patch_xray_func(struct mcount_dynamic_info *mdi, struct sym *sym)
 static void patch_code(struct mcount_dynamic_info *mdi,
 		       uintptr_t addr, uint32_t origin_code_size)
 {
-	unsigned char *origin_code_addr;
+	void *origin_code_addr;
 	unsigned char call_insn[] = { 0xe8, 0x00, 0x00, 0x00, 0x00 };
 	uint32_t target_addr = get_target_addr(mdi, addr);
 

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -259,6 +259,9 @@ static int parse_sigspec(char *spec, struct uftrace_filter_setting *setting)
 		.sa_handler  = mcount_signal_trigger,
 		.sa_flags    = SA_RESTART,
 	};
+	const char *sigrtm   = "SIGRTM";
+	const char *sigrtmin = "SIGRTMIN";
+	const char *sigrtmax = "SIGRTMAX";
 
 	pos = strchr(spec, '@');
 	if (pos == NULL)
@@ -291,10 +294,10 @@ static int parse_sigspec(char *spec, struct uftrace_filter_setting *setting)
 	}
 
 	/* real-time signals */
-	if (!strncmp(spec, "SIGRTM" + off, 6 - off)) {
-		if (!strncmp(spec, "SIGRTMIN" + off, 8 - off))
+	if (!strncmp(spec, sigrtm + off, 6 - off)) {
+		if (!strncmp(spec, sigrtmin + off, 8 - off))
 			sig = SIGRTMIN + strtol(&spec[8 - off], NULL, 0);
-		if (!strncmp(spec, "SIGRTMAX" + off, 8 - off))
+		if (!strncmp(spec, sigrtmax + off, 8 - off))
 			sig = SIGRTMAX + strtol(&spec[8 - off], NULL, 0);
 		signame = spec;
 	}


### PR DESCRIPTION
clang compiler doesn't allow the following syntax:
```
  warning: adding 'int' to a string does not append to the string
  strncmp(spec, "SIGRTM" + off, 6 - off)
                ~~~~~~~~~^~~~~
```
There are a few more warnings as follows:
```
  warning: passing 'unsigned char *' to parameter of type 'char *'
           converts between pointers to integer types with different sign
          __builtin___clear_cache(origin_code_addr,
                                  ^~~~~~~~~~~~~~~~
  warning: passing 'unsigned char *' to parameter of type 'char *'
           converts between pointers to integer types with different sign
                                  origin_code_addr + origin_code_size);
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This patch is to avoid such warnings.

Fixed: #764

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>