### PR TITLE
misc: Add clock_gettime family to misc/prototypes.h

### DIFF
--- a/misc/prototypes.h
+++ b/misc/prototypes.h
@@ -522,4 +522,22 @@ int setresgid(uid_t rgid, uid_t egid, uid_t sgid);
 int chown(const char *path, uid_t uid, uid_t gid);
 int lchown(const char *path, uid_t uid, uid_t gid);
 int fchown(int fd, uid_t uid, uid_t gid);
+
+#include <time.h>
+enum uft_clockid_t {
+	CLOCK_REALTIME = 0,
+	CLOCK_MONOTONIC,
+	CLOCK_PROCESS_CPUTIME_ID,
+	CLOCK_THREAD_CPUTIME_ID,
+	CLOCK_MONOTONIC_RAW,
+	CLOCK_REALTIME_COARSE,
+	CLOCK_MONOTONIC_COARSE,
+	CLOCK_BOOTTIME,
+	CLOCK_REALTIME_ALARM,
+	CLOCK_BOOTTIME_ALARM,
+	CLOCK_TAI = 11,
+};
+int clock_getres(enum uft_clockid_t clk_id, struct timespec *res);
+int clock_gettime(enum uft_clockid_t clk_id, struct timespec *tp);
+int clock_settime(enum uft_clockid_t clk_id, const struct timespec *tp);
 ////////////////////////////////////////////////////////////////////////////////

--- a/utils/auto-args.h
+++ b/utils/auto-args.h
@@ -25,6 +25,7 @@ static char *auto_enum_list =
 	"enum uft_epoll_op { EPOLL_CTL_ADD = 1, EPOLL_CTL_DEL, EPOLL_CTL_MOD };"
 	"enum uft_locale {LC_TYPE = 0, LC_NUMERIC, LC_TIME, LC_COLLATE, LC_MONETARY, LC_MESSAGES,LC_ALL, LC_PAPER, LC_NAME, LC_ADDRESS, LC_TELEPHONE, LC_MEASUREMENT,LC_IDENTIFICATION,};"
 	"enum uft_mode {mod_777 = 0777, mod_755 = 0755, mod_666 = 0666, mod_644 = 0644,mod_400 = 0400, mod_600 = 0600, mod_660 = 0660, mod_640 = 0640,mod_444 = 0444, mod_022 = 0022, mod_440 = 0440, mod_222 = 0222,mod_111 = 0111, mod_011 = 0011, mod_033 = 0033, mod_077 = 0077,};"
+	"enum uft_clockid_t {CLOCK_REALTIME = 0,CLOCK_MONOTONIC,CLOCK_PROCESS_CPUTIME_ID,CLOCK_THREAD_CPUTIME_ID,CLOCK_MONOTONIC_RAW,CLOCK_REALTIME_COARSE,CLOCK_MONOTONIC_COARSE,CLOCK_BOOTTIME,CLOCK_REALTIME_ALARM,CLOCK_BOOTTIME_ALARM,CLOCK_TAI = 11,};"
 ;
 
 static char *auto_args_list =
@@ -241,6 +242,9 @@ static char *auto_args_list =
 	"chown@arg1/s,arg2/i32,arg3/i32;"
 	"lchown@arg1/s,arg2/i32,arg3/i32;"
 	"fchown@arg1/d32,arg2/i32,arg3/i32;"
+	"clock_getres@arg1/e:uft_clockid_t,arg2/p;"
+	"clock_gettime@arg1/e:uft_clockid_t,arg2/p;"
+	"clock_settime@arg1/e:uft_clockid_t,arg2/p;"
 ;
 
 static char *auto_retvals_list =
@@ -452,5 +456,8 @@ static char *auto_retvals_list =
 	"chown@retval/d32;"
 	"lchown@retval/d32;"
 	"fchown@retval/d32;"
+	"clock_getres@retval/d32;"
+	"clock_gettime@retval/d32;"
+	"clock_settime@retval/d32;"
 ;
 


### PR DESCRIPTION
This patch adds the prototypes of the following functions.
```
  int clock_getres(clockid_t clk_id, struct timespec *res);
  int clock_gettime(clockid_t clk_id, struct timespec *tp);
  int clock_settime(clockid_t clk_id, const struct timespec *tp);
```
Let's say there is an example related to clock in C++ chrono as follows:
```
  $ cat chrono_clock.cc
  #include <chrono>
  int main()
  {
    std::chrono::system_clock::now();
    std::chrono::steady_clock::now();
    std::chrono::high_resolution_clock::now();
  }
```
It's very easy to see how each C++ chrono class internally calls
clock_gettime() as follows:
```
  $ g++ -std=c++11 -pg chrono_clock.cc
  $ uftrace -la -f none --no-comment a.out
  main() {
    std::chrono::_V2::system_clock::now() {
      clock_gettime(CLOCK_REALTIME, 0x7ffd800ee4c0) = 0;
    }
    std::chrono::_V2::steady_clock::now() {
      clock_gettime(CLOCK_MONOTONIC, 0x7ffd800ee4c0) = 0;
    }
    std::chrono::_V2::system_clock::now() {
      clock_gettime(CLOCK_REALTIME, 0x7ffd800ee4c0) = 0;
    }
  }
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>