### PR TITLE
doc: readme update

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,10 +1,10 @@
 QUICK GUIDE
 ===========
 
-On linux distros machines, following commands will build and install uftrace from
-source.
+On Linux distros, following commands will build and install uftrace from source.
 
-    $ sudo misc/install-deps.sh                 # optional for special features
+    $ sudo misc/install-deps.sh    # optional for advanced features
+    $ ./configure                  # --prefix can be used to change install dir
     $ make
     $ sudo make install
 
@@ -21,8 +21,9 @@ The latest version of uftrace is available at Github.
 DEPENDENCY
 ==========
 
-Now uftrace can be built without any external libraries.  But in order to use
-more advanced features, it'd be better to install them like below.
+The uftrace is written in C and tried to minimize external dependencies.
+Currently, uftrace can be built without any external libraries.  But in order to
+use more advanced features, it'd be better to install them like below.
 
 Firstly, please make sure `pkg-config` is installed in the system to properly
 detect the dependencies of uftrace.  Otherwise, some packages may not be

--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ if the system enables the function graph tracer in the kernel
 (`CONFIG_FUNCTION_GRAPH_TRACER=y`).
 
 
+How to build and install uftrace
+================================
+
+On Linux distros, [misc/install-deps.sh](misc/install-deps.sh) installs required
+software(s) on your system.  Those are for optional advanced features but highly
+recommend to install them together.
+
+    $ sudo misc/install-deps.sh
+
+Once you installed required software(s) on your system, it can be built and
+installed like following:
+
+    $ ./configure
+    $ make
+    $ sudo make install
+
+For more advanced setup, please refer [INSTALL.md](INSTALL.md) file.
+
+
 How to use uftrace
 ==================
 The uftrace command has following subcommands:
@@ -224,25 +243,6 @@ Currently python (version 2.7) is supported only.
 The `tui` command is for interactive text-based user interface using ncurses.
 It provides basic functionality of `graph`, `report` and `info` commands as of
 now.
-
-
-How to build and install uftrace
-================================
-
-On Linux distros, [misc/install-deps.sh](misc/install-deps.sh) installs required
-software(s) on your system.  Those are for optional advanced features but highly
-recommend to install them together.
-
-    $ sudo misc/install-deps.sh
-
-Once you installed required software(s) on your system, it can be built and
-installed like following:
-
-    $ ./configure
-    $ make
-    $ sudo make install
-
-For more advanced setup, please refer [INSTALL.md](INSTALL.md) file.
 
 
 Limitations

--- a/README.md
+++ b/README.md
@@ -226,21 +226,23 @@ It provides basic functionality of `graph`, `report` and `info` commands as of
 now.
 
 
-How to install uftrace
-======================
+How to build and install uftrace
+================================
 
-The uftrace is written in C and tried to minimize external dependencies.
-Currently it does not require any of them but there're some optional
-dependencies to enable advanced features.
+On Linux distros, [misc/install-deps.sh](misc/install-deps.sh) installs required
+software(s) on your system.  Those are for optional advanced features but highly
+recommend to install them together.
+
+    $ sudo misc/install-deps.sh
 
 Once you installed required software(s) on your system, it can be built and
 installed like following:
 
+    $ ./configure
     $ make
     $ sudo make install
 
-For more advanced setup, please refer
-[INSTALL.md](INSTALL.md) file.
+For more advanced setup, please refer [INSTALL.md](INSTALL.md) file.
 
 
 Limitations

--- a/README.md
+++ b/README.md
@@ -205,7 +205,14 @@ The `dump` command shows raw output of each trace record.  You can see the resul
 in the chrome browser, once the data is processed with `uftrace dump --chrome`.
 Below is a trace of clang (LLVM) compiling a small C++ template metaprogram.
 
-![uftrace-chrome-dump](doc/uftrace-chrome.png)
+[![uftrace-chrome-dump](doc/uftrace-chrome.png)](https://uftrace.github.io/dump/clang.tmp.fib.html)
+
+It also supports flame-graph output as well.  The data can be processed with
+`uftrace dump --flame-graph` and passed to
+[flamegraph.pl](https://github.com/brendangregg/FlameGraph/blob/master/flamegraph.pl).
+Below is a flame graph result of gcc compiling a simple C program.
+
+[![uftrace-flame-graph-dump](https://uftrace.github.io/dump/gcc.svg)](https://uftrace.github.io/dump/gcc.svg)
 
 The `info` command shows system and program information when recorded.
 

--- a/doc/uftrace.html
+++ b/doc/uftrace.html
@@ -1624,11 +1624,11 @@ template: title-layout
   - uftrace dump --chrome
 ---
 ### [Chrome Trace Viewer](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool)
-.footnote[<a href="https://honggyukim.github.io/uftrace/cppcon2016/clang.tmp.fib.html" target="_blank">open in chrome trace viewer</a>]
+.footnote[<a href="https://uftrace.github.io/dump/clang.tmp.fib.html" target="_blank">open in chrome trace viewer</a>]
 - Below is a trace of clang (LLVM) compiling a small C++ template metaprogram.
   - uftrace dump --chrome
 
-<a href="https://honggyukim.github.io/uftrace/cppcon2016/clang.tmp.fib.html" target="_blank">
+<a href="https://uftrace.github.io/dump/clang.tmp.fib.html" target="_blank">
 <img src="https://raw.githubusercontent.com/namhyung/uftrace/master/doc/uftrace-chrome.png" class="center-image" width="90%">
 </a>
 ---


### PR DESCRIPTION
This PR updates README page with the following changes:
- slide: Fix a broken link to clang dumped html page
- doc: Add flame-graph chart to README.md
- doc: Move build guide to upper part of README.md
- doc: Refine install description

https://github.com/honggyukim/uftrace/tree/doc/readme-update