### PR TITLE
dynamic: support for patching external modules with the full-dynamic

### DIFF
--- a/tests/s-dynmain.c
+++ b/tests/s-dynmain.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+extern int lib_a(int i);
+extern int lib_d(int i);
+
+int main(void)
+{
+	int res = lib_a(1111);
+	res += lib_d(4444);
+
+	return 0;
+}

--- a/tests/s-libdyn1.c
+++ b/tests/s-libdyn1.c
@@ -1,0 +1,24 @@
+/*
+ * This is test to trace function in a library.
+ */
+#include <unistd.h>
+
+int lib_a(int i);
+static int lib_b(int i);
+static int lib_c(int i);
+
+int lib_a(int i)
+{
+	return lib_b(i + 1) - 1;
+}
+
+static int lib_b(int i)
+{
+	return lib_c(i - 1) + 1;
+}
+
+static int lib_c(int mask)
+{
+	return getpid() % mask;
+}
+

--- a/tests/s-libdyn2.c
+++ b/tests/s-libdyn2.c
@@ -1,0 +1,24 @@
+/*
+ * This is test to trace function in a library.
+ */
+#include <unistd.h>
+
+int lib_d(int i);
+static int lib_e(int i);
+static int lib_f(int i);
+
+int lib_d(int i)
+{
+	return lib_e(i + 1) - 1;
+}
+
+static int lib_e(int i)
+{
+	return lib_f(i - 1) + 1;
+}
+
+static int lib_f(int mask)
+{
+	return getpid() % mask;
+}
+

--- a/tests/t224_dynamic_lib.py
+++ b/tests/t224_dynamic_lib.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'dynmain', """
+# DURATION     TID     FUNCTION
+         [ 26661] | main() {
+         [ 26661] |   lib_a() {
+         [ 26661] |     lib_b() {
+1.187 us [ 26661] |       lib_c();
+2.271 us [ 26661] |     } /* lib_b */
+2.647 us [ 26661] |   } /* lib_a */
+         [ 26661] |   lib_d() {
+         [ 26661] |     lib_e() {
+0.974 us [ 26661] |       lib_f();
+1.266 us [ 26661] |     } /* lib_e */
+1.438 us [ 26661] |   } /* lib_d */
+7.607 us [ 26661] | } /* main */
+""")
+
+    def build(self, name, cflags='', ldflags=''):
+        if TestBase.build_notrace_lib(self, 'dyn1', 'libdyn1', cflags, ldflags) != 0:
+            return TestBase.TEST_BUILD_FAIL
+        if TestBase.build_notrace_lib(self, 'dyn2', 'libdyn2', cflags, ldflags) != 0:
+            return TestBase.TEST_BUILD_FAIL
+
+        return TestBase.build_libmain(self, name, 's-dynmain.c',
+                                      ['libdyn1.so', 'libdyn2.so'],
+                                      cflags, ldflags, instrument=False)
+
+    def runcmd(self):
+        uftrace = TestBase.uftrace_cmd
+        options = '-Pmain -P.@libdyn1.so -P.@libdyn2.so --no-libcall'
+        program = 't-' + self.name
+        return '%s %s %s' % (uftrace, options, program)


### PR DESCRIPTION
the patch function functionally was previously only applicable to main
binary functions. However, it can also patch the functions of the
external module after the "Full-Dynamic" update. so, this PR make this
possible through the '-p' option.

Usage:
```
$ uftrace -P.@libv8.so v8_shell
```
Write the name of the function to be patched before @ and write the name
of the module containing the function.

Signed-off-by: Hanbum Park <kese111@gmail.com>