### PR TITLE
arm: aarch64: Add description for arch registers

### DIFF
--- a/arch/aarch64/mcount.S
+++ b/arch/aarch64/mcount.S
@@ -1,5 +1,32 @@
 #include "utils/asm.h"
 
+/*
+Integer registers
+  The AArch64 architecture supports 32 integer registers:
+
+    Regster  |   Volatile?  | Role
+  -----------+--------------+---------------------------------------------------
+    x0       |     Volatile | Parameter/scratch register 1, result register
+    x1 - x7  |     Volatile | Parameter/scratch register 2-8
+    x8 - x15 |     Volatile | Scratch registers
+   x16 - x17 |     Volatile | Intra-procedure-call scratch registers
+   x18       | Non-Volatile | Platform register: in kernel mode, points to KPCR
+             |              | for the current processor; in user mode, points to TEB
+   x19 - x28 | Non-Volatile | Scratch registers
+   x29 / fp  | Non-Volatile | Frame pointer
+   x30 / lr  | Non-Volatile | Link register
+
+Floating-point/SIMD registers
+  The AArch64 architecture also supports 32 floating-point/SIMD registers:
+
+    Regster  |   Volatile?  | Role
+  -----------+--------------+---------------------------------------------------
+    v0       |     Volatile | Parameter/scratch register 1, result register
+    v1 - v7  |     Volatile | Parameter/scratch registers 2-8
+    v8 - v15 | Non-Volatile | Scratch registers (only the low 64 bits are non-volatile)
+   v16 - v31 |     Volatile | Scratch registers
+*/
+
 .text
 
 /* universal stack constraint: (SP mod 16) == 0 */

--- a/arch/arm/mcount.S
+++ b/arch/arm/mcount.S
@@ -36,6 +36,34 @@
  * parameters.)
  */
 
+/*
+Integer registers
+  The ARM processor supports 16 integer registers:
+
+    Regster  |   Volatile?  | Role
+  -----------+--------------+---------------------------------------------------
+    r0       |     Volatile | Parameter, result, scratch register 1
+    r1       |     Volatile | Parameter, result, scratch register 2
+    r2       |     Volatile | Parameter, scratch register 3
+    r3       |     Volatile | Parameter, scratch register 4
+    r4 - r10 | Non-Volatile |
+    r11      | Non-Volatile | Frame pointer
+    r12      |     Volatile | Intra-procedure-call scratch register
+    r13 (SP) | Non-Volatile | Stack pointer
+    r14 (LR) | Non-Volatile | Link register
+    r15 (PC) | Non-Volatile | Program counter
+
+VFP registers
+  The VFP registers and their usage are summarized in this table:
+
+    Singles  |  Doubles  |  Quads    |   Volatile?  | Role
+  -----------+-----------+-----------+--------------+---------------------------
+    s0 - s3  |  d0 - d1  |  q0       |     Volatile | Parameters, result, scratch register
+    s4 - s15 |  d2 - d7  |  q1 - q3  |     Volatile | Parameters, scratch register
+   s16 - s31 |  d8 - d15 |  q4 - q7  | Non-Volatile |
+             | d16 - d31 |  q8 - q15 |     Volatile |
+*/
+
 #include "utils/asm.h"
 
 	.text


### PR DESCRIPTION
It'd be a lot easier to understand the assembly code by having
description table for architecture registers.

This patch adds the register table to mcount.S for ARM[1] and AArch64[2].

References:
[1] https://docs.microsoft.com/ko-kr/cpp/build/overview-of-arm-abi-conventions?view=vs-2019
[2] https://docs.microsoft.com/ko-kr/cpp/build/arm64-windows-abi-conventions?view=vs-2019

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>