### PR TITLE
build: Fix a build error due to missing errno.h

### DIFF
--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <dlfcn.h>
 #include <fnmatch.h>
+#include <errno.h>
 
 /* This should be defined before #include "utils.h" */
 #define PR_FMT     "plthook"


### PR DESCRIPTION
This patch is to fix the following build error for ARM arch.

    libmcount/plthook.c:899:20: error: 'errno' undeclared

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>