### PR TITLE
uftrace: Introduce uftrace.data/default.opts file

### DIFF
--- a/tests/s-sleep2.c
+++ b/tests/s-sleep2.c
@@ -1,0 +1,21 @@
+#include <stdlib.h>
+#include <unistd.h>
+
+void bar(void)
+{
+	usleep(3000);
+}
+
+void foo(void)
+{
+	usleep(5000);
+	bar();
+}
+
+int main(void)
+{
+	usleep(1000);
+
+	foo();
+	return 0;
+}

--- a/tests/t226_default_opts.py
+++ b/tests/t226_default_opts.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+import subprocess as sp
+
+TDIR='xxx'
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'sleep2', result="""
+# DURATION     TID     FUNCTION
+            [ 41487] | main() {
+            [ 41487] |   foo() {
+   5.107 ms [ 41487] |     usleep();
+   8.220 ms [ 41487] |   } /* foo */
+   9.336 ms [ 41487] | } /* main */
+""")
+
+    def pre(self):
+        record_cmd = '%s record -d %s -t 2ms %s' % (TestBase.uftrace_cmd, TDIR, 't-sleep2')
+        sp.call(record_cmd.split())
+        return TestBase.TEST_SUCCESS
+
+    def runcmd(self):
+        return '%s -t 4ms %s' % (TestBase.uftrace_cmd, 't-' + self.name)
+
+    def post(self, ret):
+        sp.call(['rm', '-rf', TDIR])
+        return ret

--- a/uftrace.c
+++ b/uftrace.c
@@ -460,6 +460,10 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 		break;
 
 	case 't':
+		/* add time-filter to uftrace.data/default.opts */
+		strv_append(&default_opts, "-t");
+		strv_append(&default_opts, arg);
+
 		opts->threshold = parse_time(arg, 3);
 		if (opts->range.start || opts->range.stop) {
 			pr_use("--time-range cannot be used with --time-filter\n");

--- a/uftrace.h
+++ b/uftrace.h
@@ -272,6 +272,8 @@ struct opts {
 	enum uftrace_pattern_type patt_type;
 };
 
+extern struct strv default_opts;
+
 static inline bool opts_has_filter(struct opts *opts)
 {
 	return opts->filter || opts->trigger || opts->threshold ||


### PR DESCRIPTION
This introduces a new file "default.opts" in uftrace.data directory.
The file "uftrace.data/default.opts" will contain the default options to
be applied during running analysis commands.

In some cases, the record time filters are not properly applied for
analysis commands especially for kernel and event records.

It can be fixed by applying the record time filter again for analysis
commands.

Fixed: #658 #739

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>