### PR TITLE
utils: Add pr_dbg4 and use it for trivial messages

### DIFF
--- a/utils/demangle.c
+++ b/utils/demangle.c
@@ -175,9 +175,9 @@ static void dd_debug_print(struct demangle_data *dd)
 		dd_eof(dd) ? " (EOF)" : "", dd->level ? " (not finished)" : "",
 		dd->old, dd->pos + 1, '^', dd->func, dd->line, expected);
 
-	pr_dbg2("current: %s (pos: %d/%d)\n", dd->new, dd->pos, dd->len);
+	pr_dbg3("current: %s (pos: %d/%d)\n", dd->new, dd->pos, dd->len);
 	for (i = 0; i < dd->nr_dbg; i++)
-		pr_dbg2("  [%d] %s\n", i, dd->debug[i]);
+		pr_dbg4("  [%d] %s\n", i, dd->debug[i]);
 }
 
 static const struct {

--- a/utils/dwarf.c
+++ b/utils/dwarf.c
@@ -955,7 +955,7 @@ static int get_dwarfspecs_cb(Dwarf_Die *die, void *data)
 	 */
 	sym = find_sym(bd->symtab, offset + 1);
 	if (sym == NULL || !match_name(sym, name)) {
-		pr_dbg2("skip unknown debug info: %s / %s (%lx)\n",
+		pr_dbg4("skip unknown debug info: %s / %s (%lx)\n",
 			sym ? sym->name : "no name", name, offset);
 		goto out;
 	}

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -131,6 +131,12 @@ extern void setup_signal(void);
 		__pr_dbg(PR_FMT ": " fmt, ## __VA_ARGS__);	\
 })
 
+#define pr_dbg4(fmt, ...) 					\
+({								\
+	if (dbg_domain[PR_DOMAIN] > 3)		\
+		__pr_dbg(PR_FMT ": " fmt, ## __VA_ARGS__);	\
+})
+
 #define pr_err(fmt, ...)					\
 	__pr_err_s(PR_FMT ": %s:%d:%s\n ERROR: " fmt,		\
 		 __FILE__, __LINE__, __func__, ## __VA_ARGS__)


### PR DESCRIPTION
It'd be better to distinguish between mcount and plthook related debug
messages because they are directly related to program execution.

It's better not to print too many symbol, dwarf, and demangle messages
when we want to see where the program is segfaulted.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>