### PR TITLE
aarch64: Handle struct return type by keeping more regs on stack

### DIFF
--- a/arch/aarch64/mcount.S
+++ b/arch/aarch64/mcount.S
@@ -39,6 +39,11 @@ ENTRY(mcount_return)
 	/* save return values */
 	stp	x0, x1, [sp, #-16]!
 	stp	d0, d1, [sp, #-16]!
+
+	/*
+	 * save indirect result location register
+	 * used in C++ for returning non-trivial objects
+	 */
 	str	x8, [sp, #-16]!
 
 	add	x0, sp, #32
@@ -46,8 +51,10 @@ ENTRY(mcount_return)
 	bl	mcount_exit
 	mov	x16, x0
 
-	/* restore return values */
+	/* restore indirect result location register */
 	ldr	x8, [sp], #16
+
+	/* restore return values */
 	ldp	d0, d1, [sp], #16
 	ldp	x0, x1, [sp], #16
 

--- a/arch/aarch64/mcount.S
+++ b/arch/aarch64/mcount.S
@@ -35,17 +35,22 @@ END(_mcount)
 ENTRY(mcount_return)
 	/* setup frame pointer */
 	stp	x29, x30, [sp, #-16]!
-	/* save return values */
-	stp	x0, x8, [sp, #-16]!
-	str	d0, [sp, #-16]!
 
-	add	x0, sp, #16
+	/* save return values */
+	stp	x0, x1, [sp, #-16]!
+	stp	d0, d1, [sp, #-16]!
+	str	x8, [sp, #-16]!
+
+	add	x0, sp, #32
+
 	bl	mcount_exit
 	mov	x16, x0
 
 	/* restore return values */
-	ldr	d0, [sp], #16
-	ldp	x0, x8, [sp], #16
+	ldr	x8, [sp], #16
+	ldp	d0, d1, [sp], #16
+	ldp	x0, x1, [sp], #16
+
 	/* restore frame pointer */
 	ldp	x29, x30, [sp], #16
 

--- a/arch/aarch64/plthook.S
+++ b/arch/aarch64/plthook.S
@@ -81,9 +81,19 @@ ENTRY(plthook_return)
 	stp	x0, x1, [sp, #-16]!
 	stp	d0, d1, [sp, #-16]!
 
-	add	x0, sp, #16
+	/*
+	 * save indirect result location register
+	 * used in C++ for returning non-trivial objects
+	 */
+	str	x8, [sp, #-16]!
+
+	add	x0, sp, #32
+
 	bl	plthook_exit
 	mov	x16, x0
+
+	/* restore indirect result location register */
+	ldr	x8, [sp], #16
 
 	/* restore return values */
 	ldp	d0, d1, [sp], #16

--- a/arch/aarch64/plthook.S
+++ b/arch/aarch64/plthook.S
@@ -76,16 +76,19 @@ END(plt_hooker)
 ENTRY(plthook_return)
 	/* setup frame pointer */
 	stp	x29, x30, [sp, #-16]!
-	stp	x0, x8, [sp, #-16]!
-	str	d0, [sp, #-16]!
+
+	/* save return values */
+	stp	x0, x1, [sp, #-16]!
+	stp	d0, d1, [sp, #-16]!
 
 	add	x0, sp, #16
 	bl	plthook_exit
 	mov	x16, x0
 
 	/* restore return values */
-	ldr	d0, [sp], #16
-	ldp	x0, x8, [sp], #16
+	ldp	d0, d1, [sp], #16
+	ldp	x0, x1, [sp], #16
+
 	/* restore frame pointer */
 	ldp	x29, x30, [sp], #16
 


### PR DESCRIPTION
Current implementation for mcount_return and plthook_return only reserve
x0 register assuming the size of return value is enough with 8 bytes.

But some functions may have a return type in struct and its size is more
than 8 bytes as following example:
```c
  struct { int64_t quot, int64_t rem}
         __aeabi_ldivmod(int64_t numerator, int64_t denominator) {
    int64_t rem, quot;
    quot = __divmoddi4(numerator, denominator, &rem);
    return {quot, rem};
  }
```
In this case, we might partially lose return values because the return
value is stored in x0 and x1 registers to keep 16 bytes in the return
type of struct { int64_t quot, int64_t rem}.

So this patch fixes to keep both x0 and x1 registers to prevent such
problems.

It's also required to save d0 and d1 VFP registers in return hook.

This patch is inspired by the following commit for arm.

  ffb69ce arm: Handle struct return type by keeping more regs on stack

It also saves `x8` register for library calls same as user functions.

Fixed: #791

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>