### PR TITLE
info: Disable pager for info command

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -1049,7 +1049,8 @@ int main(int argc, char *argv[])
 
 	if (opts.mode == UFTRACE_MODE_RECORD ||
 	    opts.mode == UFTRACE_MODE_RECV ||
-	    opts.mode == UFTRACE_MODE_TUI)
+	    opts.mode == UFTRACE_MODE_TUI ||
+	    opts.mode == UFTRACE_MODE_INFO)
 		opts.use_pager = false;
 	if (opts.nop)
 		opts.use_pager = false;


### PR DESCRIPTION
uftrace info output doesn't have to use pager so disable it.
It makes the output urgly especially in busybox environment.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>