### PR TITLE
record: Remove a message for installtion path check

### DIFF
--- a/cmds/record.c
+++ b/cmds/record.c
@@ -131,14 +131,10 @@ char * get_libmcount_path(struct opts *opts)
 	}
 
 #ifdef INSTALL_LIB_PATH
+	/* try first to load libmcount from the installtion path */
 	snprintf(lib, PATH_MAX, "%s/%s", INSTALL_LIB_PATH, libmcount);
 	if (access(lib, F_OK) == 0)
 		return lib;
-
-	if (errno == ENOENT)
-		pr_warn("Didn't you run 'make install' ?\n");
-
-	/* fall through */
 #endif
 	strcpy(lib, libmcount);
 	return lib;


### PR DESCRIPTION
In some cases, the following message is printed in a normal execution.

    # uftrace record --force pwd
    WARN: Didn't you run 'make install' ?
    /home/root

The message is printed if libmcount.so is not found the installtion
path, but it can be used anywhere especially in embedded environments
that use read-only file system.

It seems that specifying the basename of libmcount.so is enough for
LD_PRELOAD, it'd be better to remove this message.

But if libmcount.so is found in the installtion path, it has the higher
priority of use.

Fixed: #796

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>