### PR TITLE
misc: Add capstone package separately

### DIFF
--- a/misc/install-deps.sh
+++ b/misc/install-deps.sh
@@ -13,12 +13,15 @@ distro=$(grep "^ID=" /etc/os-release | cut -d\= -f2 | sed -e 's/"//g')
 
 case $distro in
     "ubuntu" | "debian")
-        apt-get $OPT install pandoc libdw-dev libpython2.7-dev libncursesw5-dev libcapstone-dev pkg-config ;;
+        apt-get $OPT install pandoc libdw-dev libpython2.7-dev libncursesw5-dev pkg-config
+        apt-get $OPT install libcapstone-dev ;;
     "fedora")
-        dnf install $OPT pandoc elfutils-devel python2-devel ncurses-devel capstone-devel pkgconf-pkg-config ;;
+        dnf install $OPT pandoc elfutils-devel python2-devel ncurses-devel pkgconf-pkg-config
+        dnf install $OPT capstone-devel ;;
     "rhel" | "centos")
         rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-        yum install $OPT pandoc elfutils-devel python2-devel ncurses-devel capstone-devel pkgconfig ;;
+        yum install $OPT pandoc elfutils-devel python2-devel ncurses-devel pkgconfig
+        yum install $OPT capstone-devel ;;
     *) # we can add more install command for each distros.
         echo "\"$distro\" is not supported distro, so please install packages manually." ;;
 esac


### PR DESCRIPTION
In some old distros such as Ubuntu 14.04, capstone is not provided.
In this case, the entire package installation gets failed.
```
  $ sudo ./misc/install-deps.sh
  Reading package lists... Done
  Building dependency tree
  Reading state information... Done
  E: Unable to locate package libcapstone-dev
```
To prevent such problems, it'd be better to add capstone installtion
separetely so that it doesn't affect other pacakge installation.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>