### PR TITLE
arm: Fix segfault by adjusting map start address

### DIFF
--- a/arch/arm/mcount-support.c
+++ b/arch/arm/mcount-support.c
@@ -20,8 +20,6 @@ struct lr_offset {
 
 #define REG_SP  13
 
-static struct rb_root offset_cache = RB_ROOT;
-
 /* whether current machine supports hardfp */
 static bool use_hard_float = false;
 
@@ -38,37 +36,6 @@ struct offset_entry {
 	unsigned long  addr;
 	unsigned long  offset;
 };
-
-static struct offset_entry *lookup_cache(struct rb_root *root,
-					 unsigned long addr, bool create)
-{
-	struct rb_node *parent = NULL;
-	struct rb_node **p = &root->rb_node;
-	struct offset_entry *iter;
-
-	while (*p) {
-		parent = *p;
-		iter = rb_entry(parent, struct offset_entry, node);
-
-		if (iter->addr == addr)
-			return iter;
-
-		if (iter->addr > addr)
-			p = &parent->rb_left;
-		else
-			p = &parent->rb_right;
-	}
-
-	if (!create)
-		return NULL;
-
-	iter = xmalloc(sizeof(*iter));
-	iter->addr = addr;
-
-	rb_link_node(&iter->node, parent, p);
-	rb_insert_color(&iter->node, root);
-	return iter;
-}
 
 static unsigned rotate_right(unsigned val, unsigned bits, unsigned shift)
 {
@@ -274,17 +241,10 @@ unsigned long *mcount_arch_parent_location(struct symtabs *symtabs,
 	if ((sym->addr & 1) == 0)
 		return parent_loc;
 
-	cache = lookup_cache(&offset_cache, sym->addr, false);
-	if (cache)
-		return parent_loc + cache->offset;
-
 	pr_dbg2("copying instructions of %s\n", sym->name);
 	memcpy(buf, (void *)(long)(sym->addr & ~1), sizeof(buf));
 
 	analyze_mcount_instructions(buf, &lr);
-
-	cache = lookup_cache(&offset_cache, sym->addr, true);
-	cache->offset = lr.offset;
 
 	return parent_loc + lr.offset;
 }


### PR DESCRIPTION
As of now, record command always gets segfault in arm environment.
It's a regression that was introduced by the following commit.

  d8eb70b4 symbol: Use module symbol table in find_symtabs()

This patch fixes the problem by adding map start address.  In addition
to this, it removes the code for cache lookup because it's not
thread-safe code.

Fixed: #807

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>