### PR TITLE
arch: Fix wrong comment of x86_64/mcount.S

### DIFF
--- a/arch/x86_64/mcount.S
+++ b/arch/x86_64/mcount.S
@@ -51,7 +51,7 @@ GLOBAL(mcount)
 	movq %rsp, %rdx
 	.cfi_def_cfa_register rdx
 
-	/* align stack pointer to 16-byte */
+	/* align stack pointer to 16-bit */
 	andq $0xfffffffffffffff0, %rsp
 	push %rdx
 


### PR DESCRIPTION
If you look at the bottom line, it says 0xfffffffffffffff0.
The stack pointer in the comment is incorrectly written as 16 bytes.

This commit replaces 16 bytes with 16 bits.

Signed-off-by: JinDDeok wlstjr112@naver.com