### PR TITLE
misc: Refactor run-lcov.sh script for branch on/off

### DIFF
--- a/misc/run-lcov.sh
+++ b/misc/run-lcov.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
+info_file=coverage.info
 report_dir=coverage.html
-
-if [ $# -eq 1 ]; then
-  report_dir=$1
-fi
+with_branch=0
 
 which lcov > /dev/null
 lcov_test=$?
@@ -13,9 +11,34 @@ if [ 0 -ne $lcov_test ]; then
 	exit $lcov_test
 fi
 
-info_file=coverage.info
-lcov --capture --rc lcov_branch_coverage=1 --directory . --output-file $info_file
-genhtml $info_file --branch-coverage --output-directory $report_dir
+usage() {
+    echo "Usage: $0 [<options>]
+
+  -h          print this message
+  -o <DIR>    set output report dir as <DIR>            (default: coverage.html)
+  -b          generate the report with branch coverage  (default: off)
+"
+    exit 1
+}
+
+while getopts "o:bh" opt
+do
+    case "$opt" in
+        o) report_dir=$OPTARG ;;
+	b) with_branch=1 ;;
+	h) usage ;;
+        *) usage ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+if [ $with_branch -eq 1 ]; then
+    lcov --capture --rc lcov_branch_coverage=1 --directory . --output-file $info_file
+    genhtml $info_file --branch-coverage --output-directory $report_dir
+else
+    lcov --capture --directory . --output-file $info_file
+    genhtml $info_file --output-directory $report_dir
+fi
 rm -f $info_file
 
 rmdir $report_dir 2> /dev/null


### PR DESCRIPTION
The changed usage of misc/run-lcov.sh is as follows:
```
  $ ./misc/run-lcov.sh -h
  Usage: ./misc/run-lcov.sh [<options>]

    -h          print this message
    -o <DIR>    set output report dir as <DIR>            (default: coverage.html)
    -b          generate the report with branch coverage  (default: off)
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>