### PR TITLE
dynamic: Disallow patching functions with an indirect jump

### DIFF
--- a/arch/x86_64/mcount-insn.c
+++ b/arch/x86_64/mcount-insn.c
@@ -140,8 +140,11 @@ static bool check_unsupported(struct mcount_disasm_engine *disasm, cs_insn *insn
 			}
 			break;
 		case X86_OP_MEM:
-			/* TODO */
+			/* indirect jumps are not allowed */
+			return false;
 			break;
+		case X86_OP_REG:
+			return false;
 		default:
 			break;
 		}


### PR DESCRIPTION
Since it's hard to predict the target of an indirect jump, we just disallow patching it for now.
Allowing it may cause a thread to jump to the prologue and corrupt the execution. 

Signed-off-by: Anas Balboul <anasbalbo@gmail.com>