### PR TITLE
dynamic: Set the size in disasm_check_data to the prologue size of a function

### DIFF
--- a/arch/x86_64/mcount-insn.c
+++ b/arch/x86_64/mcount-insn.c
@@ -163,6 +163,7 @@ int disasm_check_insns(struct mcount_disasm_engine *disasm,
 	struct disasm_check_data insn_check = {
 		.addr		= sym->addr + mdi->map->start,
 		.func_size	= sym->size,
+		.size		= CALL_INSN_SIZE,
 	};
 	struct dynamic_bad_symbol *badsym;
 


### PR DESCRIPTION
I tested dynamic tracing with libcapstone enabled. And I got a segfault with a special function.
The function contains a conditional jump to its "patched bytes aka prologue", yet it was instrumented by uftrace.

The function that segfault the program:

           0000000000000603 <test_func_with_trap>:
            603:	48 31 c9             	xor    %rcx,%rcx
            606:	48 ff c1             	inc    %rcx
            609:	48 83 f9 02          	cmp    $0x2,%rcx
            60d:	75 f7                	jne    606 <test_func_with_trap+0x3>
            60f:	c3                   	retq  

When I checked the value in insn_check->size, I found that it's zero. After setting it to CALL_INSN_SIZE (5), the function wasn't instrumented and the program didn't segfault.