### PR TITLE
uftrace : fix memory leak

### DIFF
--- a/cmds/info.c
+++ b/cmds/info.c
@@ -967,6 +967,10 @@ void clear_uftrace_info(struct uftrace_info *info)
 	free(info->record_date);
 	free(info->elapsed_time);
 	free(info->uftrace_version);
+	free(info->retspec);
+	free(info->autoarg);
+	free(info->autoret);
+	free(info->autoenum);
 }
 
 static void print_info(void *unused, const char *fmt, ...)

--- a/cmds/record.c
+++ b/cmds/record.c
@@ -2158,8 +2158,10 @@ int command_record(int argc, char *argv[], struct opts *opts)
 		else
 			do_child_exec(ready, opts, argc, argv);
 
-		if (channel)
+		if (channel) {
 			unlink(channel);
+			free(channel);
+		}
 		return ret;
 	}
 
@@ -2168,7 +2170,9 @@ int command_record(int argc, char *argv[], struct opts *opts)
 	else
 		ret = do_main_loop(ready, opts, pid);
 
-	if (channel)
+	if (channel) {
 		unlink(channel);
+		free(channel);
+	}
 	return ret;
 }

--- a/uftrace.c
+++ b/uftrace.c
@@ -1006,6 +1006,9 @@ static void free_opts(struct opts *opts)
 	free(opts->retval);
 	free(opts->tid);
 	free(opts->event);
+	free(opts->patch);
+	free(opts->caller);
+	free(opts->watch);
 }
 
 #ifndef UNIT_TEST


### PR DESCRIPTION
Hello,

In the process of using the record function, a memory leak occurs.

So, I added a missing "free()" function.

asprintf() man page:
```
This pointer should be passed to free(3) to release the allocated storage when it is no longer needed.
```

realloc() man page:
```
The free() function frees the memory space pointed to by ptr, which must have been returned by a previous call to malloc(), calloc() or realloc(). Otherwise, or if free(ptr) has already been called before, undefined behavior occurs. If ptr is NULL, no operation is performed.
```

valgrind log:
```
$ valgrind --leak-check=full uftrace record -P. ./yara my_first_rule my_first_rule
==15195== Memcheck, a memory error detector
==15195== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==15195== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==15195== Command: uftrace record -P. ./yara my_first_rule my_first_rule
==15195==
dummy my_first_rule
==15195== Warning: invalid file descriptor -1 in syscall write()
==15195==
==15195== HEAP SUMMARY:
==15195==     in use at exit: 72,728 bytes in 3 blocks
==15195==   total heap usage: 16,979 allocs, 16,976 frees, 2,585,351 bytes allocated
==15195==
==15195== 2 bytes in 1 blocks are definitely lost in loss record 1 of 3
==15195==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==15195==    by 0x4C2FDEF: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==15195==    by 0x43C678: strjoin (utils.c:544)
==15195==    by 0x406D88: opt_add_string (uftrace.c:221)
==15195==    by 0x406D88: parse_option (uftrace.c:515)
==15195==    by 0x61B222D: group_parse (argp-parse.c:257)
==15195==    by 0x61B222D: parser_parse_opt (argp-parse.c:747)
==15195==    by 0x61B222D: parser_parse_next (argp-parse.c:867)
==15195==    by 0x61B222D: argp_parse (argp-parse.c:921)
==15195==    by 0x405929: main (uftrace.c:1075)
==15195==
==15195== 22 bytes in 1 blocks are definitely lost in loss record 2 of 3
==15195==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==15195==    by 0x61B6A17: __vasprintf_chk (vasprintf_chk.c:80)
==15195==    by 0x61B68F1: __asprintf_chk (asprintf_chk.c:32)
==15195==    by 0x41D43B: asprintf (stdio2.h:178)
==15195==    by 0x41D43B: command_record (record.c:2140)
==15195==    by 0x405C2B: main (uftrace.c:1140)
==15195==
==15195== LEAK SUMMARY:
==15195==    definitely lost: 24 bytes in 2 blocks
==15195==    indirectly lost: 0 bytes in 0 blocks
==15195==      possibly lost: 0 bytes in 0 blocks
==15195==    still reachable: 72,704 bytes in 1 blocks
==15195==         suppressed: 0 bytes in 0 blocks
==15195== Reachable blocks (those to which a pointer was found) are not shown.
==15195== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==15195==
==15195== For counts of detected and suppressed errors, rerun with: -v
==15195== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

Thanks.
