### PR TITLE
uftrace: Fix segfault when given logfile name is already taken by a directory

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -1082,8 +1082,10 @@ int main(int argc, char *argv[])
 
 	if (opts.logfile) {
 		logfp = fopen(opts.logfile, "a");
-		if (logfp == NULL)
+		if (logfp == NULL) {
+			logfp = stderr;
 			pr_err("cannot open log file");
+		}
 
 		setvbuf(logfp, NULL, _IOLBF, 1024);
 	}


### PR DESCRIPTION
This patch is to fix segfault in --logfile.
If logfd is NULL, set logfd to stderr before calling pr_err().

Fixed: #853