### PR TITLE
dynamic: fix miss used insn_check

### DIFF
--- a/arch/x86_64/mcount-insn.c
+++ b/arch/x86_64/mcount-insn.c
@@ -129,7 +129,7 @@ static bool check_unsupported(struct mcount_disasm_engine *disasm, cs_insn *insn
 
 			/* disallow (back) jump to the prologue */
 			if (insn_check->addr <= target &&
-			    target < insn_check->addr + insn_check->size)
+			    target < insn_check->addr + insn_check->copy_size)
 				return false;
 
 			/* disallow jump to middle of other function */


### PR DESCRIPTION
check_unsupported function is designed to disallow jumps to patched
function prologue. but insn_check given as argument has been not setted
the value before using it. following the context, copy_size could be
used at here.

Signed-off-by: Hanbum Park <kese111@gmail.com>