### PR TITLE
report: Fix memory leak in print_and_delete()

### DIFF
--- a/cmds/report.c
+++ b/cmds/report.c
@@ -179,6 +179,7 @@ static void print_and_delete(struct rb_root *root, bool sorted, void *arg,
 			node = rb_entry(n, typeof(*node), name_link);
 
 		print_func(node, arg);
+		free(node->name);
 		free(node);
 	}
 }
@@ -476,11 +477,6 @@ static void print_function_diff(struct uftrace_report_node *node, void *arg)
 	}
 }
 
-static void print_nothing(struct uftrace_report_node *node, void *unused)
-{
-	/* just delete */
-}
-
 static void report_diff(struct uftrace_data *handle, struct opts *opts)
 {
 	struct opts dummy_opts = {
@@ -549,8 +545,6 @@ static void report_diff(struct uftrace_data *handle, struct opts *opts)
 
 out:
 	destroy_diff_nodes(&diff_tree);
-	print_and_delete(&base_tree, false, NULL, print_nothing);
-	print_and_delete(&pair_tree, false, NULL, print_nothing);
 	close_data_file(&dummy_opts, &data.handle);
 }
 


### PR DESCRIPTION
Hello,

In the process of using the report function, a memory leak occurs.

The memory allocated by find_or_create_node() is not freed.

So, I added `free()` function.

valgrind log:
```
$ valgrind --leak-check=full uftrace report --no-pager
==21644== Memcheck, a memory error detector
==21644== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==21644== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==21644== Command: uftrace report --no-pager
==21644==
  Total time   Self time       Calls  Function
  ==========  ==========  ==========  ====================
    9.730 ms   70.896 us           1  main
    8.167 ms    2.005 us           1  yr_compiler_get_rules
    4.551 ms  320.210 us           1  yr_arena_duplicate
    4.139 ms    4.139 ms           3  linux:schedule
    3.611 ms    5.361 us           1  _yr_compiler_compile_rules
...
==21644==
==21644== HEAP SUMMARY:
==21644==     in use at exit: 74,692 bytes in 115 blocks
==21644==   total heap usage: 34,265 allocs, 34,150 frees, 2,456,932 bytes allocated
==21644==
==21644== 15 bytes in 1 blocks are definitely lost in loss record 1 of 3
==21644==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==21644==    by 0x6129489: strdup (strdup.c:42)
==21644==    by 0x423DCA: find_or_create_node (report.c:60)
==21644==    by 0x40A2DE: insert_node (report.c:31)
==21644==    by 0x40A4D3: build_function_tree (report.c:133)
==21644==    by 0x40B05D: report_functions (report.c:225)
==21644==    by 0x40B05D: command_report (report.c:638)
==21644==    by 0x405C85: main (uftrace.c:1154)
==21644==
==21644== 1,973 bytes in 113 blocks are definitely lost in loss record 2 of 3
==21644==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==21644==    by 0x6129489: strdup (strdup.c:42)
==21644==    by 0x423DCA: find_or_create_node (report.c:60)
==21644==    by 0x40A2DE: insert_node (report.c:31)
==21644==    by 0x40A341: find_insert_node (report.c:44)
==21644==    by 0x40A46D: build_function_tree (report.c:157)
==21644==    by 0x40B05D: report_functions (report.c:225)
==21644==    by 0x40B05D: command_report (report.c:638)
==21644==    by 0x405C85: main (uftrace.c:1154)
==21644==
==21644== LEAK SUMMARY:
==21644==    definitely lost: 1,988 bytes in 114 blocks
==21644==    indirectly lost: 0 bytes in 0 blocks
==21644==      possibly lost: 0 bytes in 0 blocks
==21644==    still reachable: 72,704 bytes in 1 blocks
==21644==         suppressed: 0 bytes in 0 blocks
```