### PR TITLE
util : Change quote escaping function

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -860,7 +860,7 @@ static void dump_chrome_task_rstack(struct uftrace_dump_ops *ops,
 	char ph;
 	char spec_buf[1024];
 	struct uftrace_record *frs = task->rstack;
-	enum argspec_string_bits str_mode = NEEDS_ESCAPE;
+	enum argspec_string_bits str_mode = NEEDS_JSON;
 	struct uftrace_chrome_dump *chrome = container_of(ops, typeof(*chrome), ops);
 	bool is_process = task->t->pid == task->tid;
 	int rec_type = frs->type;

--- a/cmds/info.c
+++ b/cmds/info.c
@@ -228,7 +228,7 @@ static int fill_cmdline(void *arg)
 			*p = ' ';
 	}
 
-	p = strquote(buf, &ret);
+	p = json_quote(buf, &ret);
 	p[ret - 1] = '\n';
 
 	if ((write(fha->fd, "cmdline:", 8) < 8) ||

--- a/utils/fstack.h
+++ b/utils/fstack.h
@@ -87,7 +87,7 @@ enum argspec_string_bits {
 	HAS_MORE_BIT,
 	IS_RETVAL_BIT,
 	NEEDS_ASSIGNMENT_BIT,
-	NEEDS_ESCAPE_BIT,
+	NEEDS_JSON_BIT,
 
 	/* bit mask */
 	NEEDS_PAREN		= (1U << NEEDS_PAREN_BIT),
@@ -95,7 +95,7 @@ enum argspec_string_bits {
 	HAS_MORE		= (1U << HAS_MORE_BIT),
 	IS_RETVAL		= (1U << IS_RETVAL_BIT),
 	NEEDS_ASSIGNMENT	= (1U << NEEDS_ASSIGNMENT_BIT),
-	NEEDS_ESCAPE		= (1U << NEEDS_ESCAPE_BIT),
+	NEEDS_JSON		= (1U << NEEDS_JSON_BIT),
 };
 
 extern bool fstack_enabled;

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -681,8 +681,8 @@ void strv_free(struct strv *strv)
 #define DQUOTE '"'
 #define QUOTES "\'\""
 
-/* escape quotes with backslash - caller should free the returned string */
-char * strquote(char *str, int *len)
+/* escape double-quote with backslash - caller should free the returned string */
+char * json_quote(char *str, int *len)
 {
 	char *p = str;
 	int quote = 0;
@@ -690,20 +690,16 @@ char * strquote(char *str, int *len)
 	int orig_len = *len;
 
 	/* find number of necessary escape */
-	while ((p = strpbrk(p, QUOTES)) != NULL) {
+	while ((p = strchr(p, DQUOTE)) != NULL) {
 		quote++;
 		p++;
 	}
 
 	p = xmalloc(orig_len + quote + 1);
 
-	/* escape single- and double-quotes */
+	/* escape double-quotes */
 	for (i = k = 0; i < orig_len; i++, k++) {
-		if (str[i] == QUOTE) {
-			p[k++] = '\\';
-			p[k] = QUOTE;
-		}
-		else if (str[i] == DQUOTE) {
+		if (str[i] == DQUOTE) {
 			p[k++] = '\\';
 			p[k] = DQUOTE;
 		}

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -331,7 +331,7 @@ uint64_t parse_time(char *arg, int limited_digits);
 uint64_t parse_timestamp(char *arg);
 
 char * strjoin(char *left, char *right, const char *delim);
-char * strquote(char *str, int *len);
+char * json_quote(char *str, int *len);
 
 /* strv - string vector */
 struct strv {


### PR DESCRIPTION
Remove single quote escaping logic
And change function name from 'strquote' to 'json_quote'

After change
```
$ uftrace record -t 1ms ./python -c "print('Hello')"

$ uftrace info | grep cmdline
# cmdline             : uftrace record -t 1ms ./python -c print('Hello')

$ uftrace dump --chrome | grep command_line
"command_line":"uftrace record -t 1ms ./python -c print('Hello')"
```

I check that visualized trace output is successfully opened.

Fixed: #857

Signed-off-by: Sang-Heon Jeon <ekffu200098@gmail.com>