### PR TITLE
mcount: fix segfault in mcount_get_stack_arg()

### DIFF
--- a/arch/arm/mcount-support.c
+++ b/arch/arm/mcount-support.c
@@ -412,6 +412,7 @@ void mcount_get_stack_arg(struct mcount_arg_context *ctx,
 			  struct uftrace_arg_spec *spec)
 {
 	int offset = 1;
+	unsigned long *addr = ctx->stack_base;
 
 	switch (spec->type) {
 	case ARG_TYPE_STACK:
@@ -438,10 +439,20 @@ void mcount_get_stack_arg(struct mcount_arg_context *ctx,
 		break;
 	}
 
-	if (offset < 1 || offset > 100)
+	if (offset < 1 || offset > 100) {
 		pr_dbg("invalid stack offset: %d\n", offset);
+		memset(ctx->val.v, 0, sizeof(ctx->val));
+		return;
+	}
 
-	memcpy(ctx->val.v, ctx->stack_base + offset, spec->size);
+	addr += offset;
+
+	if (check_mem_region(ctx, (unsigned long)addr))
+		memcpy(ctx->val.v, addr, spec->size);
+	else {
+		pr_dbg("stack address is not allowed: %p\n", addr);
+		memset(ctx->val.v, 0, sizeof(ctx->val));
+	}
 }
 
 void mcount_arch_get_arg(struct mcount_arg_context *ctx,

--- a/arch/i386/mcount-support.c
+++ b/arch/i386/mcount-support.c
@@ -81,6 +81,7 @@ void mcount_get_stack_arg(struct mcount_arg_context *ctx,
                         struct uftrace_arg_spec *spec)
 {
 	int offset;
+	unsigned long *addr = ctx->stack_base;
 
 	switch (spec->type) {
 	case ARG_TYPE_STACK:
@@ -98,10 +99,20 @@ void mcount_get_stack_arg(struct mcount_arg_context *ctx,
 		break;
 	}
 
-	if (offset < 1 || offset > 100)
+	if (offset < 1 || offset > 100) {
 		pr_dbg("invalid stack offset: %d\n", offset);
+		memset(ctx->val.v, 0, sizeof(ctx->val));
+		return;
+	}
 
-	memcpy(ctx->val.v, ctx->stack_base + offset, spec->size);
+	addr += offset;
+
+	if (check_mem_region(ctx, (unsigned long)addr))
+		memcpy(ctx->val.v, addr, spec->size);
+	else {
+		pr_dbg("stack address is not allowed: %p\n", addr);
+		memset(ctx->val.v, 0, sizeof(ctx->val));
+	}
 }
 
 void mcount_arch_get_arg(struct mcount_arg_context *ctx,

--- a/arch/x86_64/mcount-support.c
+++ b/arch/x86_64/mcount-support.c
@@ -85,6 +85,7 @@ void mcount_get_stack_arg(struct mcount_arg_context *ctx,
 			  struct uftrace_arg_spec *spec)
 {
 	int offset;
+	unsigned long *addr = ctx->stack_base;
 
 	switch (spec->type) {
 	case ARG_TYPE_STACK:
@@ -103,10 +104,20 @@ void mcount_get_stack_arg(struct mcount_arg_context *ctx,
 		break;
 	}
 
-	if (offset < 1 || offset > 100)
+	if (offset < 1 || offset > 100) {
 		pr_dbg("invalid stack offset: %d\n", offset);
+		memset(ctx->val.v, 0, sizeof(ctx->val));
+		return;
+	}
 
-	memcpy(ctx->val.v, ctx->stack_base + offset, spec->size);
+	addr += offset;
+
+	if (check_mem_region(ctx, (unsigned long)addr))
+		memcpy(ctx->val.v, addr, spec->size);
+	else {
+		pr_dbg("stack address is not allowed: %p\n", addr);
+		memset(ctx->val.v, 0, sizeof(ctx->val));
+	}
 }
 
 void mcount_arch_get_arg(struct mcount_arg_context *ctx,

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -387,6 +387,9 @@ void save_trigger_read(struct mcount_thread_data *mtdp,
 		       enum trigger_read_type type, bool diff);
 #endif  /* DISABLE_MCOUNT_FILTER */
 
+bool check_mem_region(struct mcount_arg_context *ctx,
+		      unsigned long addr);
+
 void save_watchpoint(struct mcount_thread_data *mtdp,
 		     struct mcount_ret_stack *rstack,
 		     unsigned long watchpoints);

--- a/libmcount/record.c
+++ b/libmcount/record.c
@@ -363,8 +363,8 @@ static bool find_mem_region(struct rb_root *root, unsigned long addr)
 	return false;
 }
 
-static bool check_mem_region(struct mcount_arg_context *ctx,
-			     unsigned long addr)
+bool check_mem_region(struct mcount_arg_context *ctx,
+		      unsigned long addr)
 {
 	bool update = true;
 	struct mcount_mem_regions *regions = ctx->regions;
@@ -796,6 +796,12 @@ void save_watchpoint(struct mcount_thread_data *mtdp,
 		     struct mcount_ret_stack *rstack,
 		     unsigned long watchpoints)
 {
+}
+
+bool check_mem_region(struct mcount_arg_context *ctx,
+		      unsigned long addr)
+{
+	return true;
 }
 #endif
 

--- a/tests/t231_arg_bound.py
+++ b/tests/t231_arg_bound.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'arg', """
+# DURATION     TID     FUNCTION
+   0.647 us [ 17685] | __monstartup();
+   0.117 us [ 17685] | __cxa_atexit();
+            [ 17685] | main() {
+            [ 17685] |   foo() {
+            [ 17685] |     bar() {
+   0.107 us [ 17685] |       strcmp();
+   0.420 us [ 17685] |     } /* bar */
+            [ 17685] |     bar() {
+   0.044 us [ 17685] |       strcmp();
+   0.181 us [ 17685] |     } /* bar */
+            [ 17685] |     bar() {
+   0.045 us [ 17685] |       strcmp();
+   0.162 us [ 17685] |     } /* bar */
+   1.122 us [ 17685] |   } /* foo */
+ 160.575 us [ 17685] |   many(12, 0, 1, 0);
+            [ 17685] |   pass() {
+   0.083 us [ 17685] |     check();
+   0.303 us [ 17685] |   } /* pass */
+ 162.699 us [ 17685] | } /* main */
+""")
+
+    def build(self, name, cflags='', ldflags=''):
+        # cygprof doesn't support arguments now
+        if cflags.find('-finstrument-functions') >= 0:
+            return TestBase.TEST_SKIP
+        return TestBase.build(self, name, cflags, ldflags)
+
+    def runcmd(self):
+        uftrace = TestBase.uftrace_cmd
+        options = '-A "many@arg1,arg9999999,arg2,arg4294967295"'
+        program = 't-' + self.name
+        return '%s %s %s' % (uftrace, options, program)


### PR DESCRIPTION
If the given argument index is out of memory or inaccessible, a segfault will occur.
I added code to check the validity of the memory address before accessing the address.

Before :
```
$ uftrace -A puts@arg123123123 ./simple
WARN: Segmentation fault: address not mapped (addr: 0x7ffc65604290)
WARN: Backtrace from uftrace:
WARN: =====================================
WARN: [1] (puts[5597527fe660] <= main[5597527fe86b])
WARN: [0] (main[5597527fe838] <= __libc_start_main[7feaa464bb97])
WARN: child terminated by signal: 11: Segmentation fault
# DURATION     TID     FUNCTION
   0.840 us [ 13506] | __monstartup();
   0.305 us [ 13506] | __cxa_atexit();
            [ 13506] | main() {
            [ 13506] |   puts() {

uftrace stopped tracing with remaining functions
================================================
task: 13506
[1] puts
[0] main
```

After :  
```
$ uftrace -A puts@arg123123123 ./simple
mcount: /home/rls1004/contributhon/uftrace/arch/x86_64/mcount-support.c:116:mcount_get_stack_arg
 ERROR: invalid argument: 123123117
# DURATION     TID     FUNCTION
   0.567 us [ 18317] | __monstartup();
   0.257 us [ 18317] | __cxa_atexit();
```


Fixed: #858

Signed-off-by: MinJeong Kim <98nba@naver.com>