### PR TITLE
mcount: Allow full-dynamic tracing to instrument unsupported functions on x86_64 (w/ capstone)

### DIFF
--- a/arch/x86_64/mcount-arch.h
+++ b/arch/x86_64/mcount-arch.h
@@ -1,6 +1,8 @@
 #ifndef MCOUNT_ARCH_H
 #define MCOUNT_ARCH_H
 
+#include <stdint.h>
+
 #include "utils/arch.h"
 #include "utils/list.h"
 
@@ -47,9 +49,29 @@ struct sym;
 int disasm_check_insns(struct mcount_disasm_engine *disasm,
 		       struct mcount_dynamic_info *mdi, struct sym *sym);
 
+
+struct dynamic_constraint create_constraint(struct mcount_disasm_engine *disasm,
+				struct mcount_dynamic_info *mdi, struct sym *sym);
+
 struct dynamic_bad_symbol {
 	struct list_head	list;
 	struct sym		*sym;
+};
+
+struct dynamic_constraint
+{
+	uint8_t constraint[4];
+	int instr_size;
+};
+
+struct mcount_address_range{
+	uintptr_t start;
+	uintptr_t end;
+};
+
+struct dynamic_mem_region {
+	struct dynamic_mem_region*	next;
+	struct mcount_address_range range;
 };
 
 struct dynamic_bad_symbol * find_bad_jump(struct mcount_dynamic_info *mdi,

--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -1,6 +1,8 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <signal.h>
+#include <dlfcn.h>
 
 /* This should be defined before #include "utils.h" */
 #define PR_FMT     "dynamic"
@@ -12,10 +14,13 @@
 #include "utils/symbol.h"
 
 #define PAGE_SIZE  4096
+#define PAGE_MASK  (~(PAGE_SIZE-1))
 #define XRAY_SECT  "xray_instr_map"
 
 #define CALL_INSN_SIZE  5
 #define JMP_INSN_SIZE   6
+
+#define REG(name) REG_R##name
 
 /* target instrumentation function it needs to call */
 extern void __fentry__(void);
@@ -42,6 +47,22 @@ struct arch_dynamic_info {
 	unsigned			xrmap_count;
 	struct list_head		bad_targets;  /* for non-local jumps */
 };
+
+static struct rb_root redirection_tree = RB_ROOT;
+
+#ifdef HAVE_LIBCAPSTONE
+void install_trap_handler()
+{
+	struct sigaction act;
+
+	sigaction(SIGTRAP, NULL, &act); /* get current trap handler */
+	/*
+	* reuse current trap handler and set mcount_dynamic_trap as the
+	* master trap handler 
+	*/
+	sigaction(SIGTRAP, &act, NULL);
+}
+#endif
 
 int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
 {
@@ -107,6 +128,8 @@ int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
 		memcpy((void *)mdi->trampoline, trampoline, sizeof(trampoline));
 		memcpy((void *)mdi->trampoline + sizeof(trampoline),
 		       &dentry_addr, sizeof(dentry_addr));
+		
+		install_trap_handler();
 #endif
 	}
 	return 0;
@@ -495,6 +518,420 @@ static int patch_normal_func(struct mcount_dynamic_info *mdi, struct sym *sym,
 	return INSTRUMENT_SUCCESS;
 }
 
+static struct dynamic_mem_region * read_mem_regions()
+{
+	FILE *fp;
+	char buf[PATH_MAX];
+
+	fp = fopen("/proc/self/maps", "r");
+	if (fp == NULL)
+		return NULL;
+
+	struct dynamic_mem_region *ret = xzalloc(sizeof(struct dynamic_mem_region));
+	struct dynamic_mem_region *regions = ret;
+
+	while (fgets(buf, sizeof(buf), fp) != NULL) {
+		char *p = buf, *next;
+		unsigned long start, end;
+
+		start = strtoul(p, &next, 16);
+		if (*next != '-')
+			pr_warn("invalid /proc/map format\n");
+
+		p = next + 1;
+		end = strtoul(p, &next, 16);
+
+		regions->range.start = start;
+		regions->range.end = end;
+		regions->next = xzalloc(sizeof(struct dynamic_mem_region));
+		regions = regions->next;
+	}
+	regions->next = NULL;
+
+	fclose(fp);
+	return ret;
+}
+
+static void destroy_mem_regions(struct dynamic_mem_region *regions)
+{
+	struct dynamic_mem_region *current = regions;
+	struct dynamic_mem_region *previous;
+
+	while(current != NULL) {
+		previous = current;
+		current = current->next; 
+		free(previous);
+	}
+}
+
+/*
+ * Find the memory regions that are not mapped in the process address space.
+ */
+static struct dynamic_mem_region * get_free_mem_regions(struct dynamic_mem_region *mapped_mem_reg)
+{
+	struct dynamic_mem_region *ret = xzalloc(sizeof(struct dynamic_mem_region));
+	struct dynamic_mem_region *mapped_reg = mapped_mem_reg;
+	struct dynamic_mem_region *free_reg = ret;
+
+	if(mapped_reg->range.start != 0){
+		free_reg->range.start = 0;
+		free_reg->range.end = mapped_reg->range.start;
+	}
+
+	while(mapped_reg != NULL 
+			&& mapped_reg->next != NULL 
+			&& mapped_reg->next->next != NULL) 
+	{
+
+		if(mapped_reg->range.end == mapped_reg->next->range.start) {
+			mapped_reg = mapped_reg->next;
+			continue;
+		}
+		free_reg->next = xzalloc(sizeof(struct dynamic_mem_region));
+		free_reg = free_reg->next;
+
+		free_reg->range.start = mapped_reg->range.end;
+		mapped_reg = mapped_reg->next;
+		free_reg->range.end = mapped_reg->range.start;
+	}
+
+	if(mapped_reg->range.end != ULONG_MAX) {
+		free_reg->next = xzalloc(sizeof(struct dynamic_mem_region));
+		free_reg = free_reg->next;
+
+		free_reg->range.start = mapped_reg->range.end;
+		free_reg->range.end = ULONG_MAX;
+	}
+	free_reg->next = NULL;
+	
+	return ret;
+}
+
+uintptr_t add_saturation(uintptr_t x, int32_t y)
+{
+    if(y > 0 && ULONG_MAX - y < x)
+        return ULONG_MAX;
+    else if(y < 0 &&  (uintptr_t)(0 - y) > x)
+        return 0;
+    else
+        return x + y;
+}
+
+static int32_t constaint_to_integer(struct dynamic_constraint dc, uint8_t val)
+{
+	uint8_t ret[4];
+
+	for(int i = 0; i < 4; i++)
+		ret[i] = dc.constraint[i] ? dc.constraint[i] : val;
+
+	return ret[0] + (ret[1] << 8) + (ret[2] << 16) + (ret[3] << 24);
+}
+
+struct mcount_address_range intersect(struct mcount_address_range range1, 
+				struct mcount_address_range range2)
+{
+	uintptr_t min = max(range1.start, range2.start);
+	uintptr_t max = min(range1.end, range2.end);
+	struct mcount_address_range range = {0, 0};
+
+	if (min < max) {
+		range.start = min;
+		range.end = max;
+	}	
+
+	return range;
+}
+
+struct mcount_address_range constraint_to_range(struct dynamic_constraint dc, uintptr_t sym_addr)
+{
+	int32_t start = constaint_to_integer(dc, 0x00);
+	int32_t end = constaint_to_integer(dc, 0xff);
+	struct mcount_address_range ret;
+	
+	/* if MSB of constraint is zero, start will be positive and end negative */
+	if(!dc.constraint[3]){
+		start |= (1 << 31);
+		end &= (0 << 31);
+	}
+
+	/* we add to saturation for overflows*/
+	ret.start = add_saturation(sym_addr, start);
+	ret.end = add_saturation(sym_addr, end);
+
+	return ret;
+}
+
+/*
+ * Find a free memory range that intersect with the range of the constraint.
+ */
+static uintptr_t find_free_address(struct dynamic_constraint dc, uintptr_t sym_addr, int size) 
+{
+	struct dynamic_mem_region *mapped_reg;
+	struct dynamic_mem_region *free_reg;
+	struct dynamic_mem_region *reg;
+	struct mcount_address_range inter_range;
+	struct mcount_address_range cond_range = constraint_to_range(dc, sym_addr);
+	uintptr_t ret = 0;
+	int64_t offset;
+
+	mapped_reg = read_mem_regions();
+	if(mapped_reg == NULL)
+		return ret;
+	free_reg = get_free_mem_regions(mapped_reg);
+
+	reg = free_reg;
+	while(reg != NULL) {
+		inter_range = intersect(reg->range, cond_range);
+		pr_dbg3("search free address in range: [%p, %p] intersect [%p, %p] = [%p, %p] \n", reg->range.start,
+				reg->range.end, cond_range.start, cond_range.end, inter_range.start, inter_range.end);
+
+		if(inter_range.start != 0 && inter_range.end != 0) {
+			offset = inter_range.start - sym_addr;
+			if(offset < INT_MIN || offset > INT_MAX) 
+				goto next;
+
+			for(int i = 0; i < 4; i++)
+				((uint8_t*) &offset)[i] = dc.constraint[i] ? dc.constraint[i] : ((uint8_t*) &offset)[i] ;
+				
+			if( (sym_addr + (int32_t)offset) >= inter_range.start 
+					&& (sym_addr + (int32_t)offset + size) <= inter_range.end)
+			{
+				ret = sym_addr + (int32_t)offset;
+				pr_dbg3("found free address: %p \n", ret);
+				break;
+			}			
+		}
+		next:
+		reg = reg->next; 
+	}
+
+	destroy_mem_regions(mapped_reg);
+	destroy_mem_regions(free_reg);
+	return ret;
+}
+
+static mcount_redirection *lookup_redirection(struct rb_root *root,
+					    unsigned long addr, bool create)
+{
+	struct rb_node *parent = NULL;
+	struct rb_node **p = &root->rb_node;
+	mcount_redirection *iter;
+
+	while (*p) {
+		parent = *p;
+		iter = rb_entry(parent, mcount_redirection, node);
+
+		if (iter->addr == addr)
+			return iter;
+
+		if (iter->addr > addr)
+			p = &parent->rb_left;
+		else
+			p = &parent->rb_right;
+	}
+
+	if (!create)
+		return NULL;
+
+	iter = xmalloc(sizeof(*iter));
+	iter->addr = addr;
+
+	rb_link_node(&iter->node, parent, p);
+	rb_insert_color(&iter->node, root);
+	return iter;
+}
+
+uintptr_t setup_trampoline_constraint(struct dynamic_constraint dc, uintptr_t addr)
+{
+	void *trampoline_check;
+	uintptr_t first_page;
+	uintptr_t last_page;
+	unsigned char trampoline[] = { 0xff, 0x25, 0x02, 0x00, 0x00, 0x00, 0xcc, 0xcc };
+	unsigned long dentry_addr = (unsigned long)__dentry__;
+	uintptr_t free_addr = find_free_address(dc, addr + CALL_INSN_SIZE, PAGE_SIZE);
+	if(!free_addr)
+		return free_addr;
+
+	first_page = free_addr & PAGE_MASK;
+	last_page = (free_addr + sizeof(trampoline) * 2 - 1) & PAGE_MASK;
+
+	/* TODO: keep track of mapped pages and reuse them to increase the success rate */
+
+	/* always mmap first page */
+	trampoline_check = mmap((void *)first_page, PAGE_SIZE,
+					PROT_READ | PROT_WRITE | PROT_EXEC,
+		     			MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS,
+					-1, 0);
+	if (trampoline_check == MAP_FAILED)
+		pr_err("failed to mmap trampoline for setup");
+
+	/* mmap second page if needed */
+	if(first_page != last_page) {
+		trampoline_check = mmap((void *)last_page, PAGE_SIZE,
+						PROT_READ | PROT_WRITE | PROT_EXEC,
+							MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS,
+						-1, 0);
+		if (trampoline_check == MAP_FAILED)
+			pr_err("failed to mmap trampoline for setup");
+	}
+
+	memcpy((void *)free_addr, trampoline, sizeof(trampoline));
+	memcpy((void *)free_addr + sizeof(trampoline),
+			&dentry_addr, sizeof(dentry_addr));
+
+	return free_addr;
+}
+
+static int patch_code_constraint(struct dynamic_constraint dc, uintptr_t addr, struct mcount_orig_insn *orig)
+{
+	void *origin_code_addr;
+	unsigned char call_insn[] = { 0xe8, 0x00, 0x00, 0x00, 0x00 };
+	int64_t target_addr;
+	uintptr_t free_addr;
+	mcount_redirection *red;
+	
+	free_addr = setup_trampoline_constraint(dc, addr);
+	if(!free_addr)
+		return INSTRUMENT_FAILED;
+
+	target_addr = free_addr - (addr + CALL_INSN_SIZE);
+	if(target_addr < INT_MIN || target_addr > INT_MAX)
+		return INSTRUMENT_FAILED;
+
+	/* patch address */
+	origin_code_addr = (void *)addr;
+
+	/* build the instrumentation instruction */
+	memcpy(&call_insn[1], &target_addr, CALL_INSN_SIZE - 1);
+
+	for(int i = 0; i < 4; i++){
+		if(dc.constraint[i]){
+			red = lookup_redirection(&redirection_tree, addr + 1 + i, true);
+			red->insn = orig->insn + 1 + i;
+		}
+	}
+
+	memcpy(origin_code_addr, call_insn, CALL_INSN_SIZE);
+	memset(origin_code_addr + CALL_INSN_SIZE, 0x90,  /* NOP */
+	       dc.instr_size - CALL_INSN_SIZE);
+
+	/* flush icache so that cpu can execute the new insn */
+	__builtin___clear_cache(origin_code_addr,
+				origin_code_addr + dc.instr_size);
+
+	pr_dbg3("instrument address: %p, offset: %i, instr: %X%X%X%X%X \n", addr, target_addr, 
+			call_insn[0], call_insn[1], call_insn[2], call_insn[3], call_insn[4]);
+			 
+	return INSTRUMENT_SUCCESS;
+}
+
+/*
+ * To safely patch unsupported functions that jumps or may jump to their
+ * prologues, we embed an illegal instruction like "int3" in 
+ * offset of the call. The illegal instruction should be embedded
+ * in the head of every overwritten instruction, but the first one (it will be
+ * set to the call opcode).
+ * 
+ * [example]:
+ * In this example, the first instruction (push rbp) will be replaced by the call opcode. The second
+ * byte is the head of the first overwritten instruction, and it should be replaced by "int3".
+ * The 3rd and 4th bytes can be set to whatever value. The 5th byte is the head of the 
+ * second overwritten instruction, thus it should be replaced with "int3". The remaining bytes will
+ * be replaced by a "nop".
+ * Note: "int3" opcode is "0xCC"
+ *
+ *   dynamic: 0x19e98b0[01]:push rbp
+ *   dynamic: 0x19e98b1[03]:mov rbp, rsp
+ *   dynamic: 0x19e98b4[05]:mov edi, 0x4005f4
+ *
+ *   dynamic: 0x40054c[05]:call 0xCC????CC
+ *   dynamic: 0x400551[01]:nop
+ *   dynamic: 0x400552[01]:nop
+ *   dynamic: 0x400553[01]:nop
+ *   dynamic: 0x400554[01]:nop  
+ *  
+ * The role of "int3" is to redirect the thread that step into it to the out of line 
+ * instructions so that he could resume his execution without executing random instructions.
+ * 
+ * This instrumentation technique doesn't restrain to function entry and exit
+ * it could also be used to instrument an arbitrary location in a function.
+ * 
+ * Since we need to respect a constraint made from the "int3" in the offset of
+ * the call, we intersect free memory regions and the reachable range
+ * with the offset, to find a suitable place to put the trampoline in.
+ * 
+ * [example]:
+ * 
+ *   mapped region      free region      mapped region     free region        mapped region
+ *      [a, b]             [c, d]           [e, f]           [g, h]              [i, j]
+ * 							 ^				   ^				^
+ * 					  [x - 0x00CCCC00		   x		 x + 0xFFCCCCFF] 
+ *  
+ * let's suppose the symbol we instrument starts at the address x that falls in the range [e, f]
+ * and the constraint we should respect is "?? CC CC ??". the reachable range 
+ * is [x - 0x00CCCC00, x + 0xFFCCCCFF]. Any free range that intersect with our reachable range 
+ * is potentially  suitable for the trampoline. The intersection of the free range [c, d] with
+ * the reachable range gives [x - 0x00CCCC00, d]. if the size of the resulted range is smaller than
+ * the trampoline size, we move on to the next intersection. 
+ * 
+ * To make sure that the techniques works even when the user override our dynamic
+ * trap handler, we hook sigaction() to make sure that our trap handler always get 
+ * the trap signal first and then dispatch it to the user trap handler if needed.
+ *  
+ */
+static int patch_unsupported_func(struct mcount_dynamic_info *mdi, struct sym *sym,
+			     struct mcount_disasm_engine *disasm)
+{
+	uint8_t jmp_insn[14] = { 0xff, 0x25, };
+	uint64_t jmp_target;
+	struct mcount_orig_insn *orig;
+	uint64_t sym_addr = sym->addr + mdi->map->start;
+	int ret = INSTRUMENT_FAILED;
+
+	struct dynamic_constraint dc = create_constraint(disasm, mdi, sym);
+	if (dc.instr_size < CALL_INSN_SIZE)
+		return dc.instr_size;
+
+	jmp_target = sym_addr + dc.instr_size;
+	memcpy(jmp_insn + JMP_INSN_SIZE, &jmp_target, sizeof(jmp_target));
+	orig = mcount_save_code(sym_addr , dc.instr_size,
+				jmp_insn, sizeof(jmp_insn));
+	/* make sure orig->addr same as when called from __dentry__ */
+	orig->addr += CALL_INSN_SIZE;
+
+	ret = patch_code_constraint(dc, sym_addr, orig);
+	if(ret == INSTRUMENT_SUCCESS){
+		pr_dbg2("patch unsupported func: %s (patch size: %d)\n",
+			sym->name, dc.instr_size);
+	}
+
+	return ret;
+}
+
+#ifdef HAVE_LIBCAPSTONE
+void mcount_dynamic_trap(int sig, siginfo_t* info, void* _ctx)
+{
+	mcount_redirection *red;
+	/* (%rip) - 1 is the addr of the trap instruction */
+	unsigned long addr = ((ucontext_t*)_ctx)->uc_mcontext.gregs[REG(IP)] - 1;
+
+	red = lookup_redirection(&redirection_tree, addr, false);
+	if (red == NULL){
+		/* raise sigaction and run normal handler */
+		if(mcount_user_handler.sa_handler || mcount_user_handler.sa_sigaction)
+		{
+			if(mcount_user_handler.sa_flags & SA_SIGINFO)
+				mcount_user_handler.sa_sigaction(sig, info, _ctx);
+			else
+				mcount_user_handler.sa_handler(sig);
+		}
+	} else {
+		/* redirect thread to original instruction */
+		((ucontext_t*)_ctx)->uc_mcontext.gregs[REG(IP)] = (unsigned long) red->insn;
+	}
+}
+#endif
+
 int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym,
 		      struct mcount_disasm_engine *disasm,
 		      unsigned min_size)
@@ -519,6 +956,9 @@ int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym,
 
 	case DYNAMIC_NONE:
 		result = patch_normal_func(mdi, sym, disasm);
+		if(result == INSTRUMENT_FAILED) {
+			result = patch_unsupported_func(mdi, sym, disasm);
+		}
 		break;
 
 	default:

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -16,6 +16,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/syscall.h>
+#include <signal.h>
 
 #ifdef HAVE_LIBCAPSTONE
 # include <capstone/capstone.h>
@@ -250,6 +251,22 @@ static inline void mcount_memcpy4(void * restrict dst,
 		*p++ = *q++;
 }
 
+#ifndef max
+#define max(a, b) ({				\
+	typeof(a) _maxa = (a);			\
+	typeof(b) _maxb = (b);			\
+	(void) (&_maxa == &_maxb);		\
+	_maxa > _maxb ? _maxa : _maxb; })
+#endif
+
+#ifndef min
+#define min(a, b) ({				\
+	typeof(a) _maxa = (a);			\
+	typeof(b) _maxb = (b);			\
+	(void) (&_maxa == &_maxb);		\
+	_maxa < _maxb ? _maxa : _maxb; })
+#endif
+
 extern void mcount_return(void);
 extern void dynamic_return(void);
 extern unsigned long plthook_return(void);
@@ -401,6 +418,11 @@ struct mcount_dynamic_info {
 	void *arch;
 };
 
+#ifdef HAVE_LIBCAPSTONE
+struct sigaction mcount_user_handler;
+void mcount_dynamic_trap(int sig, siginfo_t* info, void* _ctx);
+#endif
+
 struct mcount_disasm_engine {
 #ifdef HAVE_LIBCAPSTONE
 	csh		engine;
@@ -420,6 +442,8 @@ struct mcount_orig_insn {
 	unsigned long		addr;
 	void			*insn;
 };
+
+typedef struct mcount_orig_insn mcount_redirection;
 
 struct mcount_orig_insn *mcount_save_code(unsigned long addr, unsigned insn_size,
 					  void *jmp_insn, unsigned jmp_size);

--- a/tests/s-dynamic.c
+++ b/tests/s-dynamic.c
@@ -1,6 +1,25 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+extern void test_jmp_prolog();
+asm(
+".type test_jmp_prolog, @function\n"
+"test_jmp_prolog:\n"
+#if defined(__x86_64__)
+"   xor %rcx, %rcx\n"
+"   inc %rcx\n"
+"   cmp $2, %rcx\n"
+"   jne test_jmp_prolog + 3\n" /* 3 size of xor reg, reg */
+#elif defined(__i386__)
+"   xor %ecx, %ecx\n"
+"   inc %ecx\n"
+"   cmp $2, %ecx\n"
+"   jne test_jmp_prolog + 2\n" /* 2 size of xor reg, reg */
+#endif
+"   ret\n"
+".size test_jmp_prolog, . -test_jmp_prolog\n"
+);
+
 int foo(int n)
 {
 	volatile int i = 0;
@@ -30,6 +49,7 @@ int main(int argc, char *argv[])
 	if (argc > 1)
 		n = atoi(argv[1]);
 
+	test_jmp_prolog();
 	foo(n);
 	bar(n);
 

--- a/tests/t223_dynamic_full.py
+++ b/tests/t223_dynamic_full.py
@@ -14,7 +14,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        if platform.machine().startswith('arm'):
+        if not TestBase.check_dependency(self, 'have_libcapstone') or platform.machine().startswith('arm'):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 

--- a/tests/t223_dynamic_full.py
+++ b/tests/t223_dynamic_full.py
@@ -8,6 +8,7 @@ class TestCase(TestBase):
         TestBase.__init__(self, 'dynamic', """
 # DURATION     TID     FUNCTION
          [ 63876] | main() {
+0.739 us [ 63876] |   test_jmp_prolog();
 0.739 us [ 63876] |   foo();
 0.833 us [ 63876] |   bar();
 1.903 us [ 63876] | } /* main */
@@ -26,6 +27,6 @@ class TestCase(TestBase):
 
     def runcmd(self):
         uftrace = TestBase.uftrace_cmd
-        options = '-P main -P foo -P bar --no-libcall'
+        options = '-P main -P foo -P bar -P test_jmp_prolog --no-libcall'
         program = 't-' + self.name
         return '%s %s %s' % (uftrace, options, program)


### PR DESCRIPTION
Some functions can't be instrumented by full-dynamic tracing, for safety reasons. Functions that jump to a prologue that has been modified may cause an undefined behavior. To be able to instrument these functions, one can embed an illegal instruction (for example "int3") in the head of every instruction that has been moved. This way, if a thread branch to the function prologue, it will step on the illegal instruction and a handler will be called by the kernel to redirect the thread to the original instruction. Afterwards, the thread will jump back to the function and resume its execution normally.
    
Instrumenting unsupported functions process is similar to full-dynamic tracing process excepts some differences:
1. Create a constraint based on the position of the "int3" in the offset of the call instruction.
2. Store the instructions located at the prolog of the function, if patchable.
3. Find and allocate a free address that respect the constraint created previously.
4. Store the position of "int3" and the address of the original instruction.
5. instrument the 'relative address call instruction' to 'prolog of the function' to call the trampoline.
    
The execution flow is similar to the full-dynamic tracing except when a thread branch to a prologue and step on an "int3":
    
1. The trap handler is called.
2. The address from where the trap handler was raised is computed.
3. If the trap handler was raised from an address related to our tracepoint, the thread is redirected to the original instruction. Else, the original handler (set by the user) is called and the execution is
resumed.

Some Drawbacks and limitations:
1. "int3" is slower than a jump/call since it needs to go to back to the kernel and dispatch it to call the trap handler.
2. With embedded "int3" in the offset it reduces the range of finding a free address. The worst case is having four "one byte instructions" in the probe location. In this case the offset of the call/jmp should be 0xCCCCCCCC and if the absolute address (probe location + 0xCCCCCCCC) is already mapped, the instrumentation will fail. A solution to this problem is to combine different illegal instructions instead of using only "int3". 
3. Since the trap handler should be set by uftrace for this technique to work, it may interfere with gdb that relies on "int3" to insert the breakpoints. It means that gdb can't be used to debug uftrace while tracing a program with this technique. 