### PR TITLE
uftrace: Fix a typo in comment

### DIFF
--- a/arch/x86_64/mcount-noplt.c
+++ b/arch/x86_64/mcount-noplt.c
@@ -14,7 +14,7 @@
 #include "utils/symbol.h"
 
 #define TRAMP_ENT_SIZE    16  /* size of trampoilne for each entry */
-#define TRAMP_PLT0_SIZE   32  /* module id + addres of plthook_addr() */
+#define TRAMP_PLT0_SIZE   32  /* module id + address of plthook_addr() */
 #define TRAMP_PCREL_JMP   10  /* PC_relative offset for JMP */
 #define TRAMP_IDX_OFFSET  1
 #define TRAMP_JMP_OFFSET  6

--- a/utils/demangle.c
+++ b/utils/demangle.c
@@ -7,7 +7,7 @@
  *
  * See https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling
  *
- * Rust demangler refered to https://github.com/alexcrichton/rustc-demangle
+ * Rust demangler referred to https://github.com/alexcrichton/rustc-demangle
  * which was released by MIT (or Apache) license.
  *
  * Copyright (c) 2014 Alex Crichton


### PR DESCRIPTION
Hello.

I corrected the typos.

Thanks.

Changes:
```
./arch/x86_64/mcount-noplt.c:17: addres -> address
./utils/demangle.c:10: refered -> referred
```