### PR TITLE
uftrace: configure script exits when OS is not Linux

### DIFF
--- a/configure
+++ b/configure
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 #-*- mode: shell-script; -*-
 
+if [ $(uname -s) != "Linux" ]; then
+    echo "uftrace is only supported on Linux"
+    exit
+fi
+
 prefix=/usr/local
 
 srcdir=$(readlink -f $(dirname $0))


### PR DESCRIPTION
Signed-off-by: Byeonggon Lee <gonny952@gmail.com>
Fixes #879 