### PR TITLE
tests: Limit workers bounded to testcases

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -646,6 +646,7 @@ if __name__ == "__main__":
     else:
         try:
             testcases = glob.glob('t*' + arg.case + '*.py')
+            arg.worker = min(arg.worker, len(testcases))
         finally:
             if len(testcases) == 0:
                 print("cannot find testcase for : %s" % arg.case)


### PR DESCRIPTION
The current runtest.py works with the full capable cpus, but it doesn't
have to create such amount if the number of tests are lower than the
cores.  This fixes the problem by limiting the number bounded to the
number of testcases.

Before:
  $ ./runtest.py 001
  Start 1 tests with 40 worker
    ...

After:
  $ ./runtest.py 001
  Start 1 tests with 1 worker
    ...

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>