### PR TITLE
fstack: Fix Null Pointer Dereference in setup_task_filter()

### DIFF
--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -177,6 +177,9 @@ setup:
 	handle->tasks = xmalloc(sizeof(*handle->tasks) * handle->nr_tasks);
 
 	for (i = 0; i < handle->nr_tasks; i++) {
+		if (handle->info.tids == NULL)
+			pr_err_ns("The info file is broken: missing tids\n");
+
 		bool found = !tid_filter;
 		int tid = handle->info.tids[i];
 		struct uftrace_task_reader *task = &handle->tasks[i];


### PR DESCRIPTION
it's only possible to be NULL when the data is broken. 

Anyway we need to protect from it.

Fixed : #882

Signed-off-by: GwanYeong Kim <gy741.kim@gmail.com>