### PR TITLE
doc: Translate report.md - name, synopsis in Korean

### DIFF
--- a/doc/ko/uftrace-report.md
+++ b/doc/ko/uftrace-report.md
@@ -2,12 +2,12 @@
 % Namhyung Kim <namhyung@gmail.com>
 % Sep, 2018
 
-NAME
+이름
 ====
-uftrace-report - Print statistics and summary for trace data
+uftrace-report - 추적한 데이터의 통계 자료와 요약을 출력 한다.
 
 
-SYNOPSIS
+사용법
 ========
 uftrace report [*options*]
 


### PR DESCRIPTION
Hi, this is my first PR, and I am so nervous!
I'm in charge of translation of uftrace-report.md in Korean.

I'm wondering if I can translate man page like this.
So, at first, I translated 'name' and 'synopsis' parts. In here, I paraphrase the 'synopsis' to '사용법' not '개요' which is a dictionary meaning of a synopsis. And I try to translate a 'statistics' better, but I can't find a proper word so I just translate it to '통계자료'.

I want to know your opinions about my translations, and if it is fine, I'll continue the translation like this.

Thank you:)
