### PR TITLE
Makefile: Fix conversion error for ARCH variable already set to x86

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ $(call allow-override,LD,$(CROSS_COMPILE)ld)
 
 uname_M := $(shell uname -m 2>/dev/null || echo not)
 
-ARCH ?= $(shell echo $(uname_M) | sed -e s/i.86/i386/ -e s/arm.*/arm/ )
+ARCH := $(shell echo $(uname_M) | sed -e s/i.86/i386/ -e s/arm.*/arm/ )
 ifeq ($(ARCH),x86_64)
-  ifneq ($(findstring m32,$(CFLAGS)),)
+  ifneq ($(findstring -m32,$(CC) $(CFLAGS)),)
     override ARCH := i386
   endif
 endif

--- a/configure
+++ b/configure
@@ -89,12 +89,10 @@ for arg; do
     eval "$opt='$val'"
 done
 
-if [ -z "$ARCH" ]; then
-    uname_M=$(uname -m 2>/dev/null || echo not)
-    ARCH=$(echo $uname_M | sed -e s/i.86/i386/ -e s/arm.*/arm/ )
-    if [ "$ARCH" = "x86_64" ] && echo "$CFLAGS" | grep -w m32 ; then
-        ARCH=i386
-    fi
+uname_M=$(uname -m 2>/dev/null || echo not)
+ARCH=$(echo $uname_M | sed -e s/i.86/i386/ -e s/arm.*/arm/ )
+if [ "$ARCH" = "x86_64" ] && echo "$CC $CFLAGS" | grep -w "\-m32" ; then
+    ARCH=i386
 fi
 
 bindir=${bindir:-${prefix}/bin}


### PR DESCRIPTION
In open-embedded, the toolchain for  qemux86 machine sets ARCH as x86,
and "-m32" option are appended in CC env variable, not in CFLAGS.
Previous script checked the host arch if ARCH absent, and
checked whether -m32 option is set from CFLAGS only.
This patch fixs above mentioned.

Signed-off-by: Junil Kim <logyourself@gmail.com>