### PR TITLE
mcount: Fix a typo in comment

### DIFF
--- a/arch/x86_64/dynamic.S
+++ b/arch/x86_64/dynamic.S
@@ -3,7 +3,7 @@
  *
  *         if %rax have value bigger than 0, it means return address
  *         to the function have patched for dynamic tracing.
- *         otherwise, it must be 0 that means error occured.
+ *         otherwise, it must be 0 that means error occurred.
  *         stack frame : parent addr = 8(%rsp), child addr = (%rsp)
  *
  *         For example:


### PR DESCRIPTION
Hello.

I corrected the typos.

Thanks.

Changes:

`occured` -> `occurred`

