### PR TITLE
record: Modified strcpy to strncpy

### DIFF
--- a/cmds/record.c
+++ b/cmds/record.c
@@ -136,7 +136,7 @@ char * get_libmcount_path(struct opts *opts)
 	if (access(lib, F_OK) == 0)
 		return lib;
 #endif
-	strcpy(lib, libmcount);
+	strncpy(lib, libmcount, PATH_MAX);
 	return lib;
 }
 


### PR DESCRIPTION
Since strnpy is safer than strcpy,
I changed `strcpy(lib, libmount)`
to `strncpy('lib, libmount, sizeof(lib))`

Signed-off-by: kangtegong <tegongkang@gmail.com>