### PR TITLE
doc: Fix typo error in uftrace-record.md

### DIFF
--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -547,7 +547,7 @@ With dynamic tracing, you can trace specific functions only given by the
 `-U`/`--unpatch` option.  With capstone disassembly engine you even don't need
 to (re)compile the target with the option above.  Now uftrace can analyze the
 instructions and (if possible) it can copy them to a different place and rewrite
-it to call `mcount()` function) so that it can be traced by uftrace.  After that
+it to call `mcount()` function so that it can be traced by uftrace.  After that
 the control is passed to the copied instructions and then returned back to the
 remaining instructions.
 


### PR DESCRIPTION
I just found unnecessary ')' in line 550, DYNAMIC TRACING [section](https://github.com/namhyung/uftrace/blob/master/doc/uftrace-record.md#dynamic-tracing).

Signed-off-by: Handong Choi wschd770@gmail.com