### PR TITLE
utils: Use a proper name for symtab->nr_alloc

### DIFF
--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -878,11 +878,11 @@ static int load_module_symbol_file(struct symtab *symtab, const char *symfile,
 
 		if (*line == '#') {
 			if (!strncmp(line, "# symbols: ", 11)) {
-				addr = strtoull(line + 11, &pos, 10);
-				symtab->nr_alloc = addr;
+				size_t nr_syms = strtoul(line + 11, &pos, 10);
+				size_t size_syms = nr_syms * sizeof(*sym);
 
-				addr *= sizeof(*sym);
-				symtab->sym = xrealloc(symtab->sym, addr);
+				symtab->nr_alloc = nr_syms;
+				symtab->sym = xrealloc(symtab->sym, size_syms);
 			}
 			continue;
 		}


### PR DESCRIPTION
It looks weird to read the number of symbols to 'addr' variable.
So it's better to use proper variable names for better readability.
```
  $ cat uftrace.data/libc-2.23.so.sym
  # symbols: 1862
  000000000001f7d0 P realloc
  000000000001f7e0 P __tls_get_addr
  000000000001f7f0 P memalign
    ...
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>