### PR TITLE
utils: Fix segfaults caused by setargs()

### DIFF
--- a/utils/utils.c
+++ b/utils/utils.c
@@ -725,24 +725,30 @@ static int setargs(char *args, char **argv)
 
 		/* consider quotes and update argv */
 		if (*args == QUOTE) {
+			++args;
+			if (*args == QUOTE )
+				continue;
 			if (argv)
-				argv[count] = ++args;
-			while (*args != QUOTE)
+				argv[count] = args;
+			while (*args && *args != QUOTE)
 				++args;
-			if (argv)
+			if (argv && *args)
 				*args = ' ';
 		}
 		else if (*args == DQUOTE) {
+			++args;
+			if (*args == DQUOTE)
+				continue;
 			if (argv)
-				argv[count] = ++args;
-			while (*args != DQUOTE)
+				argv[count] = args;
+			while (*args && *args != DQUOTE)
 				++args;
-			if (argv)
+			if (argv && *args)
 				*args = ' ';
 		}
 		else if (*args == '#') {
 			/* ignore comment line */
-			while (*args != '\n' || *args == '\0')
+			while (*args != '\n' && *args != '\0')
 				++args;
 			continue;
 		}


### PR DESCRIPTION
This PR fixes a number of segfaults caused when parsing options from a file ( `--opt-file`). Relevant issue #914 .

Note that there are still some leaks related to option parsing but they are not particularly tied to `setargs()`. They are caused by `exit()`-ing when an executable cannot be opened. This probably needs a new issue opened.

Signed-off-by: George Karlos gkarloscodes@gmail.com