### PR TITLE
dynamic: change module name source from memory map to filename

### DIFF
--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -292,7 +292,7 @@ static int do_dynamic_update(struct symtabs *symtabs, char *patch_funcs,
 	if (patch_funcs == NULL)
 		return 0;
 
-	def_mod = basename(symtabs->maps->libname);
+	def_mod = basename(symtabs->filename);
 	strv_split(&funcs, patch_funcs, ";");
 
 	strv_for_each(&funcs, name, j) {


### PR DESCRIPTION
typically, executable binary has lowest memory map and first module name
in process memory map. uftrace's one logic also based on this. however
WSL2 does not guarantee this. so, one logic in uftrace based on
assumptions mentioned above not work properly. this PR fix this.

fixed: #852

Signed-off-by: Hanbum Park <kese111@gmail.com>