### PR TITLE
util: Check/remove empty dat files

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -782,7 +782,7 @@ static void dump_raw_perf_start(struct uftrace_dump_ops *ops,
 	if (cpu == 0)
 		pr_out("\n");
 
-	pr_out("reading perf-cpu%d.dat\n", cpu);
+	pr_out("reading %s\n", perf->name);
 
 	raw->file_offset = 0;
 }

--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -829,6 +829,8 @@ int stop_kernel_tracing(struct uftrace_kernel_writer *kernel)
 int finish_kernel_tracing(struct uftrace_kernel_writer *kernel)
 {
 	int i;
+	char buf[PATH_MAX];
+	struct stat stbuf;
 
 	pr_dbg("kernel tracing stopped.\n");
 
@@ -838,6 +840,11 @@ int finish_kernel_tracing(struct uftrace_kernel_writer *kernel)
 	for (i = 0; i < kernel->nr_cpus; i++) {
 		close(kernel->traces[i]);
 		close(kernel->fds[i]);
+		snprintf(buf, sizeof(buf), "%s/kernel-cpu%d.dat",
+			 kernel->output_dir, i);
+		if(!stat(buf, &stbuf) && stbuf.st_size == 0) {
+			remove(buf);
+		}
 	}
 
 	free(kernel->traces);

--- a/utils/kernel.h
+++ b/utils/kernel.h
@@ -25,6 +25,7 @@ struct uftrace_kernel_writer {
 
 struct uftrace_kernel_reader {
 	int				nr_cpus;
+	char				*name;
 	int				last_read_cpu;
 	bool				skip_out;
 	char				*dirname;

--- a/utils/perf.c
+++ b/utils/perf.c
@@ -7,6 +7,8 @@
 #include <byteswap.h>
 #include <sys/mman.h>
 #include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 #include "uftrace.h"
 #include "utils/perf.h"
@@ -263,7 +265,7 @@ int setup_perf_data(struct uftrace_data *handle)
 	size_t i;
 	int ret = -1;
 
-	xasprintf(&pattern, "%s/perf-cpu*.dat", handle->dirname);
+	xasprintf(&pattern, "perf-cpu*.dat");
 	if (glob(pattern, GLOB_ERR, NULL, &globbuf)) {
 		pr_dbg("failed to search perf data file\n");
 		handle->hdr.feat_mask &= ~PERF_EVENT;
@@ -277,6 +279,7 @@ int setup_perf_data(struct uftrace_data *handle)
 		perf[i].fp = fopen(globbuf.gl_pathv[i], "r");
 		if (perf[i].fp == NULL)
 			pr_err("open failed: %s", globbuf.gl_pathv[i]);
+		perf[i].name = xstrdup(globbuf.gl_pathv[i]);
 	}
 
 	handle->nr_perf = globbuf.gl_pathc;

--- a/utils/perf.h
+++ b/utils/perf.h
@@ -108,6 +108,7 @@ static inline void record_perf_data(struct uftrace_perf_writer *perf,
 
 struct uftrace_perf_reader {
 	FILE			*fp;
+	char			*name;
 	bool			valid;
 	bool			done;
 	int			type;


### PR DESCRIPTION
remove automatically created dat files for each online CPUs like ‘perf-cpuXX.dat’ and 'kernel-cpuXX.dat’ if it doesn’t have no content in it.

Fixed: #893
