### PR TITLE
info: Fix stack buffer overflow when reading cmdline

### DIFF
--- a/cmds/info.c
+++ b/cmds/info.c
@@ -228,6 +228,8 @@ static int fill_cmdline(void *arg)
 			*p = ' ';
 	}
 
+	buf[sizeof(fha->buf) - 1] = '\0';
+
 	p = json_quote(buf, &ret);
 	p[ret - 1] = '\n';
 


### PR DESCRIPTION
Fixed the stack overflow by inserting null byte at the end of the string.

Fixed: #939

Signed-off-by: MinJeong Kim <98nba@naver.com>