### PR TITLE
doc: Fix typo and grammar in doc files

### DIFF
--- a/doc/uftrace-graph.md
+++ b/doc/uftrace-graph.md
@@ -16,7 +16,7 @@ DESCRIPTION
 ===========
 This command shows a function call graph for the binary or the given function
 in a uftrace record datafile.  If the function name is omitted, whole function
-call graph will be shonw.  If user gives a function name it will show backtrace
+call graph will be shown.  If user gives a function name it will show backtrace
 and calling functions.  Each function in the output is annotated with a hit
 count and the total time spent running that function.
 

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -48,7 +48,7 @@ COMMON OPTIONS
 
 \--no-libcall
 :   Do not record library function invocations.  Library calls are normally
-    traced by hooking the dynamic linker's resolve function in the PLT.
+    traced by hooking calls to the resolver function of dynamic linker in the PLT.
     One can disable it with this option.
 
 \--no-event
@@ -695,7 +695,7 @@ capstone to parse the instructions.
 Clang/LLVM 4.0 provides a dynamic instrumentation technique called
 [X-ray](http://llvm.org/docs/XRay.html).  It's similar to a combination of
 `gcc -mfentry -mnop-mcount` and `-finstrument-functions`.  The uftrace also
-supports dynamic tracing on the excutables built with the `X-ray`.
+supports dynamic tracing on the executables built with the `X-ray`.
 
 For example, you can build the target program by clang with the below option
 and equally use `-P` option for dynamic tracing like below:

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -131,7 +131,7 @@ COMMON OPTIONS
 
 \--no-libcall
 :   Do not record library function invocations.  Library calls are normally
-    traced by hooking the dynamic linker's resolve function in the PLT.
+    traced by hooking calls to the resolver function of dynamic linker in the PLT.
     One can disable it with this option.
 
 \--no-event
@@ -540,7 +540,7 @@ The uftrace tool supports dynamic function tracing which can be enabled at
 runtime (load-time, to be precise) on x86_64.  Before recording functions,
 normally you need to build the target program with `-pg` (or
 `-finstrument-functions`), then it has some performance impact because all
-funtions call `mcount()`.
+functions call `mcount()`.
 
 With dynamic tracing, you can trace specific functions only given by the
 `-P`/`--patch` option and can also disable specific functions given by the
@@ -710,7 +710,7 @@ Please see `uftrace-script`(1) for details about scripting.
 WATCH POINT
 ===========
 The uftrace watch point is to display certain value only if it's changed.
-It's conceptually same as debugger's but only works at function entry and exit
+It's conceptually same as other debuggers but only works at function entry and exit
 so it might miss some updates.
 
 As of now, following watch points are supported:

--- a/doc/uftrace-report.md
+++ b/doc/uftrace-report.md
@@ -44,7 +44,7 @@ REPORT OPTIONS
 \--diff-policy=*POLICY*
 :   Apply custom diff policy.  Available values are: "abs", "no-abs", "percent",
     "no-percent", "compact" and "full".  The "abs" is to sort diff result using
-    absolute value so positvie and negative entries can be shown together while
+    absolute value so positive and negative entries can be shown together while
     "no-abs" will show positive entries first and then negative ones.  The
     "percent" is to show diff in percentage while "no-percent" is to show the
     values.  The "full" is to show all three columns of baseline, new data and


### PR DESCRIPTION
Hi, I just found some typo and grammar issues.
Also, some lines of the document should be ignored markdown formatting, so I fixed it by using `\`.

Signed-off-by: Handong Choi <wschd770@gmail.com>