### PR TITLE
misc: Add .gdbinit for debugging

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,2 @@
+set follow-fork-mode child
+set follow-exec-mode new


### PR DESCRIPTION
This .gdbinit contains:
set follow-fork-mode child
set follow-exec-mode new

You don't have to set fork-mode and exec-mode everytime when using gdb
if your ~/.gdbinit is like following:
set auto-load safe-path /

Signed-off-by: Byeonggon Lee <gonny952@gmail.com>