### PR TITLE
uftrace: Fix memory leak in opts

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -1015,6 +1015,7 @@ static void free_opts(struct opts *opts)
 {
 	free(opts->filter);
 	free(opts->trigger);
+	free(opts->sig_trigger);
 	free(opts->sort_keys);
 	free(opts->args);
 	free(opts->retval);


### PR DESCRIPTION
Added code to free for `opts->sig_trigger`

Fixed: #963

Signed-off-by: MinJeong Kim <98nba@naver.com>