### PR TITLE
uftrace: Fix fread() error handling

### DIFF
--- a/cmds/info.c
+++ b/cmds/info.c
@@ -209,7 +209,8 @@ static int fill_cmdline(void *arg)
 	struct fill_handler_arg *fha = arg;
 	char *buf = fha->buf;
 	FILE *fp;
-	int ret, i;
+	size_t ret;
+	int i;
 	char *p;
 
 	fp = fopen("/proc/self/cmdline", "r");
@@ -219,7 +220,7 @@ static int fill_cmdline(void *arg)
 	ret = fread(buf, 1, sizeof(fha->buf), fp);
 	fclose(fp);
 
-	if (ret < 0)
+	if (ret != sizeof(fha->buf))
 		return ret;
 
 	/* cmdline separated by NUL character - convert to space */

--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -1237,7 +1237,7 @@ int save_kernel_symbol(char *dirname)
 	while ((len = fread(buf, 1, sizeof(buf), ifp)) > 0)
 		fwrite(buf, 1, len, ofp);
 
-	if (len < 0)
+	if (len != sizeof(buf))
 		ret = len;
 
 	fclose(ifp);


### PR DESCRIPTION
This isn't really accurate right. fread() doesn't always
return 0 in error. It could return < number of elements
and set errno.

Fixed: #952

Signed-off-by: GwanYeong Kim <gy741.kim@gmail.com>