### PR TITLE
android: Fix some of compile warnings and errors in android bionic

### DIFF
--- a/cmds/record.c
+++ b/cmds/record.c
@@ -29,6 +29,9 @@
 #include "utils/kernel.h"
 #include "utils/perf.h"
 
+#ifndef EFD_SEMAPHORE
+# define EFD_SEMAPHORE (1 << 0)
+#endif
 #define SHMEM_NAME_SIZE (64 - (int)sizeof(struct list_head))
 
 struct shmem_list {

--- a/cmds/recv.c
+++ b/cmds/recv.c
@@ -96,7 +96,7 @@ int setup_client_socket(struct opts *opts)
 
 	addr.sin_addr = *(struct in_addr *) hostinfo->h_addr;
 
-	if (connect(sock, &addr, sizeof(addr)) < 0)
+	if (connect(sock, (const struct sockaddr *)&addr, sizeof(addr)) < 0)
 		pr_err("socket connect failed");
 
 	return sock;
@@ -534,7 +534,7 @@ static void handle_server_sock(struct epoll_event *ev, int efd)
 	socklen_t len = sizeof(addr);
 	char hbuf[NI_MAXHOST];
 
-	client = accept(sock, &addr, &len);
+	client = accept(sock, (struct sockaddr *)&addr, &len);
 	if (client < 0)
 		pr_err("socket accept failed");
 

--- a/utils/compiler.h
+++ b/utils/compiler.h
@@ -46,8 +46,12 @@
 #define __visible_default  __attribute__((visibility("default")))
 #define __alias(func)  __attribute__((alias(#func)))
 #define __maybe_unused  __attribute__((unused))
-#define __used  __attribute__((used))
-#define __noreturn  __attribute__((noreturn))
+#ifndef __used
+# define __used  __attribute__((used))
+#endif
+#ifndef __noreturn
+# define __noreturn  __attribute__((noreturn))
+#endif
 #define __align(n)  __attribute__((aligned(n)))
 
 #endif /* UFTRACE_COMPILER_H */

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -233,9 +233,12 @@ extern void setup_signal(void);
 #define stringify(s)    __stringify(s)
 #define __stringify(s)  #s
 
-#define htonq(x)  htobe64(x)
-#define ntohq(x)  be64toh(x)
-
+#ifndef htonq
+# define htonq(x)  htobe64(x)
+#endif
+#ifndef ntohq
+# define ntohq(x)  be64toh(x)
+#endif
 /* this comes from /usr/include/elf.h */
 #ifndef ELFDATA2LSB
 # define ELFDATA2LSB	1		/* 2's complement, little endian */


### PR DESCRIPTION
This fixes following warnings and errors:
```console
/data/data/com.termux/files/home/uftrace/utils/compiler.h:50:10: warning: '__noreturn' macro redefined [-Wmacro-redefined]
# define __noreturn  __attribute__((noreturn))
         ^
/data/data/com.termux/files/usr/include/sys/cdefs.h:86:9: note: previous definition is here
#define __noreturn __attribute__((__noreturn__))

/data/data/com.termux/files/home/uftrace/utils/utils.h:237:10: warning: 'ntohq' macro redefined [-Wmacro-redefined]
# define ntohq(x)  be64toh(x)
         ^
/data/data/com.termux/files/usr/include/sys/endian.h:69:9: note: previous definition is here
#define ntohq(x) __swap64(x)

/data/data/com.termux/files/home/uftrace/utils/compiler.h:49:10: warning: '__used' macro redefined [-Wmacro-redefined]
# define __used  __attribute__((used))
         ^
/data/data/com.termux/files/usr/include/sys/cdefs.h:90:9: note: previous definition is here
#define __used __attribute__((__used__))

/data/data/com.termux/files/home/uftrace/utils/utils.h:236:10: warning: 'htonq' macro redefined [-Wmacro-redefined]
# define htonq(x)  htobe64(x)
         ^
/data/data/com.termux/files/usr/include/sys/endian.h:68:9: note: previous definition is here
#define htonq(x) __swap64(x)

/data/data/com.termux/files/home/uftrace/cmds/recv.c:99:20: warning: incompatible pointer types passing 'struct sockaddr_in *' to parameter of type 'const struct sockaddr *' [-Wincompatible-pointer-types]
        if (connect(sock, &addr, sizeof(addr)) < 0)
                          ^~~~~
/data/data/com.termux/files/usr/include/sys/socket.h:308:59: note: passing argument to parameter '__addr' here
__socketcall int connect(int __fd, const struct sockaddr* __addr, socklen_t __addr_length);
                                                          ^
4 warnings generated.
/data/data/com.termux/files/home/uftrace/cmds/recv.c:537:24: warning: incompatible pointer types passing 'struct sockaddr_in *' to parameter of type 'struct sockaddr *' [-Wincompatible-pointer-types]
        client = accept(sock, &addr, &len);
                              ^~~~~
/data/data/com.termux/files/usr/include/sys/socket.h:301:52: note: passing argument to parameter '__addr' here
__socketcall int accept(int __fd, struct sockaddr* __addr, socklen_t* __addr_length);

/data/data/com.termux/files/home/uftrace/cmds/record.c:2148:35: error: use of undeclared identifier 'EFD_SEMAPHORE'
        ready = eventfd(0, EFD_CLOEXEC | EFD_SEMAPHORE);

```

Signed-off-by: Byeonggon Lee <gonny952@gmail.com>
