### PR TITLE
utils: Support portable versionsort

### DIFF
--- a/check-deps/Makefile
+++ b/check-deps/Makefile
@@ -10,6 +10,9 @@ CHECK_LIST += arm_has_hardfp
 CHECK_LIST += have_libncurses
 CHECK_LIST += have_libdw
 CHECK_LIST += have_libcapstone
+CHECK_LIST += have_strcoll
+CHECK_LIST += have_strverscmp
+CHECK_LIST += have_versionsort
 
 #
 # This is needed for checking build dependency

--- a/check-deps/__have_strcoll.c
+++ b/check-deps/__have_strcoll.c
@@ -1,0 +1,7 @@
+#include <string.h>
+
+int main(void)
+{
+	int diff = strcoll("A", "B");
+	return 0;
+}

--- a/check-deps/__have_strverscmp.c
+++ b/check-deps/__have_strverscmp.c
@@ -1,0 +1,8 @@
+#define _GNU_SOURCE
+#include <string.h>
+
+int main(void)
+{
+	strverscmp("A2", "B1");
+	return 0;
+}

--- a/check-deps/__have_versionsort.c
+++ b/check-deps/__have_versionsort.c
@@ -1,0 +1,12 @@
+#define _GNU_SOURCE
+#include <dirent.h>
+
+int main(void)
+{
+	const struct dirent d1 = {.d_ino = 1, .d_name = "B1"};
+	const struct dirent d2 = {.d_ino = 2, .d_name = "A2"};
+	const struct dirent *dp1 = &d1;
+	const struct dirent *dp2 = &d1;
+	versionsort(&dp1, &dp2);
+	return 0;
+}

--- a/utils/gnu.h
+++ b/utils/gnu.h
@@ -1,0 +1,51 @@
+#ifndef GNU_H
+#define GNU_H
+
+#include <dirent.h>
+#include <string.h>
+#include "posix.h"
+
+#ifndef HAVE_STRVERSCMP
+static inline int strverscmp(const char *a, const char *b)
+{
+	int a_int = 0;
+	int b_int = 0;
+	size_t a_len = strlen(a);
+	size_t b_len = strlen(b);
+	size_t a_digitstart = a_len;
+	size_t b_digitstart = b_len;
+	int diff;
+
+	while (isdigit(a[a_digitstart - 1]) && a_digitstart != 0)
+		--a_digitstart;
+
+	while (isdigit(b[b_digitstart - 1]) && b_digitstart != 0)
+		--b_digitstart;
+
+	for (size_t i = a_digitstart; i != a_len; ++i) {
+		if(isdigit(a[i]))
+			a_int = a_int * 10 + (a[i] - '0');
+	}
+
+	for (size_t i = b_digitstart; i != b_len; ++i) {
+		if(isdigit(b[i]))
+			b_int = b_int * 10 + (b[i] - '0');
+	}
+
+	diff = a_int - b_int;
+
+	if (!diff)
+		return strcoll(a, b);
+
+	return diff;
+}
+#endif
+
+#ifndef HAVE_VERSIONSORT
+static inline int versionsort(const struct dirent **a, const struct dirent **b)
+{
+	return strverscmp((*a)->d_name, (*b)->d_name);
+}
+#endif
+
+#endif /* GNU_H */

--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -22,6 +22,7 @@
 #include "utils/utils.h"
 #include "utils/fstack.h"
 #include "utils/filter.h"
+#include "utils/gnu.h"
 #include "utils/rbtree.h"
 #include "utils/kernel.h"
 #include "libtraceevent/kbuffer.h"

--- a/utils/posix.h
+++ b/utils/posix.h
@@ -1,0 +1,53 @@
+#ifndef POSIX_H
+#define POSIX_H
+
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#ifdef HAVE_POSIX_SHM
+# define UFTRACE_SHMDIR_NAME "/dev/shm"
+#else
+# define UFTRACE_SHMDIR_NAME "uftrace.data/shm"
+#endif
+
+#ifndef HAVE_POSIX_SHM
+static inline int shm_open(const char *file, int oflag, mode_t mode)
+{
+	int ret;
+	char* path;
+	if(mkdir(UFTRACE_SHMDIR_NAME, S_IRWXU | S_IRWXG | S_IRWXO) && errno != EEXIST)
+		return -1;
+	const size_t path_size = sizeof(UFTRACE_SHMDIR_NAME) - 1 + strlen(file) + 1;
+	path = calloc(path_size, sizeof(char));
+	strncat(path, UFTRACE_SHMDIR_NAME, path_size - strlen(path) - 1);
+	strncat(path, file, path_size - strlen(path) - 1);
+	ret = open(path, oflag, mode);
+	free(path);
+	return ret;
+}
+
+static inline int shm_unlink(const char *file)
+{
+	int ret;
+	char* path;
+	if(mkdir(UFTRACE_SHMDIR_NAME, S_IRWXU | S_IRWXG | S_IRWXO) && errno != EEXIST)
+		return -1;
+	const size_t path_size = sizeof(UFTRACE_SHMDIR_NAME) - 1 + strlen(file) + 1;
+	path = calloc(path_size, sizeof(char));
+	strncat(path, UFTRACE_SHMDIR_NAME, path_size - strlen(path) - 1);
+	strncat(path, file, path_size - strlen(path) - 1);
+	ret = unlink(path);
+	free(path);
+	return ret;
+}
+#endif
+
+#ifndef HAVE_STRCOLL
+static inline int strcoll(const char *a, const char *b) {
+	return strcmp(a, b);
+}
+#endif
+
+#endif /* POSIX_H */


### PR DESCRIPTION
In some non-libc envirnment such as bionic,
there is no versionsort and related functions.

Signed-off-by: Byeonggon Lee <gonny952@gmail.com>