### PR TITLE
uftrace: Fix fread() error handling

### DIFF
--- a/cmds/info.c
+++ b/cmds/info.c
@@ -209,7 +209,8 @@ static int fill_cmdline(void *arg)
 	struct fill_handler_arg *fha = arg;
 	char *buf = fha->buf;
 	FILE *fp;
-	size_t ret;
+	int err;
+	int ret;
 	int i;
 	char *p;
 
@@ -218,10 +219,11 @@ static int fill_cmdline(void *arg)
 		return -1;
 
 	ret = fread(buf, 1, sizeof(fha->buf), fp);
+	err = ferror(fp);
 	fclose(fp);
 
-	if (ret != sizeof(fha->buf))
-		return ret;
+	if (!ret && err)
+		return -1;
 
 	/* cmdline separated by NUL character - convert to space */
 	for (i = 0, p = buf; i < ret; i++, p++) {

--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -1237,8 +1237,7 @@ int save_kernel_symbol(char *dirname)
 	while ((len = fread(buf, 1, sizeof(buf), ifp)) > 0)
 		fwrite(buf, 1, len, ofp);
 
-	if (len != sizeof(buf))
-		ret = len;
+	ret = ferror(ifp) ? -1 : 0;
 
 	fclose(ifp);
 	fclose(ofp);


### PR DESCRIPTION
URGENT!
#966 induces a broken state of master branch.
Currently simple command like uftrace -S scripts/strings.py ls doesn't work.

This commit fixed the problems.

From manpage:
> fread() does not distinguish between end-of-file and error, and callers
> must use feof(3) and ferror(3) to determine which occurred.

In cmds/info.c checking ret != sizeof(fha->buf) doesn't always mean that an error occured.
If the buffer is large enough, return value of fread() can be smaller than the size of the buffer.

In utils/symbol.c when while loop ends, len will be always zero.
To know an error actually occured, check the result of ferror()

Also there were compile warnings:
```console
/home/gonapps/workspace/uftrace/cmds/info.c: In function ‘fill_cmdline’:
/home/gonapps/workspace/uftrace/cmds/info.c:230:25: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  230 |  for (i = 0, p = buf; i < ret; i++, p++) {
      |                         ^
/home/gonapps/workspace/uftrace/cmds/info.c:237:22: warning: passing argument 2 of ‘json_quote’ from incompatible pointer type [-Wincompatible-pointer-types]
  237 |  p = json_quote(buf, &ret);
      |                      ^~~~
      |                      |
      |                      size_t * {aka long unsigned int *}
In file included from /home/gonapps/workspace/uftrace/utils/symbol.h:15,
                 from /home/gonapps/workspace/uftrace/uftrace.h:11,
                 from /home/gonapps/workspace/uftrace/cmds/info.c:20:
/home/gonapps/workspace/uftrace/utils/utils.h:337:8: note: expected ‘int *’ but argument is of type ‘size_t *’ {aka ‘long unsigned int *’}
  337 | char * json_quote(char *str, int *len);
      |        ^~~~~~~~~~
/home/gonapps/workspace/uftrace/cmds/info.c:241:30: warning: comparison of integer expressions of different signedness: ‘ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
```

Fixed: #952

Signed-off-by: Byeonggon Lee <gonny952@gmail.com>
