### PR TITLE
dynamic: support relative conditional branches and relative jumps 

### DIFF
--- a/arch/x86_64/mcount-arch.h
+++ b/arch/x86_64/mcount-arch.h
@@ -36,6 +36,12 @@ struct mcount_arch_context {
 #define ARCH_SUPPORT_AUTO_RECOVER  1
 #define ARCH_CAN_RESTORE_PLTHOOK   1
 
+#define ARCH_JCC8_SIZE 2
+#define ARCH_JMP32_SIZE 5
+
+#define ARCH_TRAMPOLINE_SIZE 14
+#define ARCH_BRANCH_ENTRY_SIZE ARCH_TRAMPOLINE_SIZE
+
 struct plthook_arch_context {
 	bool	has_plt_sec;
 };

--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -643,3 +643,71 @@ void mcount_arch_dynamic_recover(struct mcount_dynamic_info *mdi,
 		free(badsym);
 	}
 }
+
+int mcount_arch_branch_table_size(struct mcount_disasm_info *info)
+{
+	struct cond_branch_info *jcc_info;
+	unsigned long jcc_target;
+	int count = 0;
+	int i;
+
+	for (i = 0; i < info->nr_branch; i++) {
+		jcc_info = &info->branch_info[i];
+		jcc_target = jcc_info->branch_target;
+
+		/* no need to allocate entry for jcc that jump directly to prologue */
+		if (info->addr <= jcc_info->branch_target &&
+			jcc_target < info->addr + info->orig_size) {
+			continue;
+		}
+		count++;
+	}
+	return count * ARCH_BRANCH_ENTRY_SIZE;
+}
+
+void mcount_arch_patch_branch(struct mcount_disasm_info *info,
+					struct mcount_orig_insn *orig)
+{
+	/*
+	 * The first entry in the table starts right after the out-of-line 
+	 * execution buffer.
+	 */
+	uint64_t entry_offset = orig->insn_size;
+	uint8_t trampoline[ARCH_TRAMPOLINE_SIZE] = { 0xff, 0x25, };
+	unsigned long jcc_target;
+	unsigned long jcc_index;
+	struct cond_branch_info *jcc_info;
+	uint32_t disp;
+	int i;
+
+	for (i = 0; i < info->nr_branch; i++) {
+		jcc_info = &info->branch_info[i];
+		jcc_target = jcc_info->branch_target;
+		jcc_index = jcc_info->insn_index;
+
+		/* leave the original disp of jcc that target the prologue as it is */
+		if (info->addr <= jcc_info->branch_target &&
+			jcc_target < info->addr + info->orig_size) {
+
+			info->insns[jcc_index + 1] = jcc_target - (jcc_info->insn_addr + jcc_info->insn_size);
+			continue;
+		}
+
+		/* setup the branch entry trampoline */
+		memcpy(trampoline + JMP_INSN_SIZE, &jcc_target, sizeof(jcc_target));
+
+		/* write the entry to the branch table */
+		memcpy(orig->insn + entry_offset, trampoline, sizeof(trampoline));
+
+		/* previously, all jcc32 are downgraded to jcc8 */
+		disp = entry_offset - (jcc_index + ARCH_JCC8_SIZE);
+		if (disp > SCHAR_MAX) { /* should not happen */
+			pr_err("target is not in reach"); 
+		}
+
+		/* patch jcc displacement to target correspending entry in the table */
+		info->insns[jcc_index + 1] = disp;
+
+		entry_offset += ARCH_BRANCH_ENTRY_SIZE;
+	}
+}

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -78,7 +78,9 @@ struct mcount_orig_insn *mcount_save_code(struct mcount_disasm_info *info,
 		/* it needs to save original instructions as well */
 		int orig_size = ALIGN(info->orig_size, 16);
 		int copy_size = ALIGN(info->copy_size + jmp_size, 16);
-		patch_size = ALIGN(copy_size + orig_size, 32);
+		int table_size = mcount_arch_branch_table_size(info);
+
+		patch_size = ALIGN(copy_size + orig_size + table_size, 32);
 	}
 	else {
 		patch_size = ALIGN(info->copy_size + jmp_size, 32);
@@ -108,6 +110,8 @@ struct mcount_orig_insn *mcount_save_code(struct mcount_disasm_info *info,
 		/* save original instructions before modification */
 		orig->orig = orig->insn + patch_size - ALIGN(info->orig_size, 16);
 		memcpy(orig->orig, (void *)info->addr, info->orig_size);
+
+		mcount_arch_patch_branch(info, orig);
 	}
 
 	memcpy(orig->insn, info->insns, info->copy_size);
@@ -180,6 +184,15 @@ __weak void mcount_disasm_init(struct mcount_disasm_engine *disasm)
 }
 
 __weak void mcount_disasm_finish(struct mcount_disasm_engine *disasm)
+{
+}
+
+__weak int mcount_arch_branch_table_size(struct mcount_disasm_info *info)
+{
+	return 0;
+}
+
+__weak void mcount_arch_patch_branch(struct mcount_disasm_info *info, struct mcount_orig_insn *orig)
 {
 }
 

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -415,6 +415,13 @@ struct mcount_disasm_engine {
 #define INSTRUMENT_FAILED                       -1
 #define INSTRUMENT_SKIPPED                      -2
 
+/* 
+ * Supposing the size of smallest conditional branch is 2 byte.
+ * We can replace, at most, 3 of them by the instrumentation
+ * instruction.
+ */
+#define MAX_COND_BRANCH 3
+
 int mcount_dynamic_update(struct symtabs *symtabs, char *patch_funcs,
 			  enum uftrace_pattern_type ptype,
 			  struct mcount_disasm_engine *disasm);
@@ -426,6 +433,15 @@ struct mcount_orig_insn {
 	void			*insn;
 	int			orig_size;
 	int			insn_size;
+};
+
+struct cond_branch_info {
+	/* where the insn starts in the out-of-line exec buffer*/
+	unsigned long insn_index;
+	/* the original target address of the branch */
+	unsigned long branch_target;
+	unsigned long insn_addr;
+	unsigned long insn_size;
 };
 
 /*
@@ -446,6 +462,8 @@ struct mcount_disasm_info {
 	int			copy_size;
 	bool			modified;
 	bool			has_jump;
+	uint8_t			nr_branch;
+	struct cond_branch_info branch_info[MAX_COND_BRANCH];
 };
 
 struct mcount_orig_insn *mcount_save_code(struct mcount_disasm_info *info,
@@ -463,6 +481,9 @@ int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym,
 
 void mcount_disasm_init(struct mcount_disasm_engine *disasm);
 void mcount_disasm_finish(struct mcount_disasm_engine *disasm);
+
+int mcount_arch_branch_table_size(struct mcount_disasm_info *info);
+void mcount_arch_patch_branch(struct mcount_disasm_info *info, struct mcount_orig_insn *orig);
 
 struct dynamic_bad_symbol {
 	struct list_head	list;


### PR DESCRIPTION
Conditional branches and relative jumps in the prologue appears in 8% of uftrace functions. Thus there is a need to support them. 
The idea is to use a jcc8 to jump (when condition is met) to a trampoline which jumps to the target of the original instruction. The offset of the new jcc is patched later when the code is saved in the out of line buffer.