### PR TITLE
uftrace: Fix .travis.yml to use install-dep.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: c
 
-# Ubuntu 14.04 LTS
-dist: trusty
+# Ubuntu 16.04 LTS
+dist: xenial
 
 sudo: required
 
 install:
 - sudo apt-get -qq update
-- sudo apt-get -y  install libelf-dev libstdc++-4.8-dev pandoc
+- sudo misc/install-deps.sh -y
 
-script: ./configure && make
+script: ./configure && make && make unittest
 
 env:
   global:

--- a/misc/install-deps.sh
+++ b/misc/install-deps.sh
@@ -14,20 +14,25 @@ distro=$(grep "^ID=" /etc/os-release | cut -d\= -f2 | sed -e 's/"//g')
 case $distro in
     "ubuntu" | "debian")
         apt-get $OPT install pandoc libdw-dev libpython2.7-dev libncursesw5-dev pkg-config
-        apt-get $OPT install libcapstone-dev libluajit-5.1-dev ;;
+        apt-get $OPT install libluajit-5.1-dev || true
+        apt-get $OPT install libcapstone-dev || true ;;
     "fedora")
         dnf install $OPT pandoc elfutils-devel python2-devel ncurses-devel pkgconf-pkg-config
-        dnf install $OPT capstone-devel luajit-devel ;;
+        dnf install $OPT luajit-devel || true
+        dnf install $OPT capstone-devel || true ;;
     "rhel" | "centos")
         rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
         yum install $OPT pandoc elfutils-devel python2-devel ncurses-devel pkgconfig
-        yum install $OPT capstone-devel luajit-devel ;;
+        yum install $OPT luajit-devel || true
+        yum install $OPT capstone-devel || true ;;
     "arch" | "manjaro")
         pacman $OPT -S pandoc libelf python2 ncurses pkgconf
-        pacman $OPT -S capstone luajit ;;
+        pacman $OPT -S luajit || true
+        pacman $OPT -S capstone || true ;;
     "alpine")
         apk $OPT add elfutils-dev python2-dev ncurses-dev pkgconf
-        apk $OPT add capstone-dev luajit-dev ;;
+        apk $OPT add luajit-dev || true
+        apk $OPT add capstone-dev || true ;;
     *) # we can add more install command for each distros.
         echo "\"$distro\" is not supported distro, so please install packages manually." ;;
 esac


### PR DESCRIPTION
With this change you will immediately know
when change to install-deps.sh introduces some errors especially in Ubuntu.

Signed-off-by: Byeonggon Lee <gonny952@gmail.com>