### PR TITLE
uftrace: Fix memory leak in run_cmd

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -1044,6 +1044,7 @@ static void free_opts(struct opts *opts)
 	free(opts->patch);
 	free(opts->caller);
 	free(opts->watch);
+	free_parsed_cmdline(opts->run_cmd);
 }
 
 #ifndef UNIT_TEST


### PR DESCRIPTION
Fixed `opts->cmd_line` allocated in `parse_cmdline()` to be freed.

Fixed: #1005

Signed-off-by: MinJeong Kim <98nba@naver.com>