### PR TITLE
dynamic: Fix a bug disallowing some functions to be patched

### DIFF
--- a/arch/x86_64/mcount-insn.c
+++ b/arch/x86_64/mcount-insn.c
@@ -287,7 +287,7 @@ static bool check_unsupported(struct mcount_disasm_engine *disasm,
 
 			/* disallow (back) jump to the prologue */
 			if (info->addr < target &&
-			    target < info->addr + info->copy_size)
+			    target < info->addr + info->orig_size)
 				return false;
 
 			/* disallow jump to middle of other function */


### PR DESCRIPTION
I think that orig_size should be used here instead of copy_size.

Signed-off-by: Anas Balboul <anasbalbo@gmail.com>