### PR TITLE
doc: Update description of --tid option in related commands

### DIFF
--- a/doc/uftrace-graph.md
+++ b/doc/uftrace-graph.md
@@ -79,8 +79,8 @@ COMMON ANALYSIS OPTIONS
 :   Show all (user) events outside of user functions.
 
 \--tid=*TID*[,*TID*,...]
-:   Only print functions called by the given threads.  To see the list of
-    threads in the data file, you can use `uftrace report --threads` or
+:   Only print functions called by the given tasks.  To see the list of
+    tasks in the data file, you can use `uftrace report --task` or
     `uftrace info`.  This option can also be used more than once.
 
 \--demangle=*TYPE*

--- a/doc/uftrace-replay.md
+++ b/doc/uftrace-replay.md
@@ -102,8 +102,8 @@ COMMON ANALYSIS OPTIONS
 :   Show all (user) events outside of user functions.
 
 \--tid=*TID*[,*TID*,...]
-:   Only print functions called by the given threads.  To see the list of
-    threads in the data file, you can use `uftrace report --threads` or
+:   Only print functions called by the given tasks.  To see the list of
+    tasks in the data file, you can use `uftrace report --task` or
     `uftrace info`.  This option can also be used more than once.
 
 \--demangle=*TYPE*

--- a/doc/uftrace-report.md
+++ b/doc/uftrace-report.md
@@ -109,8 +109,8 @@ COMMON ANALYSIS OPTIONS
 :   Show all (user) events outside of user functions.
 
 \--tid=*TID*[,*TID*,...]
-:   Only print functions called by the given threads.  To see the list of
-    threads in the data file, you can use `uftrace report --task` or
+:   Only print functions called by the given tasks.  To see the list of
+    tasks in the data file, you can use `uftrace report --task` or
     `uftrace info`.  This option can also be used more than once.
 
 \--demangle=*TYPE*

--- a/doc/uftrace-script.md
+++ b/doc/uftrace-script.md
@@ -73,8 +73,8 @@ COMMON ANALYSIS OPTIONS
 :   Run script kernel functions only without user functions.
 
 \--tid=*TID*[,*TID*,...]
-:   Run script only for functions called by the given threads.  To see the list of
-    threads in the data file, you can use `uftrace report --threads` or
+:   Run script only for functions called by the given tasks.  To see the list of
+    tasks in the data file, you can use `uftrace report --task` or
     `uftrace info`.  This option can also be used more than once.
 
 \--demangle=*TYPE*

--- a/doc/uftrace-tui.md
+++ b/doc/uftrace-tui.md
@@ -79,8 +79,8 @@ COMMON ANALYSIS OPTIONS
 :   Show all (user) events outside of user functions.
 
 \--tid=*TID*[,*TID*,...]
-:   Only print functions called by the given threads.  To see the list of
-    threads in the data file, you can use `uftrace report --threads` or
+:   Only print functions called by the given tasks.  To see the list of
+    tasks in the data file, you can use `uftrace report --task` or
     `uftrace info`.  This option can also be used more than once.
 
 \--demangle=*TYPE*


### PR DESCRIPTION
I updated the description of --tid option.
'thread' --> 'task'
The related commands are graph, replay, report, script and tui.