### PR TITLE
uftrace: Fix usage description for script --record option

### DIFF
--- a/cmds/script.c
+++ b/cmds/script.c
@@ -145,7 +145,7 @@ int command_script(int argc, char *argv[], struct opts *opts)
 	}
 
 	if (!opts->script_file) {
-		pr_out("Usage: uftrace script [-S|--script] [<script_file>]\n");
+		pr_out("Usage: uftrace script (-S|--script) <script_file>\n");
 		return -1;
 	}
 

--- a/doc/ko/uftrace-script.md
+++ b/doc/ko/uftrace-script.md
@@ -9,7 +9,8 @@ uftrace-script - 기록된 데이터를 대상으로 스크립트를 실행한�
 
 사용법
 ======
-uftrace script [*options*]
+uftrace script (-S|--script) <script file> [*options*]
+uftrace script (-S|--script) <script file> [*options*] --record COMMAND
 
 
 설명

--- a/doc/uftrace-script.md
+++ b/doc/uftrace-script.md
@@ -9,7 +9,8 @@ uftrace-script - Run a script for recorded function trace
 
 SYNOPSIS
 ========
-uftrace script [*options*]
+uftrace script (-S|--script) <script file> [*options*]
+uftrace script (-S|--script) <script file> [*options*] --record COMMAND
 
 
 DESCRIPTION


### PR DESCRIPTION
Hi there,

I fixed brackets to parentheses in the usage command and added extra description to uftrace-script man page.

Fixed: #976

Signed-off-by: Handong Choi <wschd770@gmail.com>