### PR TITLE
live: Reuse --record option to keep recorded data

### DIFF
--- a/cmds/live.c
+++ b/cmds/live.c
@@ -104,30 +104,32 @@ int command_live(int argc, char *argv[], struct opts *opts)
 	};
 	int ret;
 
-	tmp_dirname = template;
-	umask(022);
-	fd = mkstemp(template);
-	if (fd < 0) {
-		if (errno != EPERM)
-			pr_err("cannot access to /tmp");
+	if (!opts->record) {
+		tmp_dirname = template;
+		umask(022);
+		fd = mkstemp(template);
+		if (fd < 0) {
+			if (errno != EPERM)
+				pr_err("cannot access to /tmp");
 
-		fd = mkstemp(template + sizeof("/tmp/") - 1);
+			fd = mkstemp(template + sizeof("/tmp/") - 1);
 
-		if (fd < 0)
-			pr_err("cannot create temp name");
-		tmp_dirname += sizeof("/tmp/") - 1;
+			if (fd < 0)
+				pr_err("cannot create temp name");
+			tmp_dirname += sizeof("/tmp/") - 1;
+		}
+
+		close(fd);
+		unlink(tmp_dirname);
+
+		atexit(cleanup_tempdir);
+
+		sa.sa_handler = sigsegv_handler;
+		sigfillset(&sa.sa_mask);
+		sigaction(SIGSEGV, &sa, NULL);
+
+		opts->dirname = tmp_dirname;
 	}
-
-	close(fd);
-	unlink(tmp_dirname);
-
-	atexit(cleanup_tempdir);
-
-	sa.sa_handler = sigsegv_handler;
-	sigfillset(&sa.sa_mask);
-	sigaction(SIGSEGV, &sa, NULL);
-
-	opts->dirname = tmp_dirname;
 
 	if (opts->list_event) {
 		if (geteuid() == 0)

--- a/doc/ko/uftrace-live.md
+++ b/doc/ko/uftrace-live.md
@@ -75,6 +75,9 @@ LIVE 옵션
 \--report
 :   replay 출력 전 live-report 를 함께 출력한다.
 
+\--record
+:   기록된 데이터를 향후 분석을 위해 저장한다.
+
 
 RECORD 옵션
 ==============

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -72,6 +72,9 @@ LIVE OPTIONS
 \--report
 :   Show live-report before replay.
 
+\--record
+:   Do not discard the recorded data.
+
 
 RECORD OPTIONS
 ==============


### PR DESCRIPTION
The live command is used to record the data in a temporary directory and
discards it after the execution.

Someone might want to see the replay output immediately, but also wants
to keep the recorded data to run another analysis command.

The current --record option is only used for script command, but can
also be used for live command for this purpose.
```
  $ rm -rf uftrace.data
  $ uftrace --record -F main t-abc
  # DURATION     TID     FUNCTION
              [109070] | main() {
              [109070] |   a() {
              [109070] |     b() {
              [109070] |       c() {
     0.933 us [109070] |         getpid();
     3.617 us [109070] |       } /* c */
     4.207 us [109070] |     } /* b */
     4.844 us [109070] |   } /* a */
     9.650 us [109070] | } /* main */

  $ uftrace replay
  # DURATION     TID     FUNCTION
              [109070] | main() {
              [109070] |   a() {
              [109070] |     b() {
              [109070] |       c() {
     0.933 us [109070] |         getpid();
     3.617 us [109070] |       } /* c */
     4.207 us [109070] |     } /* b */
     4.844 us [109070] |   } /* a */
     9.650 us [109070] | } /* main */
```
Closes: #1038

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>