### PR TITLE
tui: Use --report option to start with report mode

### DIFF
--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -2340,7 +2340,9 @@ static void tui_main_loop(struct opts *opts, struct uftrace_data *handle)
 	session = tui_session_init(opts);
 
 	/* start with graph only if there's one session */
-	if (session->nr_node > 1)
+	if (opts->report)
+		win = &report->win;
+	else if (session->nr_node > 1)
 		win = &session->win;
 	else
 		win = &graph->win;


### PR DESCRIPTION
This patch reuses --report option in tui command so that it can be used
to start the tui window in report mode.

Closes: #1037

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>