### PR TITLE
utils: Fix memory leaks in tui

### DIFF
--- a/utils/auto-args.c
+++ b/utils/auto-args.c
@@ -112,7 +112,7 @@ next:
 		while (!list_empty(&args)) {
 			arg = list_first_entry(&args, struct uftrace_arg_spec, list);
 			list_del(&arg->list);
-			free(arg);
+			free_arg_spec(arg);
 		}
 	}
 	strv_free(&specs);
@@ -261,7 +261,7 @@ static void release_auto_args(struct rb_root *root)
 
 		list_for_each_entry_safe(arg, tmp, &entry->args, list) {
 			list_del(&arg->list);
-			free(arg);
+			free_arg_spec(arg);
 		}
 
 		free(entry->name);

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -220,6 +220,13 @@ static void add_arg_spec(struct list_head *arg_list, struct uftrace_arg_spec *ar
 	}
 }
 
+void free_arg_spec(struct uftrace_arg_spec *arg)
+{
+	if (arg->fmt == ARG_FMT_ENUM)
+		free(arg->enum_str);
+	free(arg);
+}
+
 void add_trigger(struct uftrace_filter *filter, struct uftrace_trigger *tr,
 		 bool exact_match)
 {
@@ -1043,10 +1050,7 @@ next:
 		while (!list_empty(&args)) {
 			arg = list_first_entry(&args, typeof(*arg), list);
 			list_del(&arg->list);
-
-			if (arg->fmt == ARG_FMT_ENUM)
-				free(arg->enum_str);
-			free(arg);
+			free_arg_spec(arg);
 		}
 
 	}
@@ -1156,7 +1160,7 @@ void uftrace_cleanup_filter(struct rb_root *root)
 
 		list_for_each_entry_safe(arg, tmp, &filter->args, list) {
 			list_del(&arg->list);
-			free(arg);
+			free_arg_spec(arg);
 		}
 		free(filter);
 	}

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -206,6 +206,8 @@ void setup_auto_args_str(char *args, char *rets, char *enums,
 			 struct uftrace_filter_setting *setting);
 void finish_auto_args(void);
 
+void free_arg_spec(struct uftrace_arg_spec *arg);
+
 struct debug_info;
 
 struct uftrace_filter * find_auto_argspec(struct uftrace_filter *filter,


### PR DESCRIPTION
Fix memory leaks in argument enum string.

Fixed: #920

Signed-off-by: Sang-Heon Jeon <ekffu200098@gmail.com>