### PR TITLE
utils: Fix memory leak with perf data in tui

### DIFF
--- a/utils/perf.c
+++ b/utils/perf.c
@@ -237,8 +237,9 @@ out:
  * @handle - uftrace data file handle
  *
  * This function prepares to read perf event data from perf-cpu*.dat
- * files.  It returns 0 on success, -1 on failure.  Callers should
- * call finish_perf_data() after reading all perf event data.
+ * files.  It returns 0 on success which includes that perf event data
+ * already setup, -1 on failure.  Callers should call
+ * finish_perf_data() after reading all perf event data.
  */
 int setup_perf_data(struct uftrace_data *handle)
 {
@@ -247,6 +248,9 @@ int setup_perf_data(struct uftrace_data *handle)
 	char *pattern;
 	size_t i;
 	int ret = -1;
+
+	if (has_perf_data(handle))
+		return 0;
 
 	xasprintf(&pattern, "%s/perf-cpu*.dat", handle->dirname);
 	if (glob(pattern, GLOB_ERR, NULL, &globbuf)) {


### PR DESCRIPTION
Fix memory leak with setup_perf_data.
This patch will prevent duplicate allocation of perf data.

Currently, we setup perf data both when opening data files
and processing uftrace information.
- `open_data_file` in `utils/data-file.c`
- `process_uftrace_info in `cmds/info.c`

This patch will prevent duplicate allocation of perf data.

Fixed: #1024

Signed-off-by: Sang-Heon Jeon <ekffu200098@gmail.com>