### PR TITLE
support PIC code which has 'mov' as opcode.

### DIFF
--- a/arch/x86_64/Makefile
+++ b/arch/x86_64/Makefile
@@ -6,7 +6,7 @@ odir := $(objdir)/arch/x86_64
 include $(srcdir)/Makefile.include
 
 ARCH_ENTRY_SRC = $(wildcard $(sdir)/*.S)
-ARCH_MCOUNT_SRC = $(wildcard $(sdir)/mcount-*.c) $(sdir)/symbol.c
+ARCH_MCOUNT_SRC = $(wildcard $(sdir)/mcount-*.c) $(sdir)/symbol.c $(sdir)/x64_modrm.c
 ARCH_UFTRACE_SRC = $(sdir)/cpuinfo.c $(sdir)/symbol.c
 
 ARCH_MCOUNT_OBJS  = $(patsubst $(sdir)/%.S,$(odir)/%.op,$(ARCH_ENTRY_SRC))

--- a/arch/x86_64/mcount-insn.c
+++ b/arch/x86_64/mcount-insn.c
@@ -131,14 +131,13 @@ static int opnd_reg(int capstone_reg)
  *  to this.
  *    mov rcx, [calculated PC + 0x8f3f85]
  */
-static int handle_pic(cs_insn *insn, uint8_t insns[],
+static int handle_pic_lea(cs_insn *insn, uint8_t insns[],
 		      struct mcount_disasm_info *info)
 {
 	cs_x86 *x86 = &insn->detail->x86;
-
-#define REX   0
-#define OPND  1
-#define IMM   2
+	static const int REX = 0;
+	static const int OPND = 1;
+	static const int IMM = 2;
 
 	/*
 	 * array for mov instruction: REX + OPND + IMM(8-byte)

--- a/arch/x86_64/x64_modrm.c
+++ b/arch/x86_64/x64_modrm.c
@@ -1,0 +1,145 @@
+#include <stdio.h>
+#include <stdint.h>
+#include "x64_modrm.h"
+
+uint8_t modrm_to_byte(struct MODRM modrm)
+{
+	uint8_t res = 0;
+
+	res |= (modrm.mod << 6);
+	res |= (modrm.reg << 3);
+	res |= modrm.rm;
+
+	return res;
+}
+
+uint8_t sib_to_byte(struct SIB sib)
+{
+	uint8_t res = 0;
+
+	res |= (sib.ss << 6);
+	res |= (sib.index << 3);
+	res |= sib.base;
+
+	return res;
+}
+
+
+// INTEL MANUAL VOLUME 2, CH 2.1.5
+CALC_RESP calc_modrm_x64(int op1, int op2, effect_t which, int disp, struct MODRM *modrm)
+{
+	int cols = -1, rows = -1;
+	CALC_RESP res = CALC_FAILED;
+
+	/*
+	 * as effective address,
+	 * - disp32 only available when disp has none.
+	 * - and it must be the effective address cannot be reg value.
+	 *
+	 * if condition true,
+	 * adjust origin value 10 of disp32 to 5 to fit its position.
+	 */
+	if (disp == disp_none) {
+		if (which == effect_OP1 && op1 == disp32)
+			op1 -= 5;
+		else if (which == effect_OP2 && op2 == disp32)
+			op2 -= 5;
+	}
+
+	/*
+	 * santiny check, correct value range of arguments
+	 */
+	if (op1 < 0 || op2 < 0 || op1 > 7 || op2 > 7 ||
+	    disp < disp_none || disp > disp32 ||
+	    which < effect_none || which > effect_OP2) {
+		goto FAILED;
+	}
+
+	if (which == effect_none) {
+		if (disp != disp_none) {
+			goto FAILED;
+		}
+
+		rows = op1;
+		cols = op2;
+
+		modrm->mod = 3;
+		modrm->rm = rows;
+		modrm->reg = cols;
+
+		return CALC_SUCCESS;
+
+	} else if (which == effect_OP1) {
+		rows = op1;
+		cols = op2;
+	} else {
+		rows = op2;
+		cols = op1;
+	}
+
+	res = CALC_SUCCESS;
+
+	if (disp == disp_none) {
+		modrm->mod = 0;
+
+		/*
+		 * need to calc SIB addressing
+		 */
+		if (rows == 4) {
+			// SP, ESP, RSP
+			res = CALC_SUCCESS_HAS_SIB;
+		}
+		if (rows == 5) {
+			// disp32
+			res = CALC_SUCCESS_HAS_SIB;
+		}
+	}
+	else if (disp == disp8) {
+		modrm->mod = 1;
+
+		// need to calc SIB addressing
+		if (rows == 4) {
+			// SP, ESP, RSP
+			res = CALC_SUCCESS_HAS_SIB;
+		}
+	}
+	else if (disp == disp32) {
+		modrm->mod = 2;
+
+		// need to calc SIB addressing
+		if (rows == 4) {
+			// SP, ESP, RSP
+			res = CALC_SUCCESS_HAS_SIB;
+		}
+	}
+
+	modrm->rm = rows;
+	modrm->reg = cols;
+
+	return res;
+
+FAILED:
+	return CALC_FAILED;
+}
+
+CALC_RESP calc_sib_x64(int base, int scale_index, int scale, struct SIB *sib)
+{
+	CALC_RESP res;
+
+	if (scale == 1) {
+		sib->ss = 0;
+	} else if (scale == 2) {
+		sib->ss = 1;
+	} else if (scale == 4) {
+		sib->ss = 2;
+	} else if (scale == 8) {
+		sib->ss = 3;
+	} else {
+		res = CALC_FAILED;
+	}
+
+	sib->index = scale_index;
+	sib->base = base;
+
+	return res;
+}

--- a/arch/x86_64/x64_modrm.h
+++ b/arch/x86_64/x64_modrm.h
@@ -1,0 +1,121 @@
+#include <stdio.h>
+#include <stdint.h>
+
+enum r8 {
+	AL = 0,
+	CL,
+	DL,
+	BL,
+	AH,
+	CH,
+	DH,
+	BH,
+};
+
+enum r16 {
+	AX = 0,
+	CX,
+	DX,
+	BX,
+	SP,
+	BP,
+	SI,
+	DI,
+};
+
+enum r32 {
+	EAX = 0,
+	ECX,
+	EDX,
+	EBX,
+	ESP = 4,
+	// used in sib
+	ENONE = 4,
+	EBP,
+	ESI,
+	EDI,
+};
+
+enum r64 {
+	RAX = 0,
+	RCX,
+	RDX,
+	RBX,
+	RSP = 4,
+	// used in sib
+	RNONE = 4,
+	RBP,
+	RSI,
+	RDI,
+};
+
+enum xr64 {
+	R8 = 0,
+	R9,
+	R10,
+	R11,
+	R12,
+	R13,
+	R14,
+	R15,
+};
+
+enum mm {
+	MM0 = 0,
+	MM1,
+	MM2,
+	MM3,
+	MM4,
+	MM5,
+	MM6,
+	MM7,
+};
+
+enum xmm {
+	XMM0 = 0,
+	XMM1,
+	XMM2,
+	XMM3,
+	XMM4,
+	XMM5,
+	XMM6,
+	XMM7,
+};
+
+typedef enum  {
+	effect_none = 0,
+	effect_OP1,
+	effect_OP2,
+} effect_t;
+
+typedef enum {
+	disp_none = 8,
+	disp8,
+	disp32,
+} displace_t;
+
+struct MODRM {
+	unsigned int mod : 2;
+	// in other words, /digit
+	unsigned int reg : 3;
+	unsigned int rm : 3;
+};
+
+struct SIB {
+	unsigned int ss : 2;
+	unsigned int index : 3;
+	unsigned int base : 3;
+};
+
+typedef enum {
+	CALC_FAILED = -1,
+	CALC_SUCCESS = 0,
+	CALC_SUCCESS_HAS_SIB = 1,
+} CALC_RESP;
+
+// INTEL MANUAL VOLUME 2, CH 2.1.5
+CALC_RESP calc_modrm_x64(int op1, int op2, effect_t which, int disp, struct MODRM *modrm);
+CALC_RESP calc_sib_x64(int scale_index, int base, int scale, struct SIB *sib);
+
+uint8_t modrm_to_byte(struct MODRM modrm);
+uint8_t sib_to_byte(struct SIB sib);


### PR DESCRIPTION
support PIC code which has 'mov' as opcode.

# statistics

## node

### before
```
dynamic:    total:    17538
dynamic:  patched:    15702 (89.53%)
dynamic:   failed:     1836 (10.46%)
dynamic:  skipped:        0 ( 0.00%)
dynamic: no match:        0
mcount: mcount setup done
```
### after
```
dynamic:    total:    17538
dynamic:  patched:    15717 (89.61%)
dynamic:   failed:     1821 (10.38%)
dynamic:  skipped:        0 ( 0.00%)
dynamic: no match:        0
mcount: mcount setup done
```

## python 2.7

### before
```
dynamic:    total:     1109
dynamic:  patched:      336 (30.29%)
dynamic:   failed:      756 (68.16%)
dynamic:  skipped:       17 ( 1.53%)
dynamic: no match:        0
```
### after
```
dynamic:    total:     1109
dynamic:  patched:      368 (33.18%)
dynamic:   failed:      724 (65.28%)
dynamic:  skipped:       17 ( 1.53%)
dynamic: no match:        0
mcount: mcount setup done
```