### PR TITLE
build: Fix make ctags rule not to include unintended files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,7 +358,7 @@ reset-coverage:
 	$(Q)$(RM) coverage.info
 
 ctags:
-	@find . -name "*\.[chS]" -o -path ./tests -prune -o -path ./check-deps -prune \
+	@find uftrace.c uftrace.h libmcount arch utils misc libtraceevent -name "*\.[chS]" \
 		| xargs ctags --regex-asm='/^(GLOBAL|ENTRY|END)\(([^)]*)\).*/\2/'
 
 .PHONY: all config clean test dist doc ctags PHONY


### PR DESCRIPTION
The current 'make ctags' rule contains unintended files because 'find'
command start from the current directory and matches the entire files
that contains '*.[chS]'.

If uftrace base directory contains other files and directories,
unintended files may be included in 'tags' file.  So this patch
explicitly list all uftrace files and directories only.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>