### PR TITLE
graph: Enhance task graph with field, time-filter, color

### DIFF
--- a/cmds/graph.c
+++ b/cmds/graph.c
@@ -126,6 +126,12 @@ static void print_task_self_time(struct field_data *fd)
 	print_time_unit(d);
 }
 
+static void print_task_tid(struct field_data *fd)
+{
+	struct uftrace_task *task = fd->arg;
+	pr_out("[%6d]", task->tid);
+}
+
 static struct display_field field_task_total_time = {
 	.id      = GRAPH_F_TASK_TOTAL_TIME,
 	.name    = "total-time",
@@ -146,6 +152,15 @@ static struct display_field field_task_self_time = {
 	.list    = LIST_HEAD_INIT(field_task_self_time.list),
 };
 
+static struct display_field field_task_tid = {
+	.id      = GRAPH_F_TASK_TID,
+	.name    = "tid",
+	.header  = "   TID  ",
+	.length  = 8,
+	.print   = print_task_tid,
+	.list    = LIST_HEAD_INIT(field_task_tid.list),
+};
+
 /* index of this table should be matched to display_field_id */
 static struct display_field *field_table[] = {
 	&field_total_time,
@@ -157,6 +172,7 @@ static struct display_field *field_table[] = {
 static struct display_field *field_task_table[] = {
 	&field_task_total_time,
 	&field_task_self_time,
+	&field_task_tid,
 };
 
 static void setup_default_field(struct list_head *fields, struct opts *opts)
@@ -168,6 +184,7 @@ static void setup_default_task_field(struct list_head *fields, struct opts *opts
 {
 	add_field(fields, field_task_table[GRAPH_F_TASK_TOTAL_TIME]);
 	add_field(fields, field_task_table[GRAPH_F_TASK_SELF_TIME]);
+	add_field(fields, field_task_table[GRAPH_F_TASK_TID]);
 }
 
 static void print_field(struct uftrace_graph_node *node)
@@ -796,7 +813,7 @@ static bool print_task_node(struct uftrace_task *task,
 
 	print_task_field(task);
 	pr_indent(indent_mask, indent, true);
-	pr_out("[%d] %s\n", task->tid, name);
+	pr_out("%s\n", name);
 
 	if (list_empty(&task->children))
 		return false;

--- a/cmds/graph.c
+++ b/cmds/graph.c
@@ -421,7 +421,7 @@ static int print_graph(struct session_graph *graph, struct opts *opts)
 
 	if (graph->ug.root.time || graph->ug.root.nr_edges) {
 		pr_out("========== FUNCTION CALL GRAPH ==========\n");
-		print_header(&output_fields, "# ", 2);
+		print_header(&output_fields, "# ", "FUNCTION", 2);
 		indent_mask = xcalloc(opts->max_stack, sizeof(*indent_mask));
 		print_graph_node(&graph->ug, &graph->ug.root, indent_mask, 0,
 				 graph->ug.root.nr_edges > 1);

--- a/cmds/graph.c
+++ b/cmds/graph.c
@@ -813,7 +813,14 @@ static bool print_task_node(struct uftrace_task *task,
 
 	print_task_field(task);
 	pr_indent(indent_mask, indent, true);
-	pr_out("%s\n", name);
+	if (parent && parent->pid == task->pid) {
+		/* print thread name in green color */
+		pr_green("%s\n", name);
+	}
+	else {
+		/* print process name */
+		pr_out("%s\n", name);
+	}
 
 	if (list_empty(&task->children))
 		return false;

--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -1145,7 +1145,7 @@ int command_replay(int argc, char *argv[], struct opts *opts)
 		    field_table, ARRAY_SIZE(field_table));
 
 	if (!opts->flat && peek_rstack(&handle, &task) == 0)
-		print_header(&output_fields, "#", 1);
+		print_header(&output_fields, "#", "FUNCTION", 1);
 
 	while (read_rstack(&handle, &task) == 0 && !uftrace_done) {
 		struct uftrace_record *rstack = task->rstack;

--- a/tests/t230_graph_task.py
+++ b/tests/t230_graph_task.py
@@ -11,10 +11,10 @@ class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'fork', result="""
 ========== TASK GRAPH ==========
-# TOTAL-TIME   SELF-TIME : TASK
-  889.724 us  207.791 us : [27364] t-fork
-                         :  |    
-   11.706 us   11.706 us :  +----[27366] t-fork
+# TOTAL TIME   SELF TIME     TID     TASK NAME
+   16.172 ms  356.762 us  [129306] : t-fork
+                                   :  |    
+   11.015 us   11.015 us  [129317] :  +----t-fork
 """)
 
     def pre(self):

--- a/utils/field.c
+++ b/utils/field.c
@@ -3,7 +3,7 @@
 #include "utils/list.h"
 
 void print_header(struct list_head *output_fields, const char *prefix,
-		  int space)
+		  const char *postfix, int space)
 {
 	struct display_field *field;
 	bool first = true;
@@ -18,7 +18,7 @@ void print_header(struct list_head *output_fields, const char *prefix,
 		first = false;
 	}
 
-	pr_out("   FUNCTION\n");
+	pr_out("   %s\n", postfix);
 }
 
 int print_field_data(struct list_head *output_fields, struct field_data *fd,

--- a/utils/field.h
+++ b/utils/field.h
@@ -46,7 +46,7 @@ static inline uint64_t effective_addr(uint64_t addr)
 }
 
 void print_header(struct list_head *output_fields, const char *prefix,
-		  int space);
+		  const char *postfix, int space);
 int print_field_data(struct list_head *output_fields, struct field_data *fd,
 		     int space);
 int print_empty_field(struct list_head *output_fields, int space);

--- a/utils/field.h
+++ b/utils/field.h
@@ -26,6 +26,9 @@ enum display_field_id {
 	GRAPH_F_TOTAL_TIME      = 0,
 	GRAPH_F_SELF_TIME,
 	GRAPH_F_ADDR,
+
+	GRAPH_F_TASK_TOTAL_TIME = 0,
+	GRAPH_F_TASK_SELF_TIME,
 };
 
 struct display_field {

--- a/utils/field.h
+++ b/utils/field.h
@@ -29,6 +29,7 @@ enum display_field_id {
 
 	GRAPH_F_TASK_TOTAL_TIME = 0,
 	GRAPH_F_TASK_SELF_TIME,
+	GRAPH_F_TASK_TID,
 };
 
 struct display_field {


### PR DESCRIPTION
The current graph --task output show tid with task name, but it looks
confusing because it doesn't explain the number is tid info.

So it'd be better to show tid in a TID field and it looks more clear.
In addition, this patch also changes TASK to TASK-NAME in the header.

Before:
```
  $ uftrace graph --task
  ========== TASK GRAPH ==========
  # TOTAL-TIME   SELF-TIME : TASK
      9.002  m    1.041  m : [168086] chrome
                           :  +-[168130] chrome
                           :  |
      7.018  m    1.020  m :  +----[168131] chrome
                           :  |     |
      2.039  m    2.802  s :  |     +----[168200] chrome
                           :  |     |     +-[168201] chrome
      2.039  m   16.797 ms :  |     |     +-[168202] TaskSchedulerFo
      2.039  m  432.881 ms :  |     |     +-[168204] Chrome_ChildIOT
  ...
```
After:
```
  $ uftrace graph --task
  ========== TASK GRAPH ==========
  # TOTAL-TIME   SELF-TIME     TID   : TASK-NAME
      7.018  m   25.892  s  [168086] : chrome
                            [168130] : +- chrome
                                     : |
      5.059  m  682.897 ms  [168131] : +---- chrome
                                     : |     |
      2.039  m    2.972  s  [168200] : |     +---- chrome
                            [168201] : |     |     +- chrome
      2.039  m   16.415 ms  [168202] : |     |     +- TaskSchedulerFo
      2.039  m    1.352  s  [168204] : |     |     +- Chrome_ChildIOT
  ...
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>