### PR TITLE
Fix memory leaks and heap buffer overflows

### DIFF
--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -314,66 +314,62 @@ static void print_event(struct uftrace_task_reader *task,
 			u.statm = task->args.data;
 			pr_color(color, "%s (size=%"PRIu64"KB, rss=%"PRIu64"KB, shared=%"PRIu64"KB)",
 				 evt_name, u.statm->vmsize, u.statm->vmrss, u.statm->shared);
-			return;
+			break;
 		case EVENT_ID_READ_PAGE_FAULT:
 			u.page_fault = task->args.data;
 			pr_color(color, "%s (major=%"PRIu64", minor=%"PRIu64")",
 				 evt_name, u.page_fault->major, u.page_fault->minor);
-			return;
+			break;
 		case EVENT_ID_READ_PMU_CYCLE:
 			u.cycle = task->args.data;
 			pr_color(color, "%s (cycle=%"PRIu64", instructions=%"PRIu64")",
 				 evt_name, u.cycle->cycles, u.cycle->instrs);
-			return;
+			break;
 		case EVENT_ID_READ_PMU_CACHE:
 			u.cache = task->args.data;
 			pr_color(color, "%s (refers=%"PRIu64", misses=%"PRIu64")",
 				 evt_name, u.cache->refers, u.cache->misses);
-			return;
+			break;
 		case EVENT_ID_READ_PMU_BRANCH:
 			u.branch = task->args.data;
 			pr_color(color, "%s (branch=%"PRIu64", misses=%"PRIu64")",
 				 evt_name, u.branch->branch, u.branch->misses);
-			return;
+			break;
 		case EVENT_ID_DIFF_PROC_STATM:
 			u.statm = task->args.data;
 			pr_color(color, "%s (size=%+"PRId64"KB, rss=%+"PRId64"KB, shared=%+"PRId64"KB)",
 				 evt_name, u.statm->vmsize, u.statm->vmrss, u.statm->shared);
-			return;
+			break;
 		case EVENT_ID_DIFF_PAGE_FAULT:
 			u.page_fault = task->args.data;
 			pr_color(color, "%s (major=%+"PRId64", minor=%+"PRId64")",
 				 evt_name, u.page_fault->major, u.page_fault->minor);
-			return;
+			break;
 		case EVENT_ID_DIFF_PMU_CYCLE:
 			u.cycle = task->args.data;
 			pr_color(color, "%s (cycle=%+"PRId64", instructions=%+"PRId64", IPC=%.2f)",
 				 evt_name, u.cycle->cycles, u.cycle->instrs,
 				 (float)u.cycle->instrs / u.cycle->cycles);
-			return;
+			break;
 		case EVENT_ID_DIFF_PMU_CACHE:
 			u.cache = task->args.data;
 			pr_color(color, "%s (refers=%+"PRId64", misses=%+"PRId64", hit=%"PRId64"%%)",
 				 evt_name, u.cache->refers, u.cache->misses,
 				 (u.cache->refers - u.cache->misses) * 100 / u.cache->refers);
-			return;
+			break;
 		case EVENT_ID_DIFF_PMU_BRANCH:
 			u.branch = task->args.data;
 			pr_color(color, "%s (branch=%+"PRId64", misses=%+"PRId64", predict=%"PRId64"%%)",
 				 evt_name, u.branch->branch, u.branch->misses,
 				 (u.branch->branch - u.branch->misses) * 100 / u.branch->branch);
-			return;
+			break;
 		case EVENT_ID_WATCH_CPU:
 			u.cpu = task->args.data;
 			pr_color(color, "%s (cpu=%d)", evt_name, *u.cpu);
-			return;
-
+			break;
 		default:
 			pr_color(color, "%s", evt_name);
-			break;
 		}
-		pr_color(color, "user_event:%u", evt_id);
-		return;
 	}
 	else {
 		/* kernel events */

--- a/cmds/script.c
+++ b/cmds/script.c
@@ -180,8 +180,10 @@ int command_script(int argc, char *argv[], struct opts *opts)
 	strv_copy(&info.cmds, argc, argv);
 
 	/* initialize script */
-	if (script_init(&info, opts->patt_type) < 0)
-		return -1;
+	if (script_init(&info, opts->patt_type) < 0) {
+		ret = -1;
+		goto out;
+	}
 
 	while (read_rstack(&handle, &task) == 0 && !uftrace_done) {
 		if (!fstack_check_opts(task, opts))
@@ -195,10 +197,12 @@ int command_script(int argc, char *argv[], struct opts *opts)
 
 	/* dtor for script support */
 	script_uftrace_end();
-
+out:
 	script_finish();
 
 	close_data_file(opts, &handle);
+
+	strv_free(&info.cmds);
 
 	return ret;
 }

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -677,6 +677,9 @@ static int fstack_check_skip(struct uftrace_task_reader *task,
 		return -1;
 
 	if (rstack->type == UFTRACE_EXIT) {
+		if (task->stack_count < 1)
+			return 0;
+
 		/* fstack_consume() is not called yet */
 		fstack = &task->func_stack[task->stack_count - 1];
 


### PR DESCRIPTION
This PR fixes memory leaks and heap buffer overflow problems including the following commits
* fstack: Fix a heap buffer overflow
* replay: Fix a memory leak in event name
* script: Fix a memory leak in a struct strv variable

Fixes: #803 and other problems found in tests

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>