### PR TITLE
mcount: Flush data when call is deeply nested

### DIFF
--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -126,6 +126,7 @@ struct mcount_thread_data {
 	bool				recursion_marker;
 	bool				in_exception;
 	bool				dead;
+	bool				warned;
 	unsigned long			cygprof_dummy;
 	struct mcount_ret_stack		*rstack;
 	void				*argbuf;

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -788,14 +788,20 @@ static void mcount_finish(void)
 static bool mcount_check_rstack(struct mcount_thread_data *mtdp)
 {
 	if (mtdp->idx >= mcount_rstack_max) {
-		static bool warned = false;
+		if (!mtdp->warned) {
+			struct mcount_ret_stack *rstack;
 
-		if (!warned) {
-			pr_warn("too deeply nested calls: %d\n", mtdp->idx);
-			warned = true;
+			pr_warn("call depth beyond %d is not recorded.\n"
+			        "      (use --max-stack=DEPTH to record more)\n",
+				mtdp->idx);
+			/* flush current rstack */
+			rstack = &mtdp->rstack[mcount_rstack_max - 1];
+			record_trace_data(mtdp, rstack, NULL);
+			mtdp->warned = true;
 		}
 		return true;
 	}
+	mtdp->warned = false;
 	return false;
 }
 


### PR DESCRIPTION
In some cases, the target program might be crashed while running in the
deeply nested call.  In this case, the current implementation cannot
record its internal calls and lose most of the calls.

For example, there is an incorrected written factorial example.
```
  $ cat factorial.c
  int factorial(int n)
  {
      return n * factorial(n - 1);
  }

  int main()
  {
      return factorial(8);
  }
```
The user expects the deeply nested calls, but it doesn't show anything
in the current implementation.
```
  $ gcc -pg -g factorial.c
  $ uftrace -a a.out
  WARN: too deeply nested calls: 1024
  WARN: child terminated by signal: 11: Segmentation fault
  # DURATION     TID     FUNCTION
     2.010 us [ 36774] | __monstartup();
     0.847 us [ 36774] | __cxa_atexit();
```
This patch make it flush the recorded data when the call is deeply
nested and it shows the internal calls.
```
  $ gcc -pg -g factorial.c
  $ uftrace -a a.out
  # DURATION     TID     FUNCTION
     2.223 us [ 36542] | __monstartup();
     1.154 us [ 36542] | __cxa_atexit();
              [ 36542] | main() {
              [ 36542] |   factorial(8) {
              [ 36542] |     factorial(7) {
              [ 36542] |       factorial(6) {
              [ 36542] |         factorial(5) {
              [ 36542] |           factorial(4) {
              [ 36542] |             factorial(3) {
              [ 36542] |               factorial(2) {
              [ 36542] |                 factorial(1) {
              [ 36542] |                   factorial(0) {
              [ 36542] |                     factorial(-1) {
              [ 36542] |                       factorial(-2) {
              [ 36542] |                         factorial(-3) {
...
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>