### PR TITLE
support dynamic tracing for dlopen'ed modules

### DIFF
--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -55,6 +55,9 @@ static struct Hashmap *code_hmap;
 /* at least, function size must be greater than this */
 static uint64_t min_size = 0;
 
+/* disassembly engine for dynamic code patch */
+static struct mcount_disasm_engine disasm;
+
 static struct mcount_orig_insn *create_code(struct Hashmap *map,
 					    unsigned long addr)
 {
@@ -290,8 +293,7 @@ static int find_dynamic_module(struct dl_phdr_info *info, size_t sz, void *data)
 	return !fmd->needs_modules;
 }
 
-static void prepare_dynamic_update(struct mcount_disasm_engine *disasm,
-				   struct symtabs *symtabs,
+static void prepare_dynamic_update(struct symtabs *symtabs,
 				   bool needs_modules)
 {
 	struct find_module_data fmd = {
@@ -305,7 +307,7 @@ static void prepare_dynamic_update(struct mcount_disasm_engine *disasm,
 
 	code_hmap = hashmap_create(hash_size, hashmap_ptr_hash,
 				   hashmap_ptr_equals);
-	mcount_disasm_init(disasm);
+	mcount_disasm_init(&disasm);
 	dl_iterate_phdr(find_dynamic_module, &fmd);
 }
 
@@ -354,9 +356,7 @@ static bool match_pattern_list(struct list_head *patterns,
 }
 
 static int do_dynamic_update(struct symtabs *symtabs, char *patch_funcs,
-			     enum uftrace_pattern_type ptype,
-			     struct mcount_disasm_engine *disasm,
-			     unsigned min_size)
+			     enum uftrace_pattern_type ptype)
 {
 	struct uftrace_mmap *map;
 	struct symtab *symtab;
@@ -451,13 +451,13 @@ static int do_dynamic_update(struct symtabs *symtabs, char *patch_funcs,
 				continue;
 
 			if (!match_pattern_list(&patterns, map, sym->name)) {
-				if (mcount_unpatch_func(mdi, sym, disasm) == 0)
+				if (mcount_unpatch_func(mdi, sym, &disasm) == 0)
 					stats.unpatch++;
 				continue;
 			}
 
 			found = true;
-			switch (mcount_patch_func(mdi, sym, disasm, min_size)) {
+			switch (mcount_patch_func(mdi, sym, &disasm, min_size)) {
 			case INSTRUMENT_FAILED:
 				stats.failed++;
 				break;
@@ -494,7 +494,7 @@ static int do_dynamic_update(struct symtabs *symtabs, char *patch_funcs,
 	return 0;
 }
 
-static void finish_dynamic_update(struct mcount_disasm_engine *disasm)
+static void finish_dynamic_update(void)
 {
 	struct mcount_dynamic_info *mdi, *tmp;
 
@@ -502,14 +502,13 @@ static void finish_dynamic_update(struct mcount_disasm_engine *disasm)
 	while (mdi) {
 		tmp = mdi->next;
 
-		mcount_arch_dynamic_recover(mdi, disasm);
+		mcount_arch_dynamic_recover(mdi, &disasm);
 		mcount_cleanup_trampoline(mdi);
 		free(mdi);
 
 		mdi = tmp;
 	}
 
-	mcount_disasm_finish(disasm);
 	mcount_freeze_code();
 }
 
@@ -523,20 +522,19 @@ static int calc_percent(int n, int total, int *rem)
 }
 
 int mcount_dynamic_update(struct symtabs *symtabs, char *patch_funcs,
-			  enum uftrace_pattern_type ptype,
-			  struct mcount_disasm_engine *disasm)
+			  enum uftrace_pattern_type ptype)
 {
 	int ret = 0;
 	char *size_filter;
 	bool needs_modules = !!strchr(patch_funcs, '@');
 
-	prepare_dynamic_update(disasm, symtabs, needs_modules);
+	prepare_dynamic_update(symtabs, needs_modules);
 
 	size_filter = getenv("UFTRACE_PATCH_SIZE");
 	if (size_filter != NULL)
 		min_size = strtoul(size_filter, NULL, 0);
 
-	ret = do_dynamic_update(symtabs, patch_funcs, ptype, disasm, min_size);
+	ret = do_dynamic_update(symtabs, patch_funcs, ptype);
 
 	if (stats.total && stats.failed) {
 		int success = stats.total - stats.failed - stats.skipped;
@@ -554,7 +552,7 @@ int mcount_dynamic_update(struct symtabs *symtabs, char *patch_funcs,
 		pr_dbg("no match: %8d\n", stats.nomatch);
 	}
 
-	finish_dynamic_update(disasm);
+	finish_dynamic_update();
 	return ret;
 }
 

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -489,6 +489,30 @@ static void patch_func_matched(struct mcount_dynamic_info *mdi,
 		stats.nomatch++;
 }
 
+void mcount_cleanup_dynamic(void)
+{
+	mcount_disasm_finish(&disasm);
+
+	if (instrument_ml) {
+		while (!list_empty(instrument_ml)) {
+			struct module_list *ml;
+
+			ml = list_first_entry(instrument_ml, struct module_list, list);
+			while (!list_empty(&ml->patt_list)) {
+				struct patt_list *pl;
+				pl = list_first_entry(&ml->patt_list, struct patt_list, list);
+				list_del(&pl->list);
+				free(pl->module);
+				free(pl);
+			}
+
+			list_del(&ml->list);
+			free(ml->modname);
+			free(ml);
+		}
+	}
+}
+
 static int do_dynamic_update(struct symtabs *symtabs, char *patch_funcs,
 			     enum uftrace_pattern_type ptype)
 {

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -52,6 +52,9 @@ static LIST_HEAD(code_pages);
 
 static struct Hashmap *code_hmap;
 
+/* at least, function size must be greater than this */
+static uint64_t min_size = 0;
+
 static struct mcount_orig_insn *create_code(struct Hashmap *map,
 					    unsigned long addr)
 {
@@ -525,7 +528,6 @@ int mcount_dynamic_update(struct symtabs *symtabs, char *patch_funcs,
 {
 	int ret = 0;
 	char *size_filter;
-	unsigned min_size = 0;
 	bool needs_modules = !!strchr(patch_funcs, '@');
 
 	prepare_dynamic_update(disasm, symtabs, needs_modules);

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -497,6 +497,7 @@ void mcount_list_events(void);
 int mcount_arch_enable_event(struct mcount_event_info *mei);
 
 void mcount_hook_functions(void);
+void mcount_cleanup_dynamic(void);
 void mcount_handle_dlopen(struct symtabs *symtabs,
 			  struct dl_phdr_info *info, char *mod_realpath,
 			  size_t size);

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -417,8 +417,7 @@ struct mcount_disasm_engine {
 #define INSTRUMENT_SKIPPED                      -2
 
 int mcount_dynamic_update(struct symtabs *symtabs, char *patch_funcs,
-			  enum uftrace_pattern_type ptype,
-			  struct mcount_disasm_engine *disasm);
+			  enum uftrace_pattern_type ptype);
 
 struct mcount_orig_insn {
 	struct rb_node		node;

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -16,6 +16,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/syscall.h>
+#include <link.h>
 
 #ifdef HAVE_LIBCAPSTONE
 # include <capstone/capstone.h>
@@ -496,6 +497,9 @@ void mcount_list_events(void);
 int mcount_arch_enable_event(struct mcount_event_info *mei);
 
 void mcount_hook_functions(void);
+void mcount_handle_dlopen(struct symtabs *symtabs,
+			  struct dl_phdr_info *info, char *mod_realpath,
+			  size_t size);
 
 int read_pmu_event(struct mcount_thread_data *mtdp, enum uftrace_event_id id,
 		   void *buf);

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -1818,6 +1818,7 @@ static void mcount_cleanup(void)
 	script_str = NULL;
 
 	unload_module_symtabs();
+	mcount_cleanup_dynamic();
 
 	pr_dbg("exit from libmcount\n");
 }

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -89,9 +89,6 @@ static bool __maybe_unused mcount_has_caller;
 /* address of function will be called when a function returns */
 unsigned long mcount_return_fn;
 
-/* disassembly engine for dynamic code patch */
-static struct mcount_disasm_engine disasm;
-
 __weak void dynamic_return(void) { }
 
 #ifdef DISABLE_MCOUNT_FILTER
@@ -1772,7 +1769,7 @@ static __used void mcount_startup(void)
 		mcount_threshold = strtoull(threshold_str, NULL, 0);
 
 	if (patch_str)
-		mcount_dynamic_update(&symtabs, patch_str, patt_type, &disasm);
+		mcount_dynamic_update(&symtabs, patch_str, patt_type);
 
 	if (event_str)
 		mcount_setup_events(dirname, event_str, patt_type);

--- a/libmcount/wrap.c
+++ b/libmcount/wrap.c
@@ -88,6 +88,8 @@ static int dlopen_base_callback(struct dl_phdr_info *info,
 	/* report a library not found in the session maps */
 	send_dlopen_msg(data->mtdp, mcount_session_name(), data->timestamp,
 			info->dlpi_addr, info->dlpi_name);
+
+	mcount_handle_dlopen(&symtabs, info, p, size);
 	return 0;
 }
 

--- a/tests/t248_dynamic_dlopen.py
+++ b/tests/t248_dynamic_dlopen.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'dlopen', """
+# DURATION     TID     FUNCTION
+           [108977] | main() {
+187.389 us [108977] |   dlopen();
+  0.754 us [108977] |   dlsym();
+           [108977] |   lib_a() {
+           [108977] |     lib_b() {
+  1.083 us [108977] |       lib_c();
+  1.331 us [108977] |     } /* lib_b */
+  1.614 us [108977] |   } /* lib_a */
+  9.988 us [108977] |   dlclose();
+174.777 us [108977] |   dlopen();
+  0.764 us [108977] |   dlsym();
+  0.765 us [108977] |   foo();
+108.059 us [108977] |   dlclose();
+488.088 us [108977] | } /* main */
+""")
+
+    def build(self, name, cflags='', ldflags=''):
+        cflags = cflags.replace('-pg', '')
+        cflags = cflags.replace('-finstrument-functions', '')
+
+        if TestBase.build_libabc(self, cflags, ldflags) != 0:
+            return TestBase.TEST_BUILD_FAIL
+        if TestBase.build_libfoo(self, 'foo', cflags, ldflags) != 0:
+            return TestBase.TEST_BUILD_FAIL
+        return TestBase.build_libmain(self, name, 's-dlopen.c', ['libdl.so'],
+                                      cflags, ldflags)
+
+    def setup(self):
+        self.option = ' -P. -P.@libfoo.so -P.@libabc_test_lib.so'

--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -1436,6 +1436,14 @@ struct sym * find_symname(struct symtab *symtab, const char *name)
 	return NULL;
 }
 
+void append_map(struct uftrace_mmap *maps, struct uftrace_mmap *map)
+{
+	while (maps->next != NULL)
+		maps = maps->next;
+
+	maps->next = map;
+}
+
 char *symbol_getname(struct sym *sym, uint64_t addr)
 {
 	char *name;

--- a/utils/symbol.h
+++ b/utils/symbol.h
@@ -154,6 +154,8 @@ struct uftrace_mmap * find_map_by_name(struct symtabs *symtabs,
 				       const char *prefix);
 struct uftrace_mmap * find_symbol_map(struct symtabs *symtabs, char *name);
 
+void append_map(struct uftrace_mmap *maps, struct uftrace_mmap *map);
+
 int save_kernel_symbol(char *dirname);
 int load_kernel_symbol(char *dirname);
 


### PR DESCRIPTION
support instrument to modules which loaded by dynamic method dlopen.

for example : 

```
m@ubuntu:~/git/uftrace_dlopen2$ ldd `which java`
        linux-vdso.so.1 (0x00007ffcec0fc000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f86688b5000)
        libjli.so => not found
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f86686b1000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f86682c0000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f8668ad4000)

m@ubuntu:~/git/uftrace_dlopen2$ ./uftrace -L. -P.@libjvm.so java HelloWorld
Hello world!
# DURATION     TID     FUNCTION
            [110346] | JLI_Launch() {
            [110346] |   JNI_GetDefaultJavaVMInitArgs() {
   1.037 us [110346] |     Threads::is_supported_jni_version();
   4.145 us [110346] |   } /* JNI_GetDefaultJavaVMInitArgs */
            [110348] | JNI_CreateJavaVM() {
            [110348] |   Threads::create_vm() {
            [110348] |     ResourceObj::operator new() {
            [110348] |       os::malloc() {
  13.583 us [110348] |         MallocTracker::record_malloc();
  15.729 us [110348] |       } /* os::malloc */
  18.398 us [110348] |     } /* ResourceObj::operator new */
   1.124 us [110348] |     TimeStamp::update_to();
   2.608 us [110348] |     Arguments::process_sun_java_launcher_properties();
            [110348] |     os::init() {
   0.549 us [110348] |       ThreadCritical::initialize();
 113.820 us [110348] |       os::Linux::clock_init();
 147.623 us [110348] |     } /* os::init */
            [110348] |     Arguments::init_system_properties() {
            [110348] |       CHeapObj::operator new() {
```