### PR TITLE
dump: Fix segfault in do_dump_replay on inverted timestamps

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -1509,7 +1509,7 @@ static void do_dump_replay(struct uftrace_dump_ops *ops, struct opts *opts,
 			continue;
 
 		if (prev_time > frs->time)
-			ops->inverted_time(ops, task);
+			call_if_nonull(ops->inverted_time, ops, task);
 		prev_time = frs->time;
 
 


### PR DESCRIPTION
This commit checks that the inverted_time function pointer is non-NULL
before calling it in do_dump_replay.

Signed-off-by: Colin Lord <clord@xcom-labs.com>