### PR TITLE
field: Fix the output of -f addr to fit in the width

### DIFF
--- a/cmds/graph.c
+++ b/cmds/graph.c
@@ -67,7 +67,7 @@ static void print_addr(struct field_data *fd)
 	/* uftrace records (truncated) 48-bit addresses */
 	int width = sizeof(long) == 4 ? 8 : 12;
 
-	pr_out("%*lx", width, node->addr);
+	pr_out("%*"PRIx64, width, effective_addr(node->addr));
 }
 
 static struct display_field field_total_time= {

--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -53,7 +53,7 @@ static void print_addr(struct field_data *fd)
 	if (fstack == NULL)  /* LOST */
 		pr_out("%*s", width, "");
 	else
-		pr_out("%*lx", width, fstack->addr);
+		pr_out("%*"PRIx64, width, effective_addr(fstack->addr));
 }
 
 static void print_timestamp(struct field_data *fd)

--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -235,7 +235,7 @@ static void print_graph_addr(struct field_data *fd)
 	/* uftrace records (truncated) 48-bit addresses */
 	int width = sizeof(long) == 4 ? 8 : 12;
 
-	printw("%*lx", width, node->addr);
+	printw("%*"PRIx64, width, effective_addr(node->addr));
 }
 
 static struct display_field field_total_time= {

--- a/utils/field.h
+++ b/utils/field.h
@@ -39,6 +39,12 @@ struct display_field {
 	const char *alias;
 };
 
+static inline uint64_t effective_addr(uint64_t addr)
+{
+	/* return 48-bit truncated address info */
+	return addr & ((1ULL << 48) - 1);
+}
+
 void print_header(struct list_head *output_fields, const char *prefix,
 		  int space);
 int print_field_data(struct list_head *output_fields, struct field_data *fd,


### PR DESCRIPTION
Since kernel address is represented in 64-bits, it cannot fit in the
current 12 width field and it makes the output ugly.
```
  $ uftrace replay -f +addr
  # DURATION     TID      ADDRESS     FUNCTION
              [191538]       40068f | main() {
              [191538]       4004f0 |   puts() {
     6.337 us [191538] ffffffff812211d0 |     sys_newfstat();
     7.507 us [191538] ffffffff8106dba0 |     __do_page_fault();
    19.908 us [191538] ffffffff8121c910 |     sys_write();
    47.339 us [191538]       4004f0 |   } /* puts */
    48.488 us [191538]       40068f | } /* main */
```
This patch uses effective_addr function to cut the higher 16 bits for
better address display in replay, graph, and tui commands.

Fixed: #989

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>