### PR TITLE
arch/arm: Add basic dynamic tracing support for ARM

### DIFF
--- a/arch/arm/dynamic.S
+++ b/arch/arm/dynamic.S
@@ -1,0 +1,59 @@
+#include "utils/asm.h"
+
+	.text
+	.align 2
+
+/* universal stack constraint: (SP mod 16) == 0 */
+/* frame pointer was saved in the trampoline : push {fp, lr} */
+GLOBAL(__dentry__)
+	/* save original child address for mcount_find_code */
+	push	{lr}
+
+	/* save arguments */
+	push 	{r0-r3}
+
+	add	r0, sp, #24 /* r0 points to pushed LR (parent_loc) */
+	mov 	r1, lr      /* child ip */
+	mov	r2, sp      /* mcount_args */
+
+	bl 	mcount_entry
+
+	/* child addr */
+	ldr	r0, [sp, #16]
+
+	/* find location that has the original code */
+	bl	mcount_find_code
+
+	/* overwrite return address */
+	str	r0, [sp, #16]
+
+	/* restore arguments */
+	pop 	{r0-r3}
+
+	/* actual return address from mcount_find_code() */
+	pop	{ip}
+
+	/* restore fp and lr registers*/
+	pop	{fp, lr}
+
+	/* jump to the save insn */
+	bx	ip
+END(__dentry__)
+
+
+ENTRY(dynamic_return)
+	push 	{r0-r3, lr, pc}  /* ensure 8-byte alignment */
+	mov	r0, sp
+#ifdef HAVE_ARM_HARDFP
+	vpush	{d0-d1}
+#endif
+
+	bl 	mcount_exit
+
+#if HAVE_ARM_HARDFP
+	vpop	{d0-d1}
+#endif
+	/* update return address (pc) in the stack */
+	str 	r0, [sp, #20]
+	pop 	{r0-r3, lr, pc}
+END(dynamic_return)

--- a/arch/arm/mcount-arch.h
+++ b/arch/arm/mcount-arch.h
@@ -32,4 +32,12 @@ unsigned long * mcount_arch_parent_location(struct symtabs *symtabs,
 #define ARCH_PLT0_SIZE  20
 #define ARCH_PLTHOOK_ADDR_OFFSET  0
 
+struct mcount_disasm_engine;
+struct mcount_dynamic_info;
+struct mcount_disasm_info;
+
+int disasm_check_insns(struct mcount_disasm_engine *disasm,
+		       struct mcount_dynamic_info *mdi,
+		       struct mcount_disasm_info *info);
+
 #endif /* MCOUNT_ARCH_H */

--- a/arch/arm/mcount-dynamic.c
+++ b/arch/arm/mcount-dynamic.c
@@ -1,0 +1,121 @@
+#include <string.h>
+#include <stdint.h>
+#include <sys/mman.h>
+
+/* This should be defined before #include "utils.h" */
+#define PR_FMT     "dynamic"
+#define PR_DOMAIN  DBG_DYNAMIC
+
+#include "libmcount/mcount.h"
+#include "libmcount/internal.h"
+#include "mcount-arch.h"
+#include "utils/utils.h"
+#include "utils/symbol.h"
+#include "utils/rbtree.h"
+
+#define PAGE_SIZE  4096
+#define CODE_SIZE  8
+
+/* target instrumentation function it needs to call */
+extern void __dentry__(void);
+
+static void save_orig_code(struct mcount_disasm_info *info)
+{
+	struct mcount_orig_insn *orig;
+	uint32_t jmp_insn[] = {
+		0xe51ff004,	/* ldr  pc, [pc, #-4] */
+		info->addr + 8,
+	};
+	size_t jmp_insn_size = 8;
+
+	orig = mcount_save_code(info, jmp_insn, jmp_insn_size);
+
+	/* make sure orig->addr same as when called from __dentry__ */
+	orig->addr += CODE_SIZE;
+}
+
+int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
+{
+	uintptr_t dentry_addr = (uintptr_t)(void *)&__dentry__;
+	/*
+	 * trampoline assumes {x29,x30} was pushed but x29 was not updated.
+	 * make sure stack is 8-byte aligned.
+	 */
+	uint32_t trampoline[] = {
+		0xe1a0b00d,	/* mov  fp, sp */
+		0xe59fc000,	/* ldr  ip, &__dentry__  # ldr ip, [pc, #0] */
+		0xe12fff1c,	/* bx   ip */
+		dentry_addr,
+	};
+
+	/* find unused 16-byte at the end of the code segment */
+	mdi->trampoline  = ALIGN(mdi->text_addr + mdi->text_size, PAGE_SIZE);
+	mdi->trampoline -= sizeof(trampoline);
+
+	if (unlikely(mdi->trampoline < mdi->text_addr + mdi->text_size)) {
+		mdi->trampoline += sizeof(trampoline);
+		mdi->text_size += PAGE_SIZE;
+
+		pr_dbg("adding a page for fentry trampoline at %#lx\n",
+		       mdi->trampoline);
+
+		mmap((void *)mdi->trampoline, PAGE_SIZE,
+		     PROT_READ | PROT_WRITE | PROT_EXEC,
+		     MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	}
+
+	if (mprotect((void *)mdi->text_addr, mdi->text_size,
+		     PROT_READ | PROT_WRITE | PROT_EXEC)) {
+		pr_dbg("cannot setup trampoline due to protection: %m\n");
+		return -1;
+	}
+
+	memcpy((void *)mdi->trampoline, trampoline, sizeof(trampoline));
+	return 0;
+}
+
+static unsigned long get_target_addr(struct mcount_dynamic_info *mdi,
+				     unsigned long addr)
+{
+	return (mdi->trampoline - addr - 12) >> 2;
+}
+
+int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym,
+		      struct mcount_disasm_engine *disasm, unsigned min_size)
+{
+	uint32_t push = 0xe92d4800;	/* push {fp, lr} */
+	uint32_t call;
+	struct mcount_disasm_info info = {
+		.sym = sym,
+		.addr = sym->addr + mdi->map->start,
+	};
+	void *insn = (void *)info.addr;
+
+	if (min_size < CODE_SIZE)
+		min_size = CODE_SIZE;
+	if (sym->size <= min_size)
+		return INSTRUMENT_SKIPPED;
+
+	memcpy(info.insns, (void*)info.addr, CODE_SIZE);
+	info.orig_size = CODE_SIZE;
+	info.copy_size = CODE_SIZE;
+
+	save_orig_code(&info);
+
+	call = get_target_addr(mdi, info.addr);
+
+	if ((call & 0xff000000) != 0)
+		return INSTRUMENT_FAILED;
+
+	/* make a "BL" insn with 24-bit offset */
+	call |= 0xeb000000;
+
+	/* hopefully we're not patching 'memcpy' itself */
+	memcpy(insn, &push, sizeof(push));
+	memcpy(insn+4, &call, sizeof(call));
+
+	/* flush icache so that cpu can execute the new code */
+	__builtin___clear_cache(insn, insn + CODE_SIZE);
+
+	return INSTRUMENT_SUCCESS;
+}

--- a/arch/arm/mcount-dynamic.c
+++ b/arch/arm/mcount-dynamic.c
@@ -96,9 +96,8 @@ int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym,
 	if (sym->size <= min_size)
 		return INSTRUMENT_SKIPPED;
 
-	memcpy(info.insns, (void*)info.addr, CODE_SIZE);
-	info.orig_size = CODE_SIZE;
-	info.copy_size = CODE_SIZE;
+	if (disasm_check_insns(disasm, mdi, &info) < 0)
+		return INSTRUMENT_FAILED;
 
 	save_orig_code(&info);
 

--- a/arch/arm/mcount-dynamic.c
+++ b/arch/arm/mcount-dynamic.c
@@ -118,3 +118,31 @@ int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym,
 
 	return INSTRUMENT_SUCCESS;
 }
+
+static void revert_normal_func(struct mcount_dynamic_info *mdi, struct sym *sym,
+			       struct mcount_disasm_engine *disasm)
+{
+	void *addr = (void *)(uintptr_t)sym->addr + mdi->map->start;
+	void *saved_insn;
+
+	saved_insn = mcount_find_code((uintptr_t)addr + CODE_SIZE);
+	if (saved_insn == NULL)
+		return;
+
+	memcpy(addr, saved_insn, CODE_SIZE);
+	__builtin___clear_cache(addr, addr + CODE_SIZE);
+}
+
+void mcount_arch_dynamic_recover(struct mcount_dynamic_info *mdi,
+				 struct mcount_disasm_engine *disasm)
+{
+	struct dynamic_bad_symbol *badsym, *tmp;
+
+	list_for_each_entry_safe(badsym, tmp, &mdi->bad_syms, list) {
+		if (!badsym->reverted)
+			revert_normal_func(mdi, badsym->sym, disasm);
+
+		list_del(&badsym->list);
+		free(badsym);
+	}
+}

--- a/arch/arm/mcount-insn.c
+++ b/arch/arm/mcount-insn.c
@@ -1,0 +1,146 @@
+#include "libmcount/internal.h"
+#include "mcount-arch.h"
+
+#define INSN_SIZE  8
+
+#ifdef HAVE_LIBCAPSTONE
+#include <capstone/capstone.h>
+#include <capstone/platform.h>
+
+void mcount_disasm_init(struct mcount_disasm_engine *disasm)
+{
+	if (cs_open(CS_ARCH_ARM, CS_MODE_ARM, &disasm->engine) != CS_ERR_OK) {
+		pr_dbg("failed to init Capstone disasm engine\n");
+		return;
+	}
+
+	if (cs_option(disasm->engine, CS_OPT_DETAIL, CS_OPT_ON) != CS_ERR_OK)
+		pr_dbg("failed to set detail option\n");
+}
+
+void mcount_disasm_finish(struct mcount_disasm_engine *disasm)
+{
+	cs_close(&disasm->engine);
+}
+
+/* return 0 if it's ok, -1 if not supported, 1 if modifiable */
+static int check_prologue(struct mcount_disasm_engine *disasm, cs_insn *insn)
+{
+	int i;
+	cs_arm *arm;
+	cs_detail *detail;
+	bool branch = false;
+	int status = -1;
+
+	/*
+	 * 'detail' can be NULL on "data" instruction
+	 * if SKIPDATA option is turned ON
+	 */
+	if (insn->detail == NULL)
+		return -1;
+
+	/* try to fix some PC-relative instructions */
+	if (insn->id == ARM_INS_ADR)
+		return 1;
+
+	/* check if the instruction is LDR, and it uses PC register */
+	if (insn->id == ARM_INS_LDR &&
+		 ((insn->bytes[2] & 0xf) == 0xf ||
+		  (insn->bytes[1] & 0xf0) == 0xf0)) {
+		return -1;
+	}
+
+	detail = insn->detail;
+
+	for (i = 0; i < detail->groups_count; i++) {
+		// BL instruction uses PC for return address */
+		switch (detail->groups[i]) {
+		case CS_GRP_JUMP:
+			branch = true;
+			break;
+		case CS_GRP_CALL:
+		case CS_GRP_RET:
+		case CS_GRP_IRET:
+#if CS_API_MAJOR >= 4
+		case CS_GRP_BRANCH_RELATIVE:
+#endif
+			return -1;
+		default:
+			break;
+		}
+
+	}
+
+	arm = &insn->detail->arm;
+
+	if (!arm->op_count)
+		return 0;
+
+	for (i = 0; i < arm->op_count; i++) {
+		cs_arm_op *op = &arm->operands[i];
+
+		switch (op->type) {
+		case ARM_OP_REG:
+			status = 0;
+			break;
+		case ARM_OP_IMM:
+			if (branch)
+				return -1;
+			status = 0;
+			break;
+		case ARM_OP_MEM:
+			status = 0;
+			break;
+		default:
+			break;
+		}
+	}
+	return status;
+}
+
+#define REG_SHIFT  5
+
+int disasm_check_insns(struct mcount_disasm_engine *disasm,
+		       struct mcount_dynamic_info *mdi,
+		       struct mcount_disasm_info *info)
+{
+	cs_insn *insn = NULL;
+	uint32_t count, i;
+	int ret = INSTRUMENT_FAILED;
+
+	count = cs_disasm(disasm->engine, (void *)info->addr, INSN_SIZE,
+			  info->addr, 0, &insn);
+
+	for (i = 0; i < count; i++) {
+		if (check_prologue(disasm, &insn[i]) < 0) {
+			pr_dbg3("instruction not supported: %s\t %s\n",
+				insn[i].mnemonic, insn[i].op_str);
+			break;
+		}
+
+		memcpy(info->insns + info->copy_size, insn[i].bytes, insn[i].size);
+		info->copy_size += insn[i].size;
+		info->orig_size += insn[i].size;
+
+		if (info->orig_size >= INSN_SIZE) {
+			ret = INSTRUMENT_SUCCESS;
+			break;
+		}
+	}
+
+	if (count)
+		cs_free(insn, count);
+
+	return ret;
+}
+
+#else /* HAVE_LIBCAPSTONE */
+
+int disasm_check_insns(struct mcount_disasm_engine *disasm,
+		       struct mcount_dynamic_info *mdi,
+		       struct mcount_disasm_info *info)
+{
+	return INSTRUMENT_FAILED;
+}
+
+#endif /* HAVE_LIBCAPSTONE */


### PR DESCRIPTION
This PR implements dynamic tracing for ARM 32-bit.
```
$ gcc -o t-abc tests/s-abc.c

$ file t-abc
t-abc: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), ...

$ uftrace -P . t-abc
# DURATION     TID     FUNCTION
            [ 10582] | main() {
            [ 10582] |   a() {
            [ 10582] |     b() {
            [ 10582] |       c() {
   3.020 us [ 10582] |         getpid();
  13.021 us [ 10582] |       } /* c */
  14.636 us [ 10582] |     } /* b */
  16.093 us [ 10582] |   } /* a */
  18.437 us [ 10582] | } /* main */
```
The base code is just copied from aarch64 and slightly modified for ARM.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>