### PR TITLE
script: Refine debug messages for python and luajit

### DIFF
--- a/utils/script-luajit.c
+++ b/utils/script-luajit.c
@@ -213,7 +213,6 @@ static int luajit_uftrace_begin(struct script_info *info)
 {
 	int i;
 	char *s;
-	pr_dbg("%s()\n", __func__);
 
 	dllua_getglobal(L, "uftrace_begin");
 	if (dllua_isnil(L, -1))
@@ -246,8 +245,6 @@ static int luajit_uftrace_begin(struct script_info *info)
 
 static int luajit_uftrace_entry(struct script_context *sc_ctx)
 {
-	pr_dbg("%s()\n", __func__);
-
 	dllua_getglobal(L, "uftrace_entry");
 	if (dllua_isnil(L, -1)) {
 		dllua_pop(L, 1);
@@ -269,8 +266,6 @@ static int luajit_uftrace_entry(struct script_context *sc_ctx)
 
 static int luajit_uftrace_exit(struct script_context *sc_ctx)
 {
-	pr_dbg("%s()\n", __func__);
-
 	dllua_getglobal(L, "uftrace_exit");
 	if (dllua_isnil(L, -1)) {
 		dllua_pop(L, 1);
@@ -293,7 +288,6 @@ static int luajit_uftrace_exit(struct script_context *sc_ctx)
 
 static int luajit_uftrace_end(void)
 {
-	pr_dbg("%s()\n", __func__);
 	dllua_getglobal(L, "uftrace_end");
 	if (dllua_isnil(L, -1)) {
 		dllua_pop(L, 1);

--- a/utils/script-luajit.c
+++ b/utils/script-luajit.c
@@ -328,6 +328,7 @@ static int load_luajit_api_funcs(void)
 		pr_warn("%s cannot be loaded!\n", libluajit);
 		return -1;
 	}
+	pr_dbg("%s is loaded\n", libluajit);
 
 	INIT_LUAJIT_API_FUNC(luaL_newstate);
 	INIT_LUAJIT_API_FUNC(luaL_openlibs);

--- a/utils/script-luajit.c
+++ b/utils/script-luajit.c
@@ -236,7 +236,7 @@ static int luajit_uftrace_begin(struct script_info *info)
 	}
 	dllua_settable(L, -3);
 	if (dllua_pcall(L, 1, 0, 0) != 0) {
-		pr_warn("uftrace_begin failed: %s\n", dllua_tostring(L, -1));
+		pr_dbg("uftrace_begin failed: %s\n", dllua_tostring(L, -1));
 		dllua_pop(L, 1);
 		return -1;
 	}
@@ -256,7 +256,7 @@ static int luajit_uftrace_entry(struct script_context *sc_ctx)
 		setup_argument_context(false, sc_ctx);
 
 	if (dllua_pcall(L, 1, 0, 0) != 0) {
-		pr_warn("uftrace_entry failed: %s\n", dllua_tostring(L, -1));
+		pr_dbg("uftrace_entry failed: %s\n", dllua_tostring(L, -1));
 		dllua_pop(L, 1);
 		return -1;
 	}
@@ -278,7 +278,7 @@ static int luajit_uftrace_exit(struct script_context *sc_ctx)
 		setup_argument_context(true, sc_ctx);
 
 	if (dllua_pcall(L, 1, 0, 0) != 0) {
-		pr_warn("uftrace_exit failed: %s\n", dllua_tostring(L, -1));
+		pr_dbg("uftrace_exit failed: %s\n", dllua_tostring(L, -1));
 		dllua_pop(L, 1);
 		return -1;
 	}
@@ -294,7 +294,7 @@ static int luajit_uftrace_end(void)
 		return -1;
 	}
 	if (dllua_pcall(L, 0, 0, 0) != 0) {
-		pr_warn("uftrace_end failed: %s\n", dllua_tostring(L, -1));
+		pr_dbg("uftrace_end failed: %s\n", dllua_tostring(L, -1));
 		dllua_pop(L, 1);
 		return -1;
 	}

--- a/utils/script-python.c
+++ b/utils/script-python.c
@@ -125,6 +125,7 @@ static int load_python_api_funcs(void)
 		pr_warn("%s cannot be loaded!\n", libpython);
 		return -1;
 	}
+	pr_dbg("%s is loaded\n", libpython);
 
 	INIT_PY_API_FUNC(Py_Initialize);
 	INIT_PY_API_FUNC(PyImport_Import);


### PR DESCRIPTION
This PR includes the script changes below.
- script: Add a debug message to show loaded library
- script: Do not use pr_dbg at each luajit entry and exit
- script: Do not use pr_warn when luajit call failed

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>