### PR TITLE
tests: Fix some tests by checking perf_event_paranoid

### DIFF
--- a/tests/t189_replay_field2.py
+++ b/tests/t189_replay_field2.py
@@ -23,6 +23,9 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
+        if not TestBase.check_perf_paranoid(self):
+            return TestBase.TEST_SKIP
+
         uftrace  = TestBase.uftrace_cmd
         argument = '-d %s -E linux:task-name' % TDIR
         program  = 't-' + self.name

--- a/tests/t196_chrome_taskname.py
+++ b/tests/t196_chrome_taskname.py
@@ -34,6 +34,9 @@ class TestCase(TestBase):
 """, sort='chrome')
 
     def pre(self):
+        if not TestBase.check_perf_paranoid(self):
+            return TestBase.TEST_SKIP
+
         uftrace  = TestBase.uftrace_cmd
         argument = '-d %s -E linux:task-name' % TDIR
         program  = 't-' + self.name

--- a/tests/t221_taskname_time.py
+++ b/tests/t221_taskname_time.py
@@ -23,6 +23,11 @@ class TestCase(TestBase):
              bar | } /* main */
 """, sort='simple')
 
+    def pre(self):
+        if not TestBase.check_perf_paranoid(self):
+            return TestBase.TEST_SKIP
+        return TestBase.TEST_SUCCESS
+
     def runcmd(self):
         uftrace  = TestBase.uftrace_cmd
         options = '-F main -E linux:task-name -t 1'


### PR DESCRIPTION
Since some of the tests require to read perf event, they may always be
failed if /proc/sys/kernel/perf_event_paranoid is 3 by default.

This patch adds a check routine if it has a permission for reading
perf event.  Otherwise, those tests are just skipped.

Before:
```
  Test case                 pg             finstrument-fu
  ------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
  189 replay_field2       : NG NG NG NG NG NG NG NG NG NG
  196 chrome_taskname     : NG NG NG NG NG NG NG NG NG NG
  221 taskname_time       : NG NG NG NG NG NG NG NG NG NG
```
After:
```
  Test case                 pg             finstrument-fu
  ------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
  189 replay_field2       : SK SK SK SK SK SK SK SK SK SK
  196 chrome_taskname     : SK SK SK SK SK SK SK SK SK SK
  221 taskname_time       : SK SK SK SK SK SK SK SK SK SK
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>