### PR TITLE
tests: Collect abnormally finished test results

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 __pycache__/
 unittest
+failed-tests.txt


### PR DESCRIPTION
It'd be useful if abnormally finished test results are separately
collected because we don't have to see normally finished tests.

This patch makes runtest.py collect those abnormally finished results in
failed-tests.txt.

Here is the output in failed-tests.txt after running tests on x86_64.
```
  Test case                 pg             finstrument-fu
  ------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
  052 nested_func         : OK OK OK OK OK NG NG NG NG NG
  136 dynamic             : BI BI BI BI BI BI BI BI BI BI
  151 recv_runcmd         : NG NG NG NG OK NG NG NG NG NG
  162 pltbind_now_pie     : BI BI BI BI BI BI BI BI BI BI
  182 thread_exit         : SG NG NG NG OK SG NG OK OK OK
  184 arg_enum            : NG NG NG NG NG NG NG NG NG NG
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>