### PR TITLE
script: Fix a segfault when module loading is failed

### DIFF
--- a/cmds/script.c
+++ b/cmds/script.c
@@ -197,9 +197,9 @@ int command_script(int argc, char *argv[], struct opts *opts)
 
 	/* dtor for script support */
 	script_uftrace_end();
-out:
-	script_finish();
 
+	script_finish();
+out:
 	close_data_file(opts, &handle);
 
 	strv_free(&info.cmds);

--- a/utils/script.c
+++ b/utils/script.c
@@ -102,6 +102,7 @@ int script_init(struct script_info *info, enum uftrace_pattern_type ptype)
 	pr_dbg2("%s(\"%s\")\n", __func__, script_pathname);
 	if (access(script_pathname, F_OK) < 0) {
 		perror(script_pathname);
+		script_finish_filter();
 		return -1;
 	}
 
@@ -124,8 +125,10 @@ int script_init(struct script_info *info, enum uftrace_pattern_type ptype)
 		script_pathname = NULL;
 	}
 
-	if (script_pathname == NULL)
+	if (script_pathname == NULL) {
+		script_finish_filter();
 		return -1;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
This patch is to fix the following crash.
```
  $ uftrace script -S scripts/count.py --record t-abc
  WARN: libpython3.7m.so cannot be loaded!

  Segmentation fault (core dumped)
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>