### PR TITLE
build: Find and use a correct python3 version

### DIFF
--- a/check-deps/Makefile.check
+++ b/check-deps/Makefile.check
@@ -16,9 +16,10 @@ ifneq ($(wildcard $(srcdir)/check-deps/cc_has_mno_sse2),)
 endif
 
 ifneq ($(wildcard $(srcdir)/check-deps/have_libpython3),)
+  PYTHON3 := $(shell python3-config --libs | sed 's/-l\(python[0-9\.m]\+\) .*/\1/g')
   COMMON_CFLAGS += -DHAVE_LIBPYTHON3
-  COMMON_CFLAGS += -I $(shell python3 -c 'import sysconfig; print(sysconfig.get_config_vars()["INCLUDEPY"])')
-  COMMON_CFLAGS += -DLIBPYTHON3_VERSION=$(shell python3 -c 'import sysconfig; print(sysconfig.get_config_vars()["LDVERSION"])')
+  COMMON_CFLAGS += -I $(shell $(PYTHON3) -c 'import sysconfig; print(sysconfig.get_config_vars()["INCLUDEPY"])')
+  COMMON_CFLAGS += -DLIBPYTHON3_VERSION=$(shell $(PYTHON3) -c 'import sysconfig; print(sysconfig.get_config_vars()["LDVERSION"])')
 else ifneq ($(wildcard $(srcdir)/check-deps/have_libpython2.7),)
   COMMON_CFLAGS += -DHAVE_LIBPYTHON2
   COMMON_CFLAGS += -I/usr/include/python2.7


### PR DESCRIPTION
It might be failed to find a correct python3 version used for scripting.
It's because python3 version is found by the python3 binary, but not by
finding python3 library actually used.

The current implementation finds python3 version as follows:
```
  $ python3 -c 'import sysconfig; print(sysconfig.get_config_vars()["LDVERSION"])'
  3.7m
```
However, python3-config finds different version.

This patch is to find the correct version by parsing the output of
'python3-config --libs'.
```
  $ python3-config --libs | sed 's/-l\(python[0-9\.m]\+\) .*/\1/g'
  python3.5m

  $ python3.7-config --libs | sed 's/-l\(python[0-9\.m]\+\) .*/\1/g'
  python3.7m
```
This might be a corner case fix but to support many more different
environments.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>