### PR TITLE
report: Fix report tests for i386

### DIFF
--- a/cmds/report.c
+++ b/cmds/report.c
@@ -192,7 +192,7 @@ static void print_function(struct uftrace_report_node *node, void *unused)
 		print_time_unit(node->total.sum);
 		pr_out("  ");
 		print_time_unit(node->self.sum);
-		pr_out("  %10lu  %-s\n", node->call, node->name);
+		pr_out("  %10"PRIu64 "  %-s\n", node->call, node->name);
 	}
 	else {
 		uint64_t time_avg, time_min, time_max;
@@ -329,7 +329,7 @@ static void print_thread(struct uftrace_report_node *node, void *arg)
 	print_time_unit(node->total.sum);
 	pr_out("  ");
 	print_time_unit(node->self.sum);
-	pr_out("  %10lu  %6d  %-s\n", node->call, pid, t->comm);
+	pr_out("  %10"PRIu64 "  %6d  %-s\n", node->call, pid, t->comm);
 }
 
 static void report_task(struct uftrace_data *handle, struct opts *opts)


### PR DESCRIPTION
This patch is to fix the following report related tests.
```
  $ ./runtest.py -j4 report
      ...
  024 report_basic        : NG NG NG NG NG NG NG NG NG NG
  025 report_s_call       : NG NG NG NG NG NG NG NG NG NG
  046 report_task         : NZ NZ NZ NZ NZ NZ NZ NZ NZ NZ
  090 report_recursive    : NG NG NG NG NG NG NG NG NG NG
  092 report_tid          : NG NG NG NG NG NG NG NG NG NG
  093 report_filter       : NG NG NG NG NG NG NG NG NG NG
  094 report_depth        : NG NG NG NG NG NG NG NG NG NG
  106 report_time         : NG NG NG NG NG NG NG NG NG NG
  125 report_range        : NG NG NG NG NG NG NG NG NG NG
  164 report_sched        : NG NG NG NG NG NG NG NG NG NG
  216 no_libcall_report   : NG NG NG NG NG NG NG NG NG NG
```
Since the type of node->call is uint64_t, %lu is incorrectly used, so it
has to be PRIu64.  The fixed test result is as follows:
```
  $ ./runtest.py -j4 report
      ...
  024 report_basic        : OK OK OK OK OK OK OK OK OK OK
  025 report_s_call       : OK OK OK OK OK OK OK OK OK OK
  046 report_task         : OK OK OK OK OK OK OK OK OK OK
  090 report_recursive    : OK OK OK OK OK OK OK OK OK OK
  092 report_tid          : OK OK OK OK OK OK OK OK OK OK
  093 report_filter       : OK OK OK OK OK OK OK OK OK OK
  094 report_depth        : OK OK OK OK OK OK OK OK OK OK
  106 report_time         : OK OK OK OK OK OK OK OK OK OK
  125 report_range        : OK OK OK OK OK OK OK OK OK OK
  164 report_sched        : OK OK OK OK OK OK OK OK OK OK
  216 no_libcall_report   : OK OK OK OK OK OK OK OK OK OK
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>