### PR TITLE
arch/x86_64: Save RFLAGS register

### DIFF
--- a/arch/x86_64/dynamic.S
+++ b/arch/x86_64/dynamic.S
@@ -42,6 +42,10 @@
 
 GLOBAL(__dentry__)
 	.cfi_startproc
+
+	/* save RFLAGS register otherwise clobbered */
+	pushf
+
 	sub $48, %rsp
 	.cfi_adjust_cfa_offset 48
 
@@ -53,10 +57,10 @@ GLOBAL(__dentry__)
 	movq %r9,   0(%rsp)
 
 	/* child addr */
-	movq 48(%rsp), %rsi
+	movq 56(%rsp), %rsi
 
 	/* parent location */
-	lea 56(%rsp), %rdi
+	lea 64(%rsp), %rdi
 
 	/* mcount_args */
 	movq %rsp, %rdx
@@ -79,7 +83,7 @@ GLOBAL(__dentry__)
 	movq 24(%rsp), %rdx
 
 	/* child addr */
-	movq 48(%rdx), %rdi
+	movq 56(%rdx), %rdi
 
 	/* find location that has the original code */
 	call mcount_find_code
@@ -88,7 +92,7 @@ GLOBAL(__dentry__)
 	movq 24(%rsp), %rdx
 
 	/* overwrite return address */
-	movq %rax, 48(%rdx)
+	movq %rax, 56(%rdx)
 
 	pop  %r11
 	pop  %r10
@@ -106,6 +110,9 @@ GLOBAL(__dentry__)
 
 	add $48, %rsp
 	.cfi_adjust_cfa_offset -48
+
+	/* restore RFLAGS register */
+	popf
 
 	retq
 	.cfi_endproc
@@ -134,9 +141,15 @@ ENTRY(dynamic_return)
 	/* set the first argument of mcount_exit as pointer to return values */
 	movq   %rsp, %rdi
 
+	/* save RFLAGS register otherwise clobbered */
+	pushf
+
 	/* returns original parent address */
 	call   mcount_exit
-	movq   %rax, 88(%rsp)
+	movq   %rax, 96(%rsp)
+
+	/* restore RFLAGS register */
+	popf
 
 	movq    0(%rsp), %rax
 	movq    8(%rsp), %rdx

--- a/arch/x86_64/fentry.S
+++ b/arch/x86_64/fentry.S
@@ -28,6 +28,10 @@
 
 GLOBAL(__fentry__)
 	.cfi_startproc
+
+	/* save RFLAGS register otherwise clobbered */
+	pushf
+
 	sub $48, %rsp
 	.cfi_adjust_cfa_offset 48
 
@@ -40,10 +44,10 @@ GLOBAL(__fentry__)
 	movq %r9,   0(%rsp)
 
 	/* child addr */
-	movq 48(%rsp), %rsi
+	movq 56(%rsp), %rsi
 
 	/* parent location */
-	lea 56(%rsp), %rdi
+	lea 64(%rsp), %rdi
 
 	/* mcount_args */
 	movq %rsp, %rdx
@@ -75,6 +79,10 @@ GLOBAL(__fentry__)
 
 	add $48, %rsp
 	.cfi_adjust_cfa_offset -48
+
+	/* restore RFLAGS register */
+	popf
+
 	retq
 	.cfi_endproc
 END(__fentry__)

--- a/arch/x86_64/mcount.S
+++ b/arch/x86_64/mcount.S
@@ -30,6 +30,10 @@
 
 GLOBAL(mcount)
 	.cfi_startproc
+
+	/* save RFLAGS register otherwise clobbered */
+	pushf
+
 	sub $48, %rsp
 	.cfi_adjust_cfa_offset 48
 
@@ -42,7 +46,7 @@ GLOBAL(mcount)
 	movq %r9,   0(%rsp)
 
 	/* child addr */
-	movq 48(%rsp), %rsi
+	movq 56(%rsp), %rsi
 
 	/* parent location */
 	lea 8(%rbp), %rdi
@@ -77,6 +81,10 @@ GLOBAL(mcount)
 
 	add $48, %rsp
 	.cfi_adjust_cfa_offset -48
+
+	/* restore RFLAGS register */
+	popf
+
 	retq
 	.cfi_endproc
 END(mcount)
@@ -94,9 +102,15 @@ ENTRY(mcount_return)
 	/* set the first argument of mcount_exit as pointer to return values */
 	movq %rsp, %rdi
 
+	/* save RFLAGS register otherwise clobbered */
+	pushf
+
 	/* returns original parent address */
 	call mcount_exit
-	movq %rax, 40(%rsp)
+	movq %rax, 48(%rsp)
+
+	/* restore RFLAGS register */
+	popf
 
 	movq    0(%rsp), %rax
 	movq    8(%rsp), %rdx


### PR DESCRIPTION
Hey, before talking about the commit details I want to wish you all the joy of a Happy New Year !

This commit is about saving _RFLAGS_ in stack prior to calling _mcount_entry_ and similar functions that could change it. _GDB_ and other tracing/debugging tools save it as well [1].

I only modified these 3 files for tonight:

_arch/x86_64/mcount.S
arch/x86_64/dynamic.S
arch/x86_64/fentry.S_

The ones left for _x86_64_ are _xray.S_, _cyg_profile_ and _plthook.S_ 
@namhyung  Thank you for your review ! I'll update the ones left in parallel with the review.

[1] https://github.com/bminor/binutils-gdb/blob/master/gdb/gdbserver/linux-x86-low.c
line 1084.

EDIT: I'm not really sure about the need to save the flag for PLT hooks.


