### PR TITLE
tests: Fix various test failures in 32-bit environment

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -371,6 +371,32 @@ class TestBase:
 
         return True
 
+    def is_32bit(self):
+        EI_NIDENT = 16
+
+        # e_ident[] indexes
+        EI_CLASS      = 4
+
+        # EI_CLASS
+        ELFCLASSNONE  = 0
+        ELFCLASS32    = 1
+        ELFCLASS64    = 2
+        ELFCLASSNUM   = 3
+
+        try:
+            elfname = 't-' + self.name
+            f = open(elfname, 'rb')
+            elf_ident = list(f.read(EI_NIDENT))
+            ei_class = ord(elf_ident[EI_CLASS])
+            f.close()
+
+            if ei_class == ELFCLASS32:
+                return True
+        except:
+            pass
+
+        return False
+
     def prerun(self, timeout):
         ret = TestBase.TEST_SUCCESS
 

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -397,6 +397,39 @@ class TestBase:
 
         return False
 
+    def get_elf_machine(self):
+        EI_NIDENT = 16
+
+        # e_machine (architecture)
+        EM_386        = 3       # Intel 80386
+        EM_ARM        = 40      # ARM
+        EM_X86_64     = 62      # AMD x86-64 architecture
+        EM_AARCH64    = 183     # ARM AARCH64
+
+        machine = {
+            EM_386: 'i386',
+            EM_ARM: 'arm',
+            EM_X86_64: 'x86_64',
+            EM_AARCH64: 'aarch64'
+        }
+
+        try:
+            elfname = 't-' + self.name
+            f = open(elfname, 'rb')
+
+            # consume elf_ident and e_type
+            f.read(EI_NIDENT + 2)
+
+            # read e_machine
+            e_machine = ord(f.read(2)[0])
+            f.close()
+
+            return machine[e_machine]
+        except:
+            pass
+
+        return None
+
     def prerun(self, timeout):
         ret = TestBase.TEST_SUCCESS
 

--- a/tests/s-malloc-fork.c
+++ b/tests/s-malloc-fork.c
@@ -10,7 +10,7 @@ void (*real_free)(void *ptr);
 
 #define ALIGN(n, a)  (((n) + (a) - 1) & ~((a) - 1))
 
-#define MALLOC_BUFSIZE  (512 * 1024 * 1024)
+#define MALLOC_BUFSIZE  (128 * 1024 * 1024)
 /* this is needed for optimized binaries */
 static char buf[MALLOC_BUFSIZE];
 

--- a/tests/s-malloc-hook.c
+++ b/tests/s-malloc-hook.c
@@ -8,7 +8,7 @@ void (*real_free)(void *ptr);
 
 #define ALIGN(n, a)  (((n) + (a) - 1) & ~((a) - 1))
 
-#define MALLOC_BUFSIZE  (512 * 1024 * 1024)
+#define MALLOC_BUFSIZE  (128 * 1024 * 1024)
 /* this is needed for optimized binaries */
 static char buf[MALLOC_BUFSIZE];
 

--- a/tests/s-malloc-tsd.c
+++ b/tests/s-malloc-tsd.c
@@ -12,7 +12,7 @@ void (*real_free)(void *ptr);
 
 #define ALIGN(n, a)  (((n) + (a) - 1) & ~((a) - 1))
 
-#define MALLOC_BUFSIZE  (512 * 1024 * 1024)
+#define MALLOC_BUFSIZE  (128 * 1024 * 1024)
 /* this is needed for optimized binaries */
 static char buf[MALLOC_BUFSIZE];
 

--- a/tests/s-malloc.c
+++ b/tests/s-malloc.c
@@ -1,8 +1,9 @@
 #include <stdio.h>
+#include <string.h>
 
 #define ALIGN(n, a)  (((n) + (a) - 1) & ~((a) - 1))
 
-#define MALLOC_BUFSIZE  (512 * 1024 * 1024)
+#define MALLOC_BUFSIZE  (128 * 1024 * 1024)
 
 int malloc_count;
 int free_count;

--- a/tests/t043_full_demangle.py
+++ b/tests/t043_full_demangle.py
@@ -29,8 +29,7 @@ class TestCase(TestBase):
         return '%s --demangle=full -N "ns2.*" %s' % (TestBase.uftrace_cmd, 't-namespace')
 
     def fixup(self, cflags, result):
-        import platform
-        if platform.architecture()[0].startswith('32bit'):
+        if TestBase.is_32bit(self):
             return result.replace('unsigned long', 'unsigned int')
 
         return result.replace('delete(void*);',

--- a/tests/t051_return.py
+++ b/tests/t051_return.py
@@ -16,8 +16,7 @@ class TestCase(TestBase):
 """)
 
     def fixup(self, cflags, result):
-        import platform
-        if platform.machine().startswith('arm'):
+        if TestBase.get_elf_machine(self) == 'arm':
             return result.replace('memset', """memset();
    1.440 us [12703] |     memcpy""");
 

--- a/tests/t058_arg_int.py
+++ b/tests/t058_arg_int.py
@@ -24,8 +24,7 @@ class TestCase(TestBase):
     def runcmd(self):
         argopt = '-A "^int_@arg1,arg2"'
 
-        import platform
-        if platform.architecture()[0].startswith('32bit'):
+        if TestBase.is_32bit(self):
             # int_mul@arg1 is a 'long long', so we should skip arg2
             argopt = '-A "int_(add|sub|div)@arg1,arg2" -A "int_mul@arg1/i64,arg3"'
         return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)

--- a/tests/t063_retval.py
+++ b/tests/t063_retval.py
@@ -26,8 +26,7 @@ class TestCase(TestBase):
     def runcmd(self):
         argopt = '-A "^int_@arg1,arg2" -R "^int_@retval/i32"'
 
-        import platform
-        if platform.architecture()[0].startswith('32bit'):
+        if TestBase.is_32bit(self):
             # int_mul@arg1 is a 'long long', so we should skip arg2
             argopt  = '-A "int_(add|sub|div)@arg1,arg2" -A "int_mul@arg1/i64,arg3" '
             argopt += '-R "^int_@retval/i32"'

--- a/tests/t065_arg_order.py
+++ b/tests/t065_arg_order.py
@@ -24,8 +24,7 @@ class TestCase(TestBase):
     def runcmd(self):
         argopt = '-A "int_mul@arg2/x" -A "^int_@arg1,arg2" -A "int_add@arg1/i32"'
 
-        import platform
-        if platform.architecture()[0].startswith('32bit'):
+        if TestBase.is_32bit(self):
             # int_mul@arg1 is a 'long long', so we should skip arg2
             argopt  = '-A "int_mul@arg1/i64" -A "^int_@arg1" '
             argopt += '-A "int_(add|sub|div)@arg2" -A "int_mul@arg3/x" '

--- a/tests/t065_arg_order.py
+++ b/tests/t065_arg_order.py
@@ -26,8 +26,7 @@ class TestCase(TestBase):
 
         if TestBase.is_32bit(self):
             # int_mul@arg1 is a 'long long', so we should skip arg2
-            argopt  = '-A "int_mul@arg1/i64" -A "^int_@arg1" '
-            argopt += '-A "int_(add|sub|div)@arg2" -A "int_mul@arg3/x" '
-            argopt += '-A "int_add@arg1/i32"'
+            argopt  = '-A "int_mul@arg3/x" -A "^int_@arg1" '
+            argopt += '-A "int_(add|sub|div)@arg2" -A "int_mul@arg1/i64" '
 
         return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)

--- a/tests/t083_arg_float.py
+++ b/tests/t083_arg_float.py
@@ -27,17 +27,11 @@ class TestCase(TestBase):
         argopt += '-A "float_mul@fparg1/64,fparg2/32" -R "float_mul@retval/f64" '
         argopt += '-A "float_div@fparg1,fparg2"       -R "float_div@retval/f"'
 
-        import platform
-        if platform.machine().startswith('arm'):
+        if TestBase.is_32bit(self):
             # argument count follows the size of type
             argopt = argopt.replace('float_mul@fparg1/64,fparg2/32',
                                     'float_mul@fparg1/64,fparg3/32')
-
-        elif platform.machine().startswith('i686'):
-            # argument count follows the size of type
-            argopt  = '-A "float_add@fparg1/32,fparg2/32" -R "float_add@retval/f32" '
-            argopt += '-A "float_sub@fparg1/32,fparg2"    -R "float_sub@retval/f32" '
-            argopt += '-A "float_mul@fparg1/64,fparg3/32" -R "float_mul@retval/f64" '
-            argopt += '-A "float_div@fparg1/64,fparg3/64" -R "float_div@retval/f64"'
+            argopt = argopt.replace('float_div@fparg1,fparg2',
+                                    'float_div@fparg1,fparg3')
 
         return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)

--- a/tests/t084_arg_mixed.py
+++ b/tests/t084_arg_mixed.py
@@ -32,7 +32,7 @@ class TestCase(TestBase):
 
         if platform.machine().startswith('arm'):
             argopt = argopt.replace('fparg1/80%stack+1', 'fparg1/80')
-        elif platform.machine().startswith('i686'):
+        elif TestBase.is_32bit(self):
             argopt  = '-A "mixed_add@arg1/i32,fparg2/32"         -R "mixed_add@retval/f64" '
             argopt += '-A "mixed_sub@arg1/x,arg2"                -R "mixed_sub@retval" '
             argopt += '-A "mixed_mul@fparg1,arg3/i64"            -R "mixed_mul@retval/i64" '

--- a/tests/t084_arg_mixed.py
+++ b/tests/t084_arg_mixed.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from runtest import TestBase
-import platform
 
 class TestCase(TestBase):
     def __init__(self):
@@ -30,7 +29,7 @@ class TestCase(TestBase):
         argopt += '-A "mixed_div@arg1/i64,fparg1/80%stack+1" -R "mixed_div@retval/f80" '
         argopt += '-A "mixed_str@arg1/s,fparg1"              -R "mixed_str@retval/s"'
 
-        if platform.machine().startswith('arm'):
+        if TestBase.get_elf_machine(self) == 'arm':
             argopt = argopt.replace('fparg1/80%stack+1', 'fparg1/80')
         elif TestBase.is_32bit(self):
             argopt  = '-A "mixed_add@arg1/i32,fparg2/32"         -R "mixed_add@retval/f64" '

--- a/tests/t085_arg_reg.py
+++ b/tests/t085_arg_reg.py
@@ -15,6 +15,11 @@ class TestCase(TestBase):
    4.891 ms [18277] | } /* main */
 """)
 
+    def pre(self):
+        if TestBase.get_elf_machine(self) == 'i386':
+            return TestBase.TEST_SKIP
+        return TestBase.TEST_SUCCESS
+
     def build(self, name, cflags='', ldflags=''):
         # cygprof doesn't support arguments now
         if cflags.find('-finstrument-functions') >= 0:

--- a/tests/t085_arg_reg.py
+++ b/tests/t085_arg_reg.py
@@ -34,8 +34,7 @@ class TestCase(TestBase):
         argopt += '-A "mixed_div@arg1/i64,fparg1/80%stack+1" '
         argopt += '-A "mixed_str@arg1/s%rdi,fparg1%xmm0"'
 
-        import platform
-        if platform.machine().startswith('arm'):
+        if TestBase.get_elf_machine(self) == 'arm':
             argopt = argopt.replace('%rdi', '%r0')
             argopt = argopt.replace('%rsi', '%r1')
             argopt = argopt.replace('32%xmm0', '32%s0')

--- a/tests/t086_arg_stack.py
+++ b/tests/t086_arg_stack.py
@@ -37,11 +37,11 @@ class TestCase(TestBase):
         argopt += '-A "many@arg3/i32%stack+3,arg4/i32%stack+4" '
         argopt += '-A "many@arg5/i32%stack5,arg6/i32%stack6,arg7/i32%stack7"'
 
-        import platform
-        if platform.machine().startswith('i686'):
+        if TestBase.is_32bit(self):
             # i386 use stack for passing argument. so, change order.
             argopt  = '-A "many@arg1/i32%stack+7,arg2/i32%stack+8" '
             argopt += '-A "many@arg3/i32%stack+9,arg4/i32%stack+10" '
             argopt += '-A "many@arg5/i32%stack11,arg6/i32%stack12,arg7/i32%stack13"'
+            # FIXME: arm has to be handled differently
 
         return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)

--- a/tests/t087_arg_variadic.py
+++ b/tests/t087_arg_variadic.py
@@ -26,8 +26,7 @@ class TestCase(TestBase):
         argopt  = '-A "variadic@arg1/s,arg2/c,arg3/s,arg4,arg5,arg6,arg7/i64,fparg1" '
         argopt += '-A "vsnprintf@arg2,arg3/s" '
 
-        import platform
-        if platform.machine().startswith('i686'):
+        if TestBase.is_32bit(self):
             argopt  = '-A "variadic@arg1/s,arg2/c,arg3/s,arg4,arg5,arg6,arg7/i64,fparg9" '
             argopt += '-A "vsnprintf@arg2,arg3/s" '
         return '%s %s %s' % (TestBase.uftrace_cmd, argopt, 't-' + self.name)

--- a/tests/t097_dump_basic.py
+++ b/tests/t097_dump_basic.py
@@ -46,9 +46,7 @@ reading 5231.dat
         return ret
 
     def fixup(self, cflags, result):
-        import platform
-
-        if platform.architecture()[0] == '32bit':
+        if TestBase.is_32bit(self):
             result = result.replace("2 (64 bit)", "1 (32 bit)")
         p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
         if 'BuildID' not in p.communicate()[0].decode(errors='ignore'):

--- a/tests/t098_dump_tid.py
+++ b/tests/t098_dump_tid.py
@@ -58,9 +58,7 @@ reading 5188.dat
         return ret
 
     def fixup(self, cflags, result):
-        import platform
-
-        if platform.architecture()[0] == '32bit':
+        if TestBase.is_32bit(self):
             result = result.replace("2 (64 bit)", "1 (32 bit)")
         p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
         if 'BuildID' not in p.communicate()[0].decode(errors='ignore'):

--- a/tests/t099_dump_filter.py
+++ b/tests/t099_dump_filter.py
@@ -38,9 +38,7 @@ reading 5231.dat
         return ret
 
     def fixup(self, cflags, result):
-        import platform
-
-        if platform.architecture()[0] == '32bit':
+        if TestBase.is_32bit(self):
             result = result.replace("2 (64 bit)", "1 (32 bit)")
         p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
         if 'BuildID' not in p.communicate()[0].decode(errors='ignore'):

--- a/tests/t100_dump_depth.py
+++ b/tests/t100_dump_depth.py
@@ -38,9 +38,7 @@ reading 5231.dat
         return ret
 
     def fixup(self, cflags, result):
-        import platform
-
-        if platform.architecture()[0] == '32bit':
+        if TestBase.is_32bit(self):
             result = result.replace("2 (64 bit)", "1 (32 bit)")
         p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
         if 'BuildID' not in p.communicate()[0].decode(errors='ignore'):

--- a/tests/t136_dynamic.py
+++ b/tests/t136_dynamic.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from runtest import TestBase
-import platform
 
 class TestCase(TestBase):
     def __init__(self):
@@ -14,7 +13,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        if platform.machine().startswith('arm'):
+        if TestBase.get_elf_machine(self) == 'arm':
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 

--- a/tests/t140_dynamic_xray.py
+++ b/tests/t140_dynamic_xray.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from runtest import TestBase
-import platform
 
 class TestCase(TestBase):
     def __init__(self):
@@ -16,7 +15,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        if platform.machine().startswith('arm'):
+        if TestBase.get_elf_machine(self) == 'arm':
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 

--- a/tests/t223_dynamic_full.py
+++ b/tests/t223_dynamic_full.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from runtest import TestBase
-import platform
 
 class TestCase(TestBase):
     def __init__(self):
@@ -14,7 +13,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        if platform.machine().startswith('arm'):
+        if TestBase.get_elf_machine(self) == 'arm':
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 

--- a/tests/t232_dynamic_unpatch.py
+++ b/tests/t232_dynamic_unpatch.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from runtest import TestBase
-import platform
 
 class TestCase(TestBase):
     def __init__(self):
@@ -16,7 +15,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        if platform.machine().startswith('arm'):
+        if TestBase.get_elf_machine(self) == 'arm':
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 

--- a/tests/t233_dynamic_unpatch2.py
+++ b/tests/t233_dynamic_unpatch2.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from runtest import TestBase
-import platform
 
 class TestCase(TestBase):
     def __init__(self):
@@ -13,7 +12,7 @@ class TestCase(TestBase):
 """)
 
     def pre(self):
-        if platform.machine().startswith('arm'):
+        if TestBase.get_elf_machine(self) == 'arm':
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 


### PR DESCRIPTION
This PR mainly fixes the problems when testing i386 under x86_64.

It fixes tests in i386 under x86_64 environment:
```
043 full_demangle       : NG NG NG NG NG NG NG NG NG NG
058 arg_int             : NG NG NG NG NG SK SK SK SK SK
063 retval              : NG NG NG NG NG SK SK SK SK SK
065 arg_order           : NG NG NG NG NG SK SK SK SK SK
083 arg_float           : NG NG NG NG NG SK SK SK SK SK
084 arg_mixed           : NG NG NG NG NG SK SK SK SK SK
086 arg_stack           : NG NG NG NG NG SK SK SK SK SK
087 arg_variadic        : NG NG NG NG NG SK SK SK SK SK
```
It fixes tests in arm 32-bit environment:
```
048 malloc_impl         : TM TM TM TM TM TM TM TM TM TM
058 arg_int             : NG NG NG NG NG SK SK SK SK SK
063 retval              : NG NG NG NG NG SK SK SK SK SK
065 arg_order           : NG NG NG NG NG SK SK SK SK SK
119 malloc_hook         : TM TM TM TM TM TM TM TM TM TM
120 malloc_tsd          : TM TM TM TM TM TM TM TM TM TM
121 malloc_fork         : TM TM TM TM TM TM TM TM TM TM
```
Fixed: #1083

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>