### PR TITLE
tests: Skip pmu tests with check_perf_paranoid()

### DIFF
--- a/tests/t193_read_pmu_cycle.py
+++ b/tests/t193_read_pmu_cycle.py
@@ -19,6 +19,11 @@ class TestCase(TestBase):
   17.873 us [32417] | } /* main */
 """)
 
+    def pre(self):
+        if not TestBase.check_perf_paranoid(self):
+            return TestBase.TEST_SKIP
+        return TestCase.TEST_SUCCESS
+
     def runcmd(self):
         uftrace = TestBase.uftrace_cmd
         args    = '-F main -T b@read=pmu-cycle'

--- a/tests/t194_read_pmu_cache.py
+++ b/tests/t194_read_pmu_cache.py
@@ -19,6 +19,11 @@ class TestCase(TestBase):
   17.873 us [32417] | } /* main */
 """)
 
+    def pre(self):
+        if not TestBase.check_perf_paranoid(self):
+            return TestBase.TEST_SKIP
+        return TestCase.TEST_SUCCESS
+
     def runcmd(self):
         uftrace = TestBase.uftrace_cmd
         args    = '-F main -T b@read=pmu-cache'

--- a/tests/t195_read_pmu_branch.py
+++ b/tests/t195_read_pmu_branch.py
@@ -19,6 +19,11 @@ class TestCase(TestBase):
   17.873 us [32417] | } /* main */
 """)
 
+    def pre(self):
+        if not TestBase.check_perf_paranoid(self):
+            return TestBase.TEST_SKIP
+        return TestCase.TEST_SUCCESS
+
     def runcmd(self):
         uftrace = TestBase.uftrace_cmd
         args    = '-F main -T b@read=pmu-branch'

--- a/tests/t227_read_pmu_cycle2.py
+++ b/tests/t227_read_pmu_cycle2.py
@@ -21,6 +21,11 @@ class TestCase(TestBase):
   17.873 us [ 32417] | } /* main */
 """)
 
+    def pre(self):
+        if not TestBase.check_perf_paranoid(self):
+            return TestBase.TEST_SKIP
+        return TestCase.TEST_SUCCESS
+
     def runcmd(self):
         uftrace = TestBase.uftrace_cmd
         options = '-F main -T [bc]@read=pmu-cycle'

--- a/tests/t228_read_pmu_cycle3.py
+++ b/tests/t228_read_pmu_cycle3.py
@@ -36,6 +36,11 @@ class TestCase(TestBase):
   55.132 us [256522] | } /* thread_fourth */
 """, ldflags='-pthread')
 
+    def pre(self):
+        if not TestBase.check_perf_paranoid(self):
+            return TestBase.TEST_SKIP
+        return TestCase.TEST_SUCCESS
+
     def runcmd(self):
         uftrace = TestBase.uftrace_cmd
         options = '-T foo@read=pmu-cycle'


### PR DESCRIPTION
There are many pmu related tests, but the perf check rouintes are
missing, so they are all failed if the system doesn't have enough
value in `/proc/sys/kernel/perf_event_paranoid`.

This patch fixes the problem by checking and skipping the pmu tests.

Before:
```
  193 read_pmu_cycle      : NG NG NG NG NG NG NG NG NG NG
  194 read_pmu_cache      : NG NG NG NG NG NG NG NG NG NG
  195 read_pmu_branch     : NG NG NG NG NG NG NG NG NG NG
  227 read_pmu_cycle2     : NG NG NG NG NG NG NG NG NG NG
  228 read_pmu_cycle3     : NG NG NG NG NG NG NG NG NG NG
```
After:
```
  193 read_pmu_cycle      : SK SK SK SK SK SK SK SK SK SK
  194 read_pmu_cache      : SK SK SK SK SK SK SK SK SK SK
  195 read_pmu_branch     : SK SK SK SK SK SK SK SK SK SK
  227 read_pmu_cycle2     : SK SK SK SK SK SK SK SK SK SK
  228 read_pmu_cycle3     : SK SK SK SK SK SK SK SK SK SK
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>