### PR TITLE
build: Add useful configure options

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -119,6 +119,14 @@ directories or build directory with this script.
       --without-perf        build without perf event             (even if available)
       --without-schedule    build without scheduler event        (even if available)
 
+      --arch=<ARCH>         set target architecture              (default: system default arch)
+                            e.g. x86_64, aarch64, i386, or arm
+      --cross-compile=<CROSS_COMPILE>
+                            Specify the compiler prefix during compilation
+                            e.g. CC is overridden by $(CROSS_COMPILE)gcc
+      --cflags=<CFLAGS>     pass extra C compiler flags
+      --ldflags=<LDFLAGS>   pass extra linker flags
+
       -p                    preserve old setting
 
       Some influential environment variables:
@@ -138,6 +146,9 @@ For cross compile, you may want to setup the toolchain something like below:
 
     $ export CROSS_COMPILE=/path/to/cross/toolchain/arm-unknown-linux-gnueabihf-
     $ ARCH=arm CFLAGS='--sysroot /path/to/sysroot' ./configure
+        or
+    $ ./configure --arch=arm --cflags='--sysroot /path/to/sysroot' \
+          --cross-compile=/path/to/cross/toolchain/arm-unknown-linux-gnueabihf-
 
 This assumes you already installed the cross-built `libelf` on the sysroot
 directory.  Otherwise, you can also build it from source (please see below) or

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -112,19 +112,21 @@ directories or build directory with this script.
       --without-libelf      build without libelf (and libdw)     (even if found on the system)
       --without-libdw       build without libdw                  (even if found on the system)
       --without-libstdc++   build without libstdc++              (even if found on the system)
-      --without-libpython   build without libpython2.7           (even if found on the system)
+      --without-libpython   build without libpython              (even if found on the system)
+      --without-libluajit   build without libluajit              (even if found on the system)
       --without-libncurses  build without libncursesw            (even if found on the system)
+      --without-capstone    build without libcapstone            (even if found on the system)
       --without-perf        build without perf event             (even if available)
       --without-schedule    build without scheduler event        (even if available)
 
       -p                    preserve old setting
 
       Some influential environment variables:
-        ARCH           Target architecture    e.g. arm, aarch64, or x86_64
-        CROSS_COMPILE  Specify the compiler prefix during compilation
-                       e.g. CC is overridden by $(CROSS_COMPILE)gcc
-        CFLAGS         C compiler flags
-        LDFLAGS        linker flags
+        ARCH                Target architecture    e.g. x86_64, aarch64, i386, or arm
+        CROSS_COMPILE       Specify the compiler prefix during compilation
+                            e.g. CC is overridden by $(CROSS_COMPILE)gcc
+        CFLAGS              C compiler flags
+        LDFLAGS             linker flags
 
 Also you can set the target architecture and compiler options like CC, CFLAGS.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,7 +137,7 @@ feature disabled - `uftrace script` command will still exist but won't work.
 For cross compile, you may want to setup the toolchain something like below:
 
     $ export CROSS_COMPILE=/path/to/cross/toolchain/arm-unknown-linux-gnueabihf-
-    $ ./configure ARCH=arm CFLAGS='--sysroot /path/to/sysroot'
+    $ ARCH=arm CFLAGS='--sysroot /path/to/sysroot' ./configure
 
 This assumes you already installed the cross-built `libelf` on the sysroot
 directory.  Otherwise, you can also build it from source (please see below) or

--- a/configure
+++ b/configure
@@ -35,10 +35,18 @@ usage() {
   --without-perf        build without perf event             (even if available)
   --without-schedule    build without scheduler event        (even if available)
 
+  --arch=<ARCH>         set target architecture              (default: system default arch)
+                        e.g. x86_64, aarch64, i386, or arm
+  --cross-compile=<CROSS_COMPILE>
+                        Specify the compiler prefix during compilation
+                        e.g. CC is overridden by \$(CROSS_COMPILE)gcc
+  --cflags=<CFLAGS>     pass extra C compiler flags
+  --ldflags=<LDFLAGS>   pass extra linker flags
+
   -p                    preserve old setting
 
   Some influential environment variables:
-    ARCH                Target architecture    e.g. arm, aarch64, or x86_64
+    ARCH                Target architecture    e.g. x86_64, aarch64, i386, or arm
     CROSS_COMPILE       Specify the compiler prefix during compilation
                         e.g. CC is overridden by \$(CROSS_COMPILE)gcc
     CFLAGS              C compiler flags
@@ -98,6 +106,32 @@ if [ "$ARCH" = "x86_64" -o "$ARCH" = "x86" ]; then
     if echo "$CC $CFLAGS" | grep -w "\-m32" > /dev/null; then
         ARCH=i386
     fi
+fi
+
+#
+# Support --arch, --cross-compile, --cflags and --ldflags options
+#
+if [ ! -z "$arch" ]; then
+    export ARCH=$arch
+    if [ "$arch" = "x86_64" ] || [ "$arch" = "arm" ] || [ "$arch" = "aarch64" ]; then
+        export ARCH=$arch
+    elif [ "$arch" = "i386" ]; then
+        export ARCH="i386"
+        export CFLAGS="-m32 $CFLAGS"
+        export LDFLAGS="-m32 $LDFLAGS"
+    else
+        echo "$arch is not a supported architecture"
+        exit 1
+    fi
+fi
+if [ ! -z "$cross_compile" ]; then
+    export CROSS_COMPILE=$cross_compile
+fi
+if [ ! -z "$cflags" ]; then
+    export CFLAGS="$cflags $CFLAGS"
+fi
+if [ ! -z "$ldflags" ]; then
+    export LDFLAGS="$ldflags $LDFLAGS"
 fi
 
 bindir=${bindir:-${prefix}/bin}


### PR DESCRIPTION
This PR introduces some useful configure options as follows:
```
  --arch=<ARCH>         set target architecture              (default: system default arch)
                        e.g. x86_64, aarch64, i386, arm or thumb
  --cross-compile=<CROSS_COMPILE>
                        Specify the compiler prefix during compilation
                        e.g. CC is overridden by $(CROSS_COMPILE)gcc
  --cflags=<CFLAGS>     pass extra C compiler flags
  --ldflags=<LDFLAGS>   pass extra linker flags
```
Since there is ordering problem using environmental variables and
configure options together, this recommends to use configure options
only.

Especially, --arch contains some useful builtin additional support in
i386 and thumb.  i386 automatically adds -m32 option to CFLAGS and
LDFLAGS and thumb is a pseudo architecture for Thumb mode in ARM
architecture.

Closes: #1095

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>