### PR TITLE
support flat mode record and replay

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -519,7 +519,7 @@ static void get_feature_string(char *buf, size_t sz, uint64_t feature_mask)
 	const char *feat_str[] = { "PLTHOOK", "TASK_SESSION", "KERNEL",
 				   "ARGUMENT", "RETVAL", "SYM_REL_ADDR",
 				   "MAX_STACK", "EVENT", "PERF_EVENT",
-				   "AUTO_ARGS", "DEBUG_INFO" };
+				   "AUTO_ARGS", "DEBUG_INFO", "FLAT" };
 
 	/* feat_str should match to enum uftrace_feat_bits */
 	for (i = 0; i < FEAT_BIT_MAX; i++) {

--- a/cmds/record.c
+++ b/cmds/record.c
@@ -402,6 +402,9 @@ static uint64_t calc_feat_mask(struct opts *opts)
 	globfree(&g);
 	free(buf);
 
+	if (opts->flat)
+		features |= FLAT;
+
 	return features;
 }
 

--- a/cmds/record.c
+++ b/cmds/record.c
@@ -318,6 +318,9 @@ static void setup_child_environ(struct opts *opts, int argc, char *argv[])
 	if (opts->srcline)
 		setenv("UFTRACE_SRCLINE", "1", 1);
 
+	if (opts->flat)
+		setenv("UFTRACE_FLAT", "1", 1);
+
 	if (argc > 0) {
 		char *args = NULL;
 		int i;

--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -379,6 +379,17 @@ static void print_event(struct uftrace_task_reader *task,
 	free(evt_name);
 }
 
+static void print_task_newline(int current_tid)
+{
+	if (prev_tid != -1 && current_tid != prev_tid) {
+		if (print_empty_field(&output_fields, 1))
+			pr_out(" | ");
+		pr_out("\n");
+	}
+
+	prev_tid = current_tid;
+}
+
 static int print_flat_rstack(struct uftrace_data *handle,
 			     struct uftrace_task_reader *task,
 			     struct opts *opts)
@@ -425,17 +436,6 @@ static int print_flat_rstack(struct uftrace_data *handle,
 out:
 	symbol_putname(sym, name);
 	return 0;
-}
-
-static void print_task_newline(int current_tid)
-{
-	if (prev_tid != -1 && current_tid != prev_tid) {
-		if (print_empty_field(&output_fields, 1))
-			pr_out(" | ");
-		pr_out("\n");
-	}
-
-	prev_tid = current_tid;
 }
 
 #define print_char(c)                                                   \

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -174,6 +174,8 @@ extern int page_size_in_kb;
 extern bool kernel_pid_update;
 extern bool mcount_auto_recover;
 
+extern bool mcount_flat;
+
 enum mcount_global_flag {
 	MCOUNT_GFL_SETUP	= (1U << 0),
 	MCOUNT_GFL_FINISH	= (1U << 1),

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -44,6 +44,9 @@ int shmem_bufsize = SHMEM_BUFFER_SIZE;
 /* recover return address of parent automatically */
 bool mcount_auto_recover = ARCH_SUPPORT_AUTO_RECOVER;
 
+/* boolean flag to flat entry only recording */
+bool mcount_flat = false;
+
 /* global flag to control mcount behavior */
 unsigned long mcount_global_flags = MCOUNT_GFL_SETUP;
 
@@ -1777,6 +1780,9 @@ static __used void mcount_startup(void)
 
 	if (getenv("UFTRACE_KERNEL_PID_UPDATE"))
 		kernel_pid_update = true;
+
+	if (getenv("UFTRACE_FLAT"))
+		mcount_flat = true;
 
 	pthread_atfork(atfork_prepare_handler, NULL, atfork_child_handler);
 

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -1237,6 +1237,8 @@ static int __mcount_entry(unsigned long *parent_loc, unsigned long child,
 	rstack->nr_events  = 0;
 	rstack->event_idx  = ARGBUF_SIZE;
 
+	mcount_entry_filter_record(mtdp, rstack, &tr, regs);
+
 	if (unlikely(mcount_flat)) {
 		/* record function entry only in flat mode */
 		mtdp->idx = 0;
@@ -1252,7 +1254,6 @@ static int __mcount_entry(unsigned long *parent_loc, unsigned long child,
 			mcount_auto_restore(mtdp);
 	}
 
-	mcount_entry_filter_record(mtdp, rstack, &tr, regs);
 	mcount_unguard_recursion(mtdp);
 	return 0;
 }

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -1237,12 +1237,20 @@ static int __mcount_entry(unsigned long *parent_loc, unsigned long child,
 	rstack->nr_events  = 0;
 	rstack->event_idx  = ARGBUF_SIZE;
 
-	/* hijack the return address of child */
-	*parent_loc = mcount_return_fn;
+	if (unlikely(mcount_flat)) {
+		/* record function entry only in flat mode */
+		mtdp->idx = 0;
+		rstack->depth = 0;
+		record_trace_data(mtdp, rstack, NULL);
+	}
+	else {
+		/* hijack the return address of child */
+		*parent_loc = mcount_return_fn;
 
-	/* restore return address of parent */
-	if (mcount_auto_recover)
-		mcount_auto_restore(mtdp);
+		/* restore return address of parent */
+		if (mcount_auto_recover)
+			mcount_auto_restore(mtdp);
+	}
 
 	mcount_entry_filter_record(mtdp, rstack, &tr, regs);
 	mcount_unguard_recursion(mtdp);

--- a/libmcount/misc.c
+++ b/libmcount/misc.c
@@ -144,6 +144,9 @@ void mcount_rstack_restore(struct mcount_thread_data *mtdp)
 	int idx;
 	struct mcount_ret_stack *rstack;
 
+	if (unlikely(mcount_flat))
+		return;
+
 	/* reverse order due to tail calls */
 	for (idx = mtdp->idx - 1; idx >= 0; idx--) {
 		rstack = &mtdp->rstack[idx];
@@ -165,6 +168,9 @@ void mcount_rstack_reset(struct mcount_thread_data *mtdp)
 {
 	int idx;
 	struct mcount_ret_stack *rstack;
+
+	if (unlikely(mcount_flat))
+		return;
 
 	for (idx = mtdp->idx - 1; idx >= 0; idx--) {
 		rstack = &mtdp->rstack[idx];

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -816,6 +816,8 @@ static unsigned long __plthook_entry(unsigned long *ret_addr,
 	rstack->nr_events  = 0;
 	rstack->event_idx  = ARGBUF_SIZE;
 
+	mcount_entry_filter_record(mtdp, rstack, &tr, regs);
+
 	if (unlikely(mcount_flat)) {
 		/* record function entry only in flat mode */
 		mtdp->idx = 0;
@@ -830,8 +832,6 @@ static unsigned long __plthook_entry(unsigned long *ret_addr,
 		if (mcount_auto_recover)
 			mcount_auto_restore(mtdp);
 	}
-
-	mcount_entry_filter_record(mtdp, rstack, &tr, regs);
 
 	if (unlikely(special_flag)) {
 		/* force flush rstack on some special functions */

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -816,12 +816,20 @@ static unsigned long __plthook_entry(unsigned long *ret_addr,
 	rstack->nr_events  = 0;
 	rstack->event_idx  = ARGBUF_SIZE;
 
-	/* hijack the return address of child */
-	*ret_addr = (unsigned long)plthook_return;
+	if (unlikely(mcount_flat)) {
+		/* record function entry only in flat mode */
+		mtdp->idx = 0;
+		rstack->depth = 0;
+		record_trace_data(mtdp, rstack, NULL);
+	}
+	else {
+		/* hijack the return address of child */
+		*ret_addr = (unsigned long)plthook_return;
 
-	/* restore return address of parent */
-	if (mcount_auto_recover)
-		mcount_auto_restore(mtdp);
+		/* restore return address of parent */
+		if (mcount_auto_recover)
+			mcount_auto_restore(mtdp);
+	}
 
 	mcount_entry_filter_record(mtdp, rstack, &tr, regs);
 

--- a/uftrace.c
+++ b/uftrace.c
@@ -554,6 +554,7 @@ static error_t parse_option(int key, char *arg, struct argp_state *state)
 
 	case OPT_flat:
 		opts->flat = true;
+		opts->no_event = true;
 		break;
 
 	case OPT_no_libcall:

--- a/uftrace.h
+++ b/uftrace.h
@@ -60,6 +60,7 @@ enum uftrace_feat_bits {
 	PERF_EVENT_BIT,
 	AUTO_ARGS_BIT,
 	DEBUG_INFO_BIT,
+	FLAT_BIT,
 
 	FEAT_BIT_MAX,
 
@@ -75,6 +76,7 @@ enum uftrace_feat_bits {
 	PERF_EVENT		= (1U << PERF_EVENT_BIT),
 	AUTO_ARGS		= (1U << AUTO_ARGS_BIT),
 	DEBUG_INFO		= (1U << DEBUG_INFO_BIT),
+	FLAT			= (1U << FLAT_BIT),
 };
 
 enum uftrace_info_bits {
@@ -92,6 +94,7 @@ enum uftrace_info_bits {
 	RECORD_DATE,
 	PATTERN_TYPE,
 	VERSION,
+	FLATINFO,
 };
 
 struct uftrace_info {
@@ -130,6 +133,7 @@ struct uftrace_info {
 	float load15;
 	enum uftrace_pattern_type patt_type;
 	char *uftrace_version;
+	int flat;
 };
 
 enum {


### PR DESCRIPTION
This PR introduces flat mode record and replay.

This is useful especially when hijacking return address is somewhat problematic
and makes the target program get crashed.

Even in this case, flat mode record will be fine so we can test if the problem comes
from hijacking the return address or not.

Before:
```
  $ uftrace --flat t-abc
  [0] ==> 130594/0: ip (__monstartup), time (30541796096373175)
  [1] <== 130594/0: ip (__monstartup), time (30541796096374552:1377)
  [2] ==> 130594/0: ip (__cxa_atexit), time (30541796096378498)
  [3] <== 130594/0: ip (__cxa_atexit), time (30541796096379375:877)
  [4] ==> 130594/0: ip (main), time (30541796096380338)
  [5] ==> 130594/1: ip (a), time (30541796096380582)
  [6] ==> 130594/2: ip (b), time (30541796096380738)
  [7] ==> 130594/3: ip (c), time (30541796096380868)
  [8] ==> 130594/4: ip (getpid), time (30541796096381092)
  [9] <== 130594/4: ip (getpid), time (30541796096381828:736)
  [10] <== 130594/3: ip (c), time (30541796096382565:1697)
  [11] <== 130594/2: ip (b), time (30541796096382872:2134)
  [12] <== 130594/1: ip (a), time (30541796096383085:2503)
  [13] <== 130594/0: ip (main), time (30541796096383275:2937)
```
After:
```
  $ uftrace --flat t-abc
  #  ELAPSED     TID     FUNCTION
              [112571] | __monstartup()
     1.537 us [112571] | __cxa_atexit()
     2.927 us [112571] | main()
     3.230 us [112571] | a()
     3.407 us [112571] | b()
     3.587 us [112571] | c()
     3.817 us [112571] | getpid()
```
The changes in print_flat_rstack are mostly based on print_graph_rstack,
but simplified only for flat mode replay.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>