### PR TITLE
doc: Add -U/-Z missing options for dynamic tracing

### DIFF
--- a/doc/ko/uftrace-live.md
+++ b/doc/ko/uftrace-live.md
@@ -94,6 +94,11 @@ RECORD 옵션
     이 옵션은 한번 이상 쓰일 수 있다.
     관련 설명은 *DYNAMIC TRACING* 을 참고한다.
 
+-U *FUNC*, \--unpatch=*FUNC*
+:   주어진 FUNC 함수에 대해 동적 패치를 적용하지 않는다.
+    이 옵션은 한번 이상 쓰일 수 있다.
+    관련 설명은 *DYNAMIC TRACING* 을 참고한다.
+
 -Z *SIZE*, \--size-filter=*SIZE*
 :   SIZE 바이트보다 큰 함수들을 동적으로 패치한다.
     동적추적에 대해서는 *DYNAMIC TRACING* 을 참고한다.

--- a/doc/ko/uftrace-record.md
+++ b/doc/ko/uftrace-record.md
@@ -34,6 +34,11 @@ RECORD 옵션
     이 옵션은 한번 이상 쓰일 수 있다.
     관련 설명은 *DYNAMIC TRACING* 을 참고한다.
 
+-U *FUNC*, \--unpatch=*FUNC*
+:   주어진 FUNC 함수에 대해 동적 패치를 적용하지 않는다.
+    이 옵션은 한번 이상 쓰일 수 있다.
+    관련 설명은 *DYNAMIC TRACING* 을 참고한다.
+
 -Z *SIZE*, \--size-filter=*SIZE*
 :   SIZE 바이트보다 큰 함수들을 동적으로 패치한다.
     동적추적에 대해서는 *DYNAMIC TRACING* 을 참고한다.

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -91,6 +91,13 @@ RECORD OPTIONS
     gcc with `-pg -mfentry -mnop-mcount` or clang with `-fxray-instrument`.
     This option can be used more than once.  See *DYNAMIC TRACING*.
 
+-U *FUNC*, \--unpatch=*FUNC*
+:   Do not apply dynamic patching for FUNC.  This option can be used more than once.
+    See *DYNAMIC TRACING*.
+
+-Z *SIZE*, \--size-filter=*SIZE*
+:   Patch functions bigger than SIZE bytes dynamically.  See *DYNAMIC TRACING*.
+
 -E *EVENT*, \--event=*EVENT*
 :   Enable event tracing.  The event should be available on the system.
 

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -35,6 +35,10 @@ RECORD OPTIONS
 :   Patch FUNC dynamically.  This option can be used more than once.
     See *DYNAMIC TRACING*.
 
+-U *FUNC*, \--unpatch=*FUNC*
+:   Do not apply dynamic patching for FUNC.  This option can be used more than once.
+    See *DYNAMIC TRACING*.
+
 -Z *SIZE*, \--size-filter=*SIZE*
 :   Patch functions bigger than SIZE bytes dynamically.  See *DYNAMIC TRACING*.
 


### PR DESCRIPTION
The options -U/--unpatch and -Z/--size-filter are missing in some man
pages so this patch adds them.

Closes: #1102

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>