### PR TITLE
build: Add multi-arch and multi-compiler build test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: c
 
+arch:
+  - amd64
+  - arm64
+
+compiler:
+  - gcc
+
 # Ubuntu 16.04 LTS
 dist: xenial
 


### PR DESCRIPTION
Recently, Travis CI released support for multi-arch build. And also, it has multi-compiler support.

By this commit, travis will compile with amd64, arm64 architecture and with gcc, clang compiler. (Each arch x compilers)

Fixed: #1112 

Signed-off-by: Daniel T. Lee <danieltimlee@gmail.com>