### PR TITLE
utils: Fix memory leak in graph

### DIFF
--- a/utils/graph.c
+++ b/utils/graph.c
@@ -162,6 +162,7 @@ static int add_graph_exit(struct uftrace_task_graph *tg)
 			    snode->pid == tg->task->t->ppid) {
 				node = snode->node;
 				list_del(&snode->list);
+				free(snode);
 				pr_dbg("recover from fork\n");
 				goto out;
 			}


### PR DESCRIPTION
Add missing free to add_graph_exit when recover from fork.
This patch will remove memory leak when use graph command with fork.

Fixed: #1110

Signed-off-by: Sang-Heon Jeon <ekffu200098@gmail.com>