### PR TITLE
aarch64: Fix floating point args recording

### DIFF
--- a/arch/aarch64/mcount-arch.h
+++ b/arch/aarch64/mcount-arch.h
@@ -26,7 +26,9 @@ struct mcount_regs {
 #define ARCH_MAX_REG_ARGS  8
 #define ARCH_MAX_FLOAT_REGS  8
 
+#define HAVE_MCOUNT_ARCH_CONTEXT
 struct mcount_arch_context {
+	double d[ARCH_MAX_FLOAT_REGS];
 };
 
 #define ARCH_PLT0_SIZE  32

--- a/arch/aarch64/mcount-support.c
+++ b/arch/aarch64/mcount-support.c
@@ -193,3 +193,27 @@ unsigned long mcount_arch_plthook_addr(struct plthook_data *pd, int idx)
 	sym = &pd->dsymtab.sym[0];
 	return sym->addr - ARCH_PLT0_SIZE;
 }
+
+void mcount_save_arch_context(struct mcount_arch_context *ctx)
+{
+	asm volatile ("str d0, %0\n" : "=m" (ctx->d[0]));
+	asm volatile ("str d1, %0\n" : "=m" (ctx->d[1]));
+	asm volatile ("str d2, %0\n" : "=m" (ctx->d[2]));
+	asm volatile ("str d3, %0\n" : "=m" (ctx->d[3]));
+	asm volatile ("str d4, %0\n" : "=m" (ctx->d[4]));
+	asm volatile ("str d5, %0\n" : "=m" (ctx->d[5]));
+	asm volatile ("str d6, %0\n" : "=m" (ctx->d[6]));
+	asm volatile ("str d7, %0\n" : "=m" (ctx->d[7]));
+}
+
+void mcount_restore_arch_context(struct mcount_arch_context *ctx)
+{
+	asm volatile ("ldr d0, %0\n" :: "m" (ctx->d[0]));
+	asm volatile ("ldr d1, %0\n" :: "m" (ctx->d[1]));
+	asm volatile ("ldr d2, %0\n" :: "m" (ctx->d[2]));
+	asm volatile ("ldr d3, %0\n" :: "m" (ctx->d[3]));
+	asm volatile ("ldr d4, %0\n" :: "m" (ctx->d[4]));
+	asm volatile ("ldr d5, %0\n" :: "m" (ctx->d[5]));
+	asm volatile ("ldr d6, %0\n" :: "m" (ctx->d[6]));
+	asm volatile ("ldr d7, %0\n" :: "m" (ctx->d[7]));
+}

--- a/arch/aarch64/mcount-support.c
+++ b/arch/aarch64/mcount-support.c
@@ -174,12 +174,12 @@ void mcount_arch_get_retval(struct mcount_arg_context *ctx,
 		if (spec->size <= 4) {
 			asm volatile ("ldr s0, %1\n"
 				      "str s0, %0\n" :
-				      "=m" (ctx->val.v) : "m" (float_retval));
+				      "=m" (ctx->val.v) : "m" (*float_retval));
 		}
 		else {
 			asm volatile ("ldr d0, %1\n"
 				      "str d0, %0\n" :
-				      "=m" (ctx->val.v) : "m" (float_retval));
+				      "=m" (ctx->val.v) : "m" (*float_retval));
 		}
 	}
 	else


### PR DESCRIPTION
This PR fixes a few floating point argument/retval recording.

Here is an example program.
```c
$ cat float-test.c
#include <stdio.h>

float float_add(float a, float b)
{
        fprintf(stderr, "float_add(%f, %f)", a, b);
        return a + b;
}

double double_add(double a, double b)
{
        fprintf(stderr, "double_add(%lf, %lf)", a, b);
        return a + b;
}

int main(int argc, char *argv[])
{
        double c;

        c = float_add(-0.1, 0.2);
        fprintf(stderr, " = %lf\n", c);

        c = double_add(-0.11, 0.22);
        fprintf(stderr, " = %lf\n", c);

        return c > 0;
}
```
Before:
```
$ uftrace -a -F main a.out
float_add(1213624708152897478526956949371466656365453977070085167863541782041015626505309452532498268575431296447550982841406775763334082854912.000000, 0.000000) = 0.100000
double_add(-0.110000, 0.220000) = 0.110000
# DURATION     TID     FUNCTION
            [  6041] | main(0xffffa16c9d24, 0xffffc577f9d8) {
            [  6041] |   float_add(-0.100000, 0.200000) {
   1.300 ms [  6041] |     fprintf(&_IO_2_1_stderr_, "float_add(%f, %f)") = 161;
   1.311 ms [  6041] |   } = -3967.511719; /* float_add */
  49.271 us [  6041] |   fprintf(&_IO_2_1_stderr_, " = %lf\n") = 12;
            [  6041] |   double_add(-0.110000, 0.220000) {
  27.187 us [  6041] |     fprintf(&_IO_2_1_stderr_, "double_add(%lf, %lf)") = 31;
  33.906 us [  6041] |   } = 0.000000; /* double_add */
  22.656 us [  6041] |   fprintf(&_IO_2_1_stderr_, " = %lf\n") = 12;
   1.437 ms [  6041] | } = 1; /* main */
```
After:
```
$ uftrace -a -F main a.out
float_add(-0.100000, 0.200000) = 0.100000
double_add(-0.110000, 0.220000) = 0.110000
# DURATION     TID     FUNCTION
            [  5383] | main(0xffffafd08d24, 0xffffc06bf268) {
            [  5383] |   float_add(-0.100000, 0.200000) {
   1.197 ms [  5383] |     fprintf(&_IO_2_1_stderr_, "float_add(%f, %f)") = 30;
   1.209 ms [  5383] |   } = 0.100000; /* float_add */
  48.281 us [  5383] |   fprintf(&_IO_2_1_stderr_, " = %lf\n") = 12;
            [  5383] |   double_add(-0.110000, 0.220000) {
  30.104 us [  5383] |     fprintf(&_IO_2_1_stderr_, "double_add(%lf, %lf)") = 31;
  36.926 us [  5383] |   } = 0.110000; /* double_add */
  22.604 us [  5383] |   fprintf(&_IO_2_1_stderr_, " = %lf\n") = 12;
   1.335 ms [  5383] | } = 1; /* main */
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>