### PR TITLE
utils: Lower debug level in demangler and symbol

### DIFF
--- a/utils/demangle.c
+++ b/utils/demangle.c
@@ -166,16 +166,16 @@ static void dd_debug_print(struct demangle_data *dd)
 	if (dd->func == NULL)
 		dd->func = "demangle";
 
-	if (dbg_domain[DBG_DEMANGLE] <= 1) {
-		pr_dbg("demangle failed: %s\n", dd->old);
+	if (dbg_domain[DBG_DEMANGLE] <= 3) {
+		pr_dbg3("demangle failed: %s\n", dd->old);
 		return;
 	}
 
-	pr_dbg2("simple demangle failed:%s%s\n%s\n%*c\n%s:%d: \"%s\" expected\n",
+	pr_dbg4("simple demangle failed:%s%s\n%s\n%*c\n%s:%d: \"%s\" expected\n",
 		dd_eof(dd) ? " (EOF)" : "", dd->level ? " (not finished)" : "",
 		dd->old, dd->pos + 1, '^', dd->func, dd->line, expected);
 
-	pr_dbg3("current: %s (pos: %d/%d)\n", dd->new, dd->pos, dd->len);
+	pr_dbg4("current: %s (pos: %d/%d)\n", dd->new, dd->pos, dd->len);
 	for (i = 0; i < dd->nr_dbg; i++)
 		pr_dbg4("  [%d] %s\n", i, dd->debug[i]);
 }

--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -966,7 +966,7 @@ static int load_module_symbol_file(struct symtab *symtab, const char *symfile,
 		sym->name = demangle(name);
 		sym->size = 0;
 
-		pr_dbg3("[%zd] %c %lx + %-5u %s\n", symtab->nr_sym,
+		pr_dbg4("[%zd] %c %lx + %-5u %s\n", symtab->nr_sym,
 			sym->type, sym->addr, sym->size, sym->name);
 
 		if (symtab->nr_sym > 1 && sym[-1].size == 0)


### PR DESCRIPTION
In most cases, demangler error is not a critical issue, but it looks
very annoying to see a lot of demangler failures in debug level 1.

In addition, symbol info can also be printed in a higher debug level.

This patch lowers the debug levels to hide messages which are not
related to tracing execution such as mcount and plthook.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>