### PR TITLE
tests: fix the way of checking linux version

### DIFF
--- a/tests/t022_filter_kernel.py
+++ b/tests/t022_filter_kernel.py
@@ -42,7 +42,7 @@ class TestCase(TestBase):
         # Linux v4.17 (x86_64) changed syscall routines
         major, minor, release = uname[2].split('.')
         if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 4 and int(minor) >= 17:
+           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
             result = result.replace('sys_gete', '__x64_sys_gete')
 
         return result

--- a/tests/t079_replay_kernel_D.py
+++ b/tests/t079_replay_kernel_D.py
@@ -53,7 +53,7 @@ class TestCase(TestBase):
         # Linux v4.17 (x86_64) changed syscall routines
         major, minor, release = uname[2].split('.')
         if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 4 and int(minor) >= 17:
+           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
             result = result.replace('sys_', '__x64_sys_')
 
         return result.replace(' sys_open', ' sys_openat')

--- a/tests/t081_kernel_depth.py
+++ b/tests/t081_kernel_depth.py
@@ -46,7 +46,7 @@ class TestCase(TestBase):
         # Linux v4.17 (x86_64) changed syscall routines
         major, minor, release = uname[2].split('.')
         if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 4 and int(minor) >= 17:
+           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
             result = result.replace(' sys_', ' __x64_sys_')
 
         return result.replace(' sys_open', ' sys_openat')

--- a/tests/t103_dump_kernel.py
+++ b/tests/t103_dump_kernel.py
@@ -84,7 +84,7 @@ class TestCase(TestBase):
         # Linux v4.17 (x86_64) changed syscall routines
         major, minor, release = uname[2].split('.')
         if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 4 and int(minor) >= 17:
+           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
             result = result.replace('sys_get', '__x64_sys_get')
 
         return result

--- a/tests/t104_graph_kernel.py
+++ b/tests/t104_graph_kernel.py
@@ -72,7 +72,7 @@ class TestCase(TestBase):
         # Linux v4.17 (x86_64) changed syscall routines
         major, minor, release = uname[2].split('.')
         if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 4 and int(minor) >= 17:
+           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
             result = result.replace('sys_get', '__x64_sys_get')
 
         return result

--- a/tests/t111_kernel_tid.py
+++ b/tests/t111_kernel_tid.py
@@ -79,7 +79,7 @@ class TestCase(TestBase):
         # Linux v4.17 (x86_64) changed syscall routines
         major, minor, release = uname[2].split('.')
         if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 4 and int(minor) >= 17:
+           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
             result = result.replace('sys_', '__x64_sys_')
 
         return result

--- a/tests/t132_trigger_kernel.py
+++ b/tests/t132_trigger_kernel.py
@@ -46,7 +46,7 @@ class TestCase(TestBase):
         # Linux v4.17 (x86_64) changed syscall routines
         major, minor, release = uname[2].split('.')
         if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 4 and int(minor) >= 17:
+           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
             result = result.replace('sys_', '__x64_sys_')
 
         return result.replace(' sys_open', ' sys_openat')

--- a/tests/t137_kernel_tid_update.py
+++ b/tests/t137_kernel_tid_update.py
@@ -54,7 +54,7 @@ class TestCase(TestBase):
         # Linux v4.17 (x86_64) changed syscall routines
         major, minor, release = uname[2].split('.')
         if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 4 and int(minor) >= 17:
+           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
             result = result.replace('sys_', '__x64_sys_')
 
         return result

--- a/tests/t138_kernel_dynamic.py
+++ b/tests/t138_kernel_dynamic.py
@@ -43,7 +43,7 @@ class TestCase(TestBase):
         # Linux v4.17 (x86_64) changed syscall routines
         major, minor, release = uname[2].split('.')
         if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 4 and int(minor) >= 17:
+           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
             result = result.replace('sys_', '__x64_sys_')
 
         return result

--- a/tests/t139_kernel_dynamic2.py
+++ b/tests/t139_kernel_dynamic2.py
@@ -34,7 +34,7 @@ class TestCase(TestBase):
         # Linux v4.17 (x86_64) changed syscall routines
         major, minor, release = uname[2].split('.')
         if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 4 and int(minor) >= 17:
+           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
             return result.replace(' sys_open', ' __x64_sys_openat')
         else:
             return result.replace(' sys_open', ' sys_openat')

--- a/tests/t143_recv_kernel.py
+++ b/tests/t143_recv_kernel.py
@@ -60,7 +60,7 @@ class TestCase(TestBase):
         # Linux v4.17 (x86_64) changed syscall routines
         major, minor, release = uname[2].split('.')
         if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 4 and int(minor) >= 17:
+           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
             result = result.replace('sys_', '__x64_sys_')
 
         return result.replace(' sys_open', ' sys_openat')

--- a/tests/t174_replay_filter_kernel.py
+++ b/tests/t174_replay_filter_kernel.py
@@ -52,7 +52,7 @@ class TestCase(TestBase):
         # Linux v4.17 (x86_64) changed syscall routines
         major, minor, release = uname[2].split('.')
         if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 4 and int(minor) >= 17:
+           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
             result = result.replace('sys_', '__x64_sys_')
 
         return result.replace(' sys_open', ' sys_openat')


### PR DESCRIPTION

Linux version check code have error, so this commit fix it.

Because Linux v4.17 (x86_64) changed syscall routines,
one commit add some codes for checking Linux version.

commit id: b4812af
However, this code have an error. If your Linux version is
more than 4.17 and less than 5.0, there is no error.
But my linux version is more than 5.0, so there is error.

The past commit(b4812af) fix test cases. The number is
022, 079, 081, 103, 104, 111, 132, 137, 138, 139, 143 and 174.
So I apply the new way of version check to that cases(12 cases).

This is my Linux environment.
```
$ uname -r
Linux kali 5.2.0-kali3-amd64 #1 SMP Debian 5.2.17-1kali2
(2019-10-17) x86_64 GNU/Linux
```

This is my test results. (before commit)
```
$ cd test
$ ./runtest.py
$ cat failed-tests.txt
Test case                 pg             finstrument-fu
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
022 filter_kernel       : NG NG NG NG NG NG NG NG NG NG
079 replay_kernel_D     : NG NG NG NG NG NG NG NG NG NG
081 kernel_depth        : NG NG NG NG NG NG NG NG NG NG
103 dump_kernel         : NG NG NG NG NG NG NG NG NG NG
104 graph_kernel        : NG NG NG NG NG NG NG NG NG NG
111 kernel_tid          : NG NG NG NG NG NG NG NG NG NG
125 report_range        : OK OK OK OK OK OK OK OK OK NG
132 trigger_kernel      : NG NG NG NG NG NG NG NG NG NG
136 dynamic             : OK OK OK OK OK BI BI BI BI BI
137 kernel_tid_update   : NG NG TM NG NG NG NG TM NG TM
138 kernel_dynamic      : NG NG NG NG NG NG NG NG NG NG
139 kernel_dynamic2     : NG NG NG NG NG NG NG NG NG NG
141 recv_basic          : OK OK OK NZ OK OK OK OK OK OK
143 recv_kernel         : NG NG NG NG NG NG NG NG NG NG
147 event_sdt           : BI BI BI BI BI BI BI BI BI BI
150 recv_event          : BI BI BI BI BI BI BI BI BI BI
151 recv_runcmd         : NG NG NG NG NG NG NG NG NG NG
174 replay_filter_kernel: NG NG NG NG NG NG NG NG NG NG
181 graph_full          : NG NG NG NG NG NG NG NG NG NG
184 arg_enum            : NG NG NG NG NG NG NG NG NG NG
203 arg_dwarf3          : OK OK NG NG NG SK SK SK SK SK
204 arg_dwarf4          : OK OK NG NG OK SK SK SK SK SK
212 noplt_libcall       : NG NG NG NG NG OK OK OK OK OK
226 default_opts        : NG OK OK OK OK OK OK OK OK OK
232 dynamic_unpatch     : OK OK OK OK OK BI BI BI BI BI
```

This is my test results after fix version checking issue.
```
$ cd test
$ ./runtest.py
$ cat failed-tests.txt
Test case                 pg             finstrument-fu
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
079 replay_kernel_D     : NG NG NG NG NG NG NG NG NG NG
081 kernel_depth        : NG NG NG NG NG NG NG NG NG NG
103 dump_kernel         : NG NG NG NG NG NG NG NG NG NG
104 graph_kernel        : NG NG NG NG NG NG NG NG NG NG
111 kernel_tid          : NG NG NG NG NG NG NG NG NG NG
117 time_range          : OK OK NG OK OK OK OK OK OK OK
132 trigger_kernel      : NG NG NG NG NG NG NG NG NG NG
136 dynamic             : OK OK OK OK OK BI BI BI BI BI
137 kernel_tid_update   : OK OK OK OK TM OK OK OK OK TM
143 recv_kernel         : NG NG NG NG NG NG NG NG NG NG
147 event_sdt           : BI BI BI BI BI BI BI BI BI BI
149 event_kernel2       : OK OK OK OK OK NG OK OK OK OK
150 recv_event          : BI BI BI BI BI BI BI BI BI BI
151 recv_runcmd         : NG NG NG NG NG NG NG NG NG NG
158 report_diff_policy1 : OK OK NG OK OK OK OK OK OK OK
174 replay_filter_kernel: NG NG NG NG NG NG NG NG NG NG
181 graph_full          : NG NG NG NG NG NG NG NG NG NG
184 arg_enum            : NG NG NG NG NG NG NG NG NG NG
203 arg_dwarf3          : OK OK NG NG NG SK SK SK SK SK
204 arg_dwarf4          : OK OK NG NG OK SK SK SK SK SK
212 noplt_libcall       : NG NG NG NG NG OK OK OK OK OK
232 dynamic_unpatch     : OK OK OK OK OK BI BI BI BI BI
```

This commit can fix the test cases of number 022, 138, 139.
In my opinion, test case of umber 079, 081, 103, 104, 111, 132,
137, 143, 174 have some more bugs.(about linux syscall routines)

Signed-off-by: Dohyun Kim <kimdo331@naver.com>