### PR TITLE
report: show source line info with --srcline option

### DIFF
--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -392,7 +392,7 @@ static void update_report_node(struct uftrace_task_reader *task, char *symname,
 	if (list_is_none(&graph_node->link))
 		list_add_tail(&graph_node->link, &node->head);
 
-	report_update_node(&node->n, task);
+	report_update_node(&node->n, task, NULL);
 }
 
 static int build_tui_node(struct uftrace_task_reader *task,

--- a/doc/uftrace-report.md
+++ b/doc/uftrace-report.md
@@ -58,6 +58,9 @@ REPORT OPTIONS
     `--data` option, index 1 is for data given by the `--diff` option, and index
     2 is for (percentage) differences between the two data.
 
+\--srcline
+:   Show source location of each function if available.
+
 
 COMMON OPTIONS
 ==============
@@ -166,6 +169,18 @@ This command shows information like the following:
       Total time   Self time   Num funcs     TID  Task name
       ==========  ==========  ==========  ======  ================
        22.178 us   22.178 us           7   29955  t-abc
+
+    $ uftrace record --srcline abc
+    $ uftrace report --srcline
+      Total time   Self time       Calls  Function [Source]
+      ==========  ==========  ==========  ====================
+       17.508 us    2.199 us           1  main [./tests/s-abc.c:26]
+       15.309 us    2.384 us           1  a [./tests/s-abc.c:11]
+       12.925 us    2.633 us           1  b [./tests/s-abc.c:16]
+       10.292 us    5.159 us           1  c [./tests/s-abc.c:21]
+        5.133 us    5.133 us           1  getpid
+        3.437 us    3.437 us           1  __monstartup
+        1.959 us    1.959 us           1  __cxa_atexit
 
 To see a difference between two data:
 

--- a/tests/t235_report_srcline.py
+++ b/tests/t235_report_srcline.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'abc', """
+  Total time   Self time       Calls  Function [Source]
+  ==========  ==========  ==========  ====================
+    2.559 us    0.306 us           1  main [tests/s-abc.c:26]
+    2.253 us    0.292 us           1  a [tests/s-abc.c:11]
+    1.961 us    0.342 us           1  b [tests/s-abc.c:16]
+    1.619 us    0.555 us           1  c [tests/s-abc.c:21]
+    1.064 us    1.064 us           1  getpid
+    0.372 us    0.372 us           1  __monstartup
+    0.186 us    0.186 us           1  __cxa_atexit
+""", cflags='-g')
+
+    def build(self, name, cflags='', ldflags=''):
+        if cflags.find('-finstrument-functions') >= 0:
+            return TestBase.TEST_SKIP
+
+        return TestBase.build(self, name, cflags, ldflags)
+
+    def prepare(self):
+        self.subcmd = 'record'
+        self.option = '--srcline'
+        return self.runcmd()
+
+    def setup(self):
+        self.subcmd = 'report'
+        self.option = '--srcline'
+
+    def sort(self, output):
+        """ This function post-processes output of the test to be compared .
+            It ignores blank and comment (#) lines and remaining functions.  """
+        result = []
+        for ln in output.split('\n'):
+            if ln.strip() == '':
+                continue
+            line = ln.split()
+            if line[0] == 'Total':
+                continue
+            if line[0].startswith('='):
+                continue
+            # A report line consists of following data
+            # [0]         [1]   [2]        [3]   [4]     [5]       [6]
+            # total_time  unit  self_time  unit  called  function  srcline
+            if line[-1].startswith('__'):
+                continue
+
+            if len(line) < 7 :
+                result.append('%s %s' % (line[-2], line[-1]))
+            else :
+                result.append('%s %s %s' % (line[-3], line[-2], line[-1][1:-1].split('/')[-1]))
+
+        return '\n'.join(result)

--- a/uftrace.h
+++ b/uftrace.h
@@ -440,6 +440,9 @@ struct sym * task_find_sym(struct uftrace_session_link *sess,
 struct sym * task_find_sym_addr(struct uftrace_session_link *sess,
 				struct uftrace_task_reader *task,
 				uint64_t time, uint64_t addr);
+struct debug_location * task_find_loc_addr(struct uftrace_session_link *sess,
+					   struct uftrace_task_reader *task,
+					   uint64_t time, uint64_t addr);
 
 typedef int (*walk_sessions_cb_t)(struct uftrace_session *session, void *arg);
 void walk_sessions(struct uftrace_session_link *sess,

--- a/utils/report.c
+++ b/utils/report.c
@@ -58,6 +58,7 @@ find_or_create_node(struct rb_root *root, const char *name,
 		return NULL;
 
 	node->name = xstrdup(name);
+	node->loc = NULL;
 	init_time_stat(&node->total);
 	init_time_stat(&node->self);
 
@@ -88,7 +89,8 @@ void report_delete_node(struct rb_root *root, struct uftrace_report_node *node)
 }
 
 void report_update_node(struct uftrace_report_node *node,
-			struct uftrace_task_reader *task)
+			struct uftrace_task_reader *task,
+			struct debug_location *loc)
 {
 	struct fstack *fstack;
 	uint64_t total_time;
@@ -117,6 +119,7 @@ void report_update_node(struct uftrace_report_node *node,
 	update_time_stat(&node->total, total_time, recursive);
 	update_time_stat(&node->self, self_time, false);
 	node->call++;
+	node->loc = loc;
 }
 
 void report_calc_avg(struct rb_root *root)
@@ -512,7 +515,7 @@ void report_diff_nodes(struct rb_root *orig_root, struct rb_root *pair_root,
 void destroy_diff_nodes(struct rb_root *diff_root)
 {
 	struct rb_node *n = rb_first(diff_root);
-	
+
 	while (n) {
 		struct uftrace_report_node *iter;
 
@@ -782,7 +785,7 @@ TEST_CASE(report_sort)
 	for (i = 0; i < TEST_NODES; i++) {
 		node = xzalloc(sizeof(*node));
 		report_add_node(&name_tree, test_name[i], node);
-		report_update_node(node, &task);
+		report_update_node(node, &task, NULL);
 		task.stack_count++;
 	}
 	report_calc_avg(&name_tree);
@@ -888,7 +891,7 @@ TEST_CASE(report_diff)
 
 		node = xzalloc(sizeof(*node));
 		report_add_node(&orig_tree, orig_name[i], node);
-		report_update_node(node, &orig_task);
+		report_update_node(node, &orig_task, NULL);
 		orig_task.stack_count++;
 	}
 	report_calc_avg(&orig_tree);
@@ -900,7 +903,7 @@ TEST_CASE(report_diff)
 
 		node = xzalloc(sizeof(*node));
 		report_add_node(&pair_tree, pair_name[i], node);
-		report_update_node(node, &pair_task);
+		report_update_node(node, &pair_task, NULL);
 		pair_task.stack_count++;
 	}
 	report_calc_avg(&pair_tree);

--- a/utils/report.h
+++ b/utils/report.h
@@ -21,6 +21,7 @@ struct uftrace_report_node {
 	char				*name;
 	struct report_time_stat 	total;
 	struct report_time_stat 	self;
+	struct debug_location		*loc;
 	uint64_t			call;
 	struct rb_node			name_link;
 	struct rb_node			sort_link;
@@ -47,7 +48,8 @@ struct uftrace_report_node * report_find_node(struct rb_root *root,
 void report_add_node(struct rb_root *root, const char *name,
 		     struct uftrace_report_node *node);
 void report_update_node(struct uftrace_report_node *node,
-			struct uftrace_task_reader *task);
+			struct uftrace_task_reader *task,
+			struct debug_location *loc);
 void report_calc_avg(struct rb_root *root);
 void report_delete_node(struct rb_root *root, struct uftrace_report_node *node);
 


### PR DESCRIPTION
Show source line info of each function with loaded debug_info.

Fixed: #763

Could I leave 'Signed off' message after code review?

I think there are many other ways to implement this feature.
All comments are welcome.