### PR TITLE
misc: Add kali to install-deps.sh

### DIFF
--- a/misc/install-deps.sh
+++ b/misc/install-deps.sh
@@ -12,7 +12,7 @@ OPT="${@}"
 distro=$(grep "^ID=" /etc/os-release | cut -d\= -f2 | sed -e 's/"//g')
 
 case $distro in
-    "ubuntu" | "debian" | "raspbian")
+    "ubuntu" | "debian" | "raspbian" | "kali")
         apt-get $OPT install pandoc libdw-dev libpython2.7-dev libncursesw5-dev pkg-config
         apt-get $OPT install libluajit-5.1-dev || true
         apt-get $OPT install libcapstone-dev || true ;;


### PR DESCRIPTION
Since kali uses the same package install commands, it just simply adds kali to ubuntu case.

Signed-off-by: Dohyun Kim <kimdo331@naver.com>