### PR TITLE
dynamic: Fix a crash in x86_64 full dynamic tracing

### DIFF
--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -125,8 +125,9 @@ int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
 
 void mcount_cleanup_trampoline(struct mcount_dynamic_info *mdi)
 {
-	if (mprotect(PAGE_ADDR(mdi->text_addr), 
-			 PAGE_LEN(mdi->text_addr, mdi->text_size), PROT_EXEC))
+	if (mprotect(PAGE_ADDR(mdi->text_addr),
+		     PAGE_LEN(mdi->text_addr, mdi->text_size),
+		     PROT_READ | PROT_EXEC))
 		pr_err("cannot restore trampoline due to protection");
 }
 


### PR DESCRIPTION
In some environments, full dynamic tracing gets always crashed.
```
  $ uftrace record -P. --debug-domain dynamic:3 t-abc
  dynamic: dynamic patch type: t-abc: 0 (none)
  dynamic: patch normal func: a (patch size: 9)
  dynamic: patch normal func: b (patch size: 9)
  dynamic: patch normal func: c (patch size: 9)
  dynamic: patch normal func: main (patch size: 8)
  dynamic: patched all (4) functions in 't-abc'
  WARN: child terminated by signal: 11: Segmentation fault
```
It works fine on many other machines, but gets crashed on some specific
machines.

It might has some read-only data in trampoline code, but the cleanup
phase sets the permission only with PROT_EXEC.

The reason is not 100% clear now, but it's verified that adding
PROT_READ permission fixes the crash problem.

Fixed: #1071

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>