### PR TITLE
debug: Add a new debug domain for wrap

### DIFF
--- a/libmcount/mcount.h
+++ b/libmcount/mcount.h
@@ -83,6 +83,6 @@ struct mcount_shmem_buffer {
 };
 
 /* must be in sync with enum debug_domain (bits) */
-#define DBG_DOMAIN_STR  "TSDFfsKMpPERW"
+#define DBG_DOMAIN_STR  "TSDFfsKMpPERWw"
 
 #endif /* UFTRACE_MCOUNT_H */

--- a/libmcount/wrap.c
+++ b/libmcount/wrap.c
@@ -7,8 +7,8 @@
 #include <spawn.h>
 
 /* This should be defined before #include "utils.h" */
-#define PR_FMT     "mcount"
-#define PR_DOMAIN  DBG_MCOUNT
+#define PR_FMT     "wrap"
+#define PR_DOMAIN  DBG_WRAP
 
 #include "libmcount/mcount.h"
 #include "libmcount/internal.h"

--- a/uftrace.c
+++ b/uftrace.c
@@ -336,6 +336,8 @@ static void parse_debug_domain(char *arg)
 			dbg_domain[DBG_SCRIPT] = level;
 		else if (!strcmp(tok, "dwarf"))
 			dbg_domain[DBG_DWARF] = level;
+		else if (!strcmp(tok, "wrap"))
+			dbg_domain[DBG_WRAP] = level;
 	}
 
 	dbg_domain_set = true;

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -71,6 +71,7 @@ enum debug_domain {
 	DBG_EVENT,
 	DBG_SCRIPT,
 	DBG_DWARF,
+	DBG_WRAP,
 	DBG_DOMAIN_MAX,
 };
 extern int dbg_domain[DBG_DOMAIN_MAX];


### PR DESCRIPTION
It'd be better to distinguish "wrap" domain from other debug messages.

Having this debug domain, users can easily see if there are some
wrapped functions such as dlopen as well.

It's especially useful if some problems are because of backtrace or
exception handling, etc.

This PR also adjusts debug messages in wrap domain as follows.
```
  $ g++ -pg -o t-exception4 tests/s-exception4.cpp

  $ uftrace record --force --debug-domain wrap:2 t-exception4
  wrap: __cxa_throw: exception thrown from [2]
  wrap: __cxa_begin_catch: exception catched begin on [1]
  wrap: __cxa_end_catch: exception catched end

  $ uftrace record --force --debug-domain wrap:3 t-exception4
  wrap: __cxa_throw: exception thrown from [2]
  wrap: mcount_rstack_reset_exception: [1] parent at 0x7fffc93355a8
  wrap: mcount_rstack_reset_exception: [0] parent at 0x7fffc93355c8
  wrap: mcount_rstack_reset_exception: exception returned to [1]
  wrap: __cxa_begin_catch: exception catched begin on [1]
  wrap: __cxa_end_catch: exception catched end
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>