### PR TITLE
dwarf: Produce srcline in .dbg for -finstrument-functions

### DIFF
--- a/utils/dwarf.c
+++ b/utils/dwarf.c
@@ -262,8 +262,8 @@ static int setup_dwarf_info(const char *filename, struct debug_info *dinfo,
 {
 	int fd;
 
-	if (!force && check_trace_functions(filename) != TRACE_MCOUNT)
-		return 0;
+	if (force || check_trace_functions(filename) != TRACE_CYGPROF)
+		dinfo->needs_args = true;
 
 	pr_dbg2("setup dwarf debug info for %s\n", filename);
 
@@ -1043,6 +1043,12 @@ static void build_dwarf_info(struct debug_info *dinfo, struct symtab *symtab,
 
 		if (uftrace_done)
 			break;
+
+		/* do not read arguments when it's not needed */
+		if (!dinfo->needs_args) {
+			bd.nr_args = 0;
+			bd.nr_rets = 0;
+		}
 
 		dwarf_getsrcfiles(&cudie, &bd.files.files, &bd.files.num);
 

--- a/utils/dwarf.h
+++ b/utils/dwarf.h
@@ -40,6 +40,7 @@ struct debug_info {
 	int			nr_locs;
 	int			nr_locs_used;
 	int			file_type;
+	bool			needs_args;
 };
 
 extern void prepare_debug_info(struct symtabs *symtabs,


### PR DESCRIPTION
LoisHuang reported that the current implementation does not generate
source location info when the target binary is compiled with
-finstrument-functions even though it has debug info.

Binary compilation:
```
  $ gcc -g -finstrument-functions -o t-abc.finst tests/s-abc.c
```
Before:
```
  $ uftrace record -a t-abc.finst
  $ cat uftrace.data/*.dbg
  cat: cannot access 'uftrace.data/*.dbg': No such file or directory
```
After:
```
  $ uftrace record -a t-abc.finst
  $ cat uftrace.data/t-abc.finst.dbg
  F: 73a a
  L: 11 tests/s-abc.c
  F: 77a b
  L: 16 tests/s-abc.c
  F: 7ba c
  L: 21 tests/s-abc.c
  F: 818 main
  L: 26 tests/s-abc.c
```
Please note that it doesn't generate arguments information unnecessarily
because TRACE_CYGPROF type only has source location information.

Fixed: #1152

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>