### PR TITLE
kernel: Properly handle offlined CPUs for kernel tracing

### DIFF
--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -650,7 +650,7 @@ int setup_kernel_tracing(struct uftrace_kernel_writer *kernel, struct opts *opts
 	if (ret < 0)
 		return ret;
 
-	kernel->nr_cpus = n = sysconf(_SC_NPROCESSORS_ONLN);
+	kernel->nr_cpus = n = sysconf(_SC_NPROCESSORS_CONF);
 
 	kernel->traces	= xcalloc(n, sizeof(*kernel->traces));
 	kernel->fds	= xcalloc(n, sizeof(*kernel->fds));


### PR DESCRIPTION
If some cpus are offlined especially from the initial numbers, then
the current implementation fails to collect correct kernel-cpuXX.dat.

It's because it just simply counts the number of cpus, then collects
from cpu0 by looping over the number of cpus.

Here is the problematic cpu settings.
```
  $ cat /sys/devices/system/cpu/possible
  0-7

  $ cat /sys/devices/system/cpu/offline
  0-3,6-7

  $ cat /sys/devices/system/cpu/online
  4-5
```
In this case, uftrace has to collect kernel-cpu4.dat and kernel-cpu5.dat,
but it just collects kernel-cpu0.dat and kernel-cpu1.dat, which are
empty because they are offlined.

This patch fixes the problem by looping over all the cpus rather than
considering only online cpus.  It changes from _SC_NPROCESSORS_ONLN to
_SC_NPROCESSORS_CONF.
```
  _SC_NPROCESSORS_ONLN
    The number of processors currently online

  _SC_NPROCESSORS_CONF
    The number of processors configured.
```
Fixed: #1151

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>