### PR TITLE
dwarf : Remove common compile directory prefix from file name in .dbg

### DIFF
--- a/utils/dwarf.h
+++ b/utils/dwarf.h
@@ -41,6 +41,7 @@ struct debug_info {
 	int			nr_locs_used;
 	int			file_type;
 	bool			needs_args;
+	char			*base_dir;
 };
 
 extern void prepare_debug_info(struct symtabs *symtabs,


### PR DESCRIPTION
Remove the common directory prefix if file name is under
the compile unit's compilation directory (DW_AT_comp_dir).

Signed-off-by: Eunseon Lee <esintospace@gmail.com>