### PR TITLE
mcount: Generate .dbg file for library with debug section

### DIFF
--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -102,8 +102,7 @@ static void mcount_filter_init(enum uftrace_pattern_type ptype, char *dirname,
 	if (getenv("UFTRACE_SRCLINE") == NULL)
 		return;
 
-	symtabs.exec_map->mod = load_module_symtab(&symtabs,
-						   symtabs.exec_map->libname);
+	load_module_symtabs(&symtabs);
 
 	/* use debug info if available */
 	prepare_debug_info(&symtabs, ptype, NULL, NULL, false, force);
@@ -1358,7 +1357,7 @@ static int __cygprof_entry(unsigned long parent, unsigned long child)
 		mtdp->in_exception = false;
 	}
 
-	/* 
+	/*
 	 * recording arguments and return value is not supported.
 	 * also 'recover' trigger is only work for -pg entry.
 	 */

--- a/tests/t246_report_srcline2.py
+++ b/tests/t246_report_srcline2.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'lib', """
+  Total time   Self time       Calls  Function [Source]
+  ==========  ==========  ==========  ====================
+    4.457 us    0.630 us           2  lib_a
+    3.266 us    0.413 us           1  main [xxx/uftrace/tests/s-libmain.c:16]
+    2.853 us    0.412 us           1  foo [xxx/uftrace/tests/s-libmain.c:11]
+    1.811 us    0.598 us           1  lib_b [xxx/uftrace/tests/s-lib.c:15]
+    1.213 us    1.213 us           1  lib_c [xxx/uftrace/tests/s-lib.c:20]
+""", cflags='-g')
+
+    def build(self, name, cflags='', ldflags=''):
+        if TestBase.build_libabc(self, cflags, ldflags) != 0:
+            return TestBase.TEST_BUILD_FAIL
+        return TestBase.build_libmain(self, name, 's-libmain.c',
+                                      ['libabc_test_lib.so'],
+                                      cflags, ldflags)
+
+    def prepare(self):
+        self.subcmd = 'record'
+        self.option = '--srcline'
+        return self.runcmd()
+
+    def setup(self):
+        self.subcmd = 'report'
+        self.option = '--srcline'
+
+    def sort(self, output):
+        """ This function post-processes output of the test to be compared .
+            It ignores blank and comment (#) lines and remaining functions.  """
+        result = []
+        for ln in output.split('\n'):
+            if ln.strip() == '':
+                continue
+            line = ln.split()
+            if line[0] == 'Total':
+                continue
+            if line[0].startswith('='):
+                continue
+            # A report line consists of following data
+            # [0]         [1]   [2]        [3]   [4]     [5]       [6]
+            # total_time  unit  self_time  unit  called  function  srcline
+            if line[-1].startswith('__'):
+                continue
+
+            if len(line) < 7 :
+                result.append('%s %s' % (line[-2], line[-1]))
+            else :
+                result.append('%s %s %s' % (line[-3], line[-2], line[-1][1:-1].split('/')[-1]))
+
+        return '\n'.join(result)


### PR DESCRIPTION
It generates .dbg file for every library with debug information
linked to the main executable when recording with --srcline option.

Fixed: #1138

Signed-off-by: Eunseon Lee <esintospace@gmail.com>
