### PR TITLE
tests: Fix stucked or failed tests in aarch64

### DIFF
--- a/tests/t079_replay_kernel_D.py
+++ b/tests/t079_replay_kernel_D.py
@@ -28,7 +28,7 @@ class TestCase(TestBase):
 
         self.subcmd  = 'record'
         self.option  = '-K3 '
-        self.option += '-N %s@kernel' % 'exit_to_usermode_loop '
+        self.option += '-N %s@kernel ' % 'exit_to_usermode_loop'
         self.option += '-N %s@kernel' % '_*do_page_fault'
 
         record_cmd = self.runcmd()

--- a/tests/t080_replay_kernel_D2.py
+++ b/tests/t080_replay_kernel_D2.py
@@ -31,6 +31,6 @@ class TestCase(TestBase):
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
-    def runcmd(self):
+    def setup(self):
         self.subcmd = 'replay'
         self.option = '-k -D2'

--- a/tests/t111_kernel_tid.py
+++ b/tests/t111_kernel_tid.py
@@ -4,16 +4,27 @@ from runtest import TestBase
 import subprocess as sp
 import os
 
-TDIR='xxx'
-
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', serial=True, result=""" # DURATION TID FUNCTION [ 1661] | main() { [ 1661] | fork() { 5.135 us [
-1661] | sys_writev(); 32.391 us [ 1661] | sys_clone(); 130.930 us [ 1661] | } /*
-fork */ [ 1661] | wait() { 7.074 us [ 1661] | sys_wait4(); 691.873 us [ 1661] |
-} /* wait */ [ 1661] | a() { [ 1661] | b() { [ 1661] | c() { 4.234 us [ 1661] |
-getpid(); 5.680 us [ 1661] | } /* c */ 6.094 us [ 1661] | } /* b */ 6.602 us [
-1661] | } /* a */ 849.948 us [ 1661] | } /* main */ """)
+        TestBase.__init__(self, 'fork', serial=True, result="""
+# DURATION    TID     FUNCTION
+            [ 1661] | main() {
+            [ 1661] |   fork() {
+   5.135 us [ 1661] |     sys_writev();
+  32.391 us [ 1661] |     sys_clone();
+ 130.930 us [ 1661] |   } /* fork */
+            [ 1661] |   wait() {
+   7.074 us [ 1661] |     sys_wait4();
+ 691.873 us [ 1661] |   } /* wait */
+            [ 1661] |   a() {
+            [ 1661] |     b() {
+            [ 1661] |       c() {
+   4.234 us [ 1661] |         getpid();
+   5.680 us [ 1661] |       } /* c */
+   6.094 us [ 1661] |     } /* b */
+   6.602 us [ 1661] |   } /* a */
+ 849.948 us [ 1661] | } /* main */
+""")
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
@@ -31,7 +42,7 @@ getpid(); 5.680 us [ 1661] | } /* c */ 6.094 us [ 1661] | } /* b */ 6.602 us [
 
     def setup(self):
         t = 0
-        for ln in open(os.path.join(TDIR, 'task.txt')):
+        for ln in open(os.path.join('uftrace.data', 'task.txt')):
             if not ln.startswith('TASK'):
                 continue
             try:

--- a/tests/t143_recv_kernel.py
+++ b/tests/t143_recv_kernel.py
@@ -39,7 +39,7 @@ class TestCase(TestBase):
         self.pr_debug('prerun command: ' + recv_cmd)
         self.recv_p = sp.Popen(recv_cmd.split())
 
-        self.dirname = 'dir-' + random.randint(100000, 999999)
+        self.dirname = 'dir-%d' % random.randint(100000, 999999)
         self.subcmd = 'record'
         self.option = '-H %s --port %s -d %s' % ('localhost', self.port, self.dirname)
         self.exearg = 't-' + self.name


### PR DESCRIPTION
This patch fixes some tests that are stuck or failed in aarch64.

Fixed: #1157, #1158

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>