### PR TITLE
kernel: Skip post_ttbr_update_workaround() in aarch64

### DIFF
--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -597,6 +597,15 @@ static void skip_kernel_functions(struct uftrace_kernel_writer *kernel)
 		/* Disable syscall tracing in the kernel */
 		"syscall_trace_enter_phase1",
 		"syscall_slow_exit_work",
+#ifdef __aarch64__
+		/*
+		 * TTBR is for page table setting and it is needed for security
+		 * enhancement against spectre/meltdown attacks.
+		 * post_ttbr_update_workaround() is better to be hidden not to
+		 * confuse general users unnecessarily.
+		 */
+		"post_ttbr_update_workaround",
+#endif
 	};
 	const char *skip_patches[] = {
 		/* kernel 4.17 changed syscall entry on x86_64 */


### PR DESCRIPTION
TTBR is for page table setting and it is needed for security
enhancement against spectre/meltdown attacks.

post_ttbr_update_workaround() is better to be hidden not to
confuse general users unnecessarily.

Before:
```
  $ uftrace -F main -k t-abc
  # DURATION     TID     FUNCTION
              [  4788] | main() {
     1.041 us [  4788] |   post_ttbr_update_workaround();
              [  4788] |   a() {
     1.041 us [  4788] |     post_ttbr_update_workaround();
              [  4788] |     b() {
     0.521 us [  4788] |       post_ttbr_update_workaround();
              [  4788] |       c() {
     0.521 us [  4788] |         post_ttbr_update_workaround();
              [  4788] |         getpid() {
     0.521 us [  4788] |           post_ttbr_update_workaround();
     1.042 us [  4788] |           sys_getpid();
     1.042 us [  4788] |           post_ttbr_update_workaround();
     6.771 us [  4788] |         } /* getpid */
     0.521 us [  4788] |         post_ttbr_update_workaround();
    14.584 us [  4788] |       } /* c */
     1.041 us [  4788] |       post_ttbr_update_workaround();
    19.792 us [  4788] |     } /* b */
     0.520 us [  4788] |     post_ttbr_update_workaround();
    25.000 us [  4788] |   } /* a */
     0.521 us [  4788] |   post_ttbr_update_workaround();
    30.208 us [  4788] | } /* main */
```
After:
```
  $ uftrace -F main -k t-abc
  # DURATION     TID     FUNCTION
              [  4866] | main() {
              [  4866] |   a() {
              [  4866] |     b() {
              [  4866] |       c() {
              [  4866] |         getpid() {
     1.042 us [  4866] |           sys_getpid();
     3.646 us [  4866] |         } /* getpid */
     9.375 us [  4866] |       } /* c */
    11.979 us [  4866] |     } /* b */
    14.584 us [  4866] |   } /* a */
    17.187 us [  4866] | } /* main */
```
Link: https://lists.infradead.org/pipermail/linux-arm-kernel/2018-January/551838.html
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>