### PR TITLE
replay: show source line info with --srcline option

### DIFF
--- a/cmds/graph.c
+++ b/cmds/graph.c
@@ -507,7 +507,7 @@ static int print_graph(struct session_graph *graph, struct opts *opts)
 
 	if (graph->ug.root.time || graph->ug.root.nr_edges) {
 		pr_out("========== FUNCTION CALL GRAPH ==========\n");
-		print_header(&output_fields, "# ", "FUNCTION", 2);
+		print_header(&output_fields, "# ", "FUNCTION", 2, true);
 		indent_mask = xcalloc(opts->max_stack, sizeof(*indent_mask));
 		print_graph_node(&graph->ug, &graph->ug.root, indent_mask, 0,
 				 graph->ug.root.nr_edges > 1);
@@ -942,7 +942,7 @@ static int graph_print_task(struct uftrace_data *handle, struct opts *opts)
 		    field_task_table, ARRAY_SIZE(field_task_table));
 
 	pr_out("========== TASK GRAPH ==========\n");
-	print_header(&output_task_fields, "# ", "TASK NAME", 2);
+	print_header(&output_task_fields, "# ", "TASK NAME", 2, true);
 
 	indent_mask = xcalloc(handle->nr_tasks, sizeof(*indent_mask));
 

--- a/tests/t236_replay_srcline.py
+++ b/tests/t236_replay_srcline.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'abc', """
+# DURATION     TID     FUNCTION [SOURCE]
+   0.678 us [ 19939] | __monstartup();
+   0.234 us [ 19939] | __cxa_atexit();
+            [ 19939] | main() { /* tests/s-abc.c:26 */
+            [ 19939] |   a() { /* tests/s-abc.c:11 */
+            [ 19939] |     b() { /* tests/s-abc.c:16 */
+            [ 19939] |       c() { /* tests/s-abc.c:21 */
+   1.120 us [ 19939] |         getpid();
+   1.697 us [ 19939] |       } /* c at tests/s-abc.c:21 */
+   2.044 us [ 19939] |     } /* b at tests/s-abc.c:16 */
+   2.329 us [ 19939] |   } /* a at tests/s-abc.c:11 */
+   2.644 us [ 19939] | } /* main at tests/s-abc.c:26 */
+""", cflags='-g')
+
+    def build(self, name, cflags='', ldflags=''):
+        if cflags.find('-finstrument-functions') >= 0:
+            return TestBase.TEST_SKIP
+
+        return TestBase.build(self, name, cflags, ldflags)
+
+    def prepare(self):
+        self.subcmd = 'record'
+        self.option = '--srcline'
+        return self.runcmd()
+
+    def setup(self):
+        self.subcmd = 'replay'
+        self.option = '--srcline'
+
+    def sort(self, output):
+        """ This function post-processes output of the test to be compared .
+            It ignores blank and comment (#) lines and remaining functions.  """
+        result = []
+        before_main = True
+        for ln in output.split('\n'):
+            if ln.find(' | main()') > 0:
+                before_main = False
+            if before_main:
+                continue
+            # ignore result of remaining functions which follows a blank line
+            if ln.strip() == '':
+                break
+
+            func = ln.split('|', 1)[-1].split('/*')
+
+            if len(func) < 2 :
+                result.append('%s' % (func[0]))
+            else :
+                result.append('%s %s' % (func[-2], func[-1][0:-3].split('/')[-1]))
+
+        return '\n'.join(result)

--- a/uftrace.c
+++ b/uftrace.c
@@ -594,17 +594,14 @@ static int parse_option(struct opts *opts, int key, char *arg)
 
 	case 'A':
 		opts->args = opt_add_string(opts->args, arg);
-		opts->srcline = true;
 		break;
 
 	case 'R':
 		opts->retval = opt_add_string(opts->retval, arg);
-		opts->srcline = true;
 		break;
 
 	case 'a':
 		opts->auto_args = true;
-		opts->srcline = true;
 		break;
 
 	case 'l':
@@ -1465,7 +1462,7 @@ TEST_CASE(option_parsing2)
 	};
 	int argc = ARRAY_SIZE(argv);
 	int saved_debug = debug;
-	
+
 	parse_options(argc, argv, &opts);
 
 	TEST_EQ(opts.mode, UFTRACE_MODE_REPLAY);

--- a/utils/field.c
+++ b/utils/field.c
@@ -3,7 +3,7 @@
 #include "utils/list.h"
 
 void print_header(struct list_head *output_fields, const char *prefix,
-		  const char *postfix, int space)
+		  const char *postfix, int space, bool new_line)
 {
 	struct display_field *field;
 	bool first = true;
@@ -18,7 +18,9 @@ void print_header(struct list_head *output_fields, const char *prefix,
 		first = false;
 	}
 
-	pr_out("   %s\n", postfix);
+	pr_out("   %s", postfix);
+	if (new_line)
+		pr_out("\n");
 }
 
 int print_field_data(struct list_head *output_fields, struct field_data *fd,

--- a/utils/field.h
+++ b/utils/field.h
@@ -50,7 +50,7 @@ static inline uint64_t effective_addr(uint64_t addr)
 }
 
 void print_header(struct list_head *output_fields, const char *prefix,
-		  const char *postfix, int space);
+		  const char *postfix, int space, bool new_line);
 int print_field_data(struct list_head *output_fields, struct field_data *fd,
 		     int space);
 int print_empty_field(struct list_head *output_fields, int space);


### PR DESCRIPTION
Show source location of each function with loaded debug_info.

'-g' and '-pg' options are required when compiling an executable
to have source line information like this.
```
  $ gcc -o t-abc -g -pg tests/s-abc.c
```
The '--srcline' option is required when using record command.
```
  $ uftrace record --srcline t-abc
```
The '--srcline' option is also required when using replay command.
```
  $ uftrace replay --srcline
    # DURATION     TID     FUNCTION [SOURCE]
       1.483 us [  3237] | __monstartup();
       0.658 us [  3237] | __cxa_atexit();
		[  3237] | main() { [tests/s-abc.c:26]
		[  3237] |   a() { [tests/s-abc.c:11]
		[  3237] |     b() { [tests/s-abc.c:16]
		[  3237] |       c() { [tests/s-abc.c:21]
       3.711 us [  3237] |         getpid();
       5.800 us [  3237] |       } /* c */ [tests/s-abc.c:21]
       6.950 us [  3237] |     } /* b */ [tests/s-abc.c:16]
       7.934 us [  3237] |   } /* a */ [tests/s-abc.c:11]
       9.085 us [  3237] | } /* main */ [tests/s-abc.c:26]
```
Fixed: #1159

Signed-off-by: Eunseon Lee <esintospace@gmail.com>