### PR TITLE
test: Enable sub-case with -finstrument-functions option in srcline tests

### DIFF
--- a/tests/t068_filter_time_A.py
+++ b/tests/t068_filter_time_A.py
@@ -15,13 +15,6 @@ class TestCase(TestBase):
    2.107 ms [23157] | } /* main */
 """)
 
-    def build(self, name, cflags='', ldflags=''):
-        # cygprof doesn't support return value now
-        if cflags.find('-finstrument-functions') >= 0:
-            return TestBase.TEST_SKIP
-
-        return TestBase.build(self, name, cflags, ldflags)
-
     def setup(self):
         self.option  = '-t 1ms -R mem_alloc@retval '
         self.option += '-A mem_free@arg1 -A usleep@plt,arg1'

--- a/tests/t235_report_srcline.py
+++ b/tests/t235_report_srcline.py
@@ -16,12 +16,6 @@ class TestCase(TestBase):
     0.186 us    0.186 us           1  __cxa_atexit
 """, cflags='-g')
 
-    def build(self, name, cflags='', ldflags=''):
-        if cflags.find('-finstrument-functions') >= 0:
-            return TestBase.TEST_SKIP
-
-        return TestBase.build(self, name, cflags, ldflags)
-
     def prepare(self):
         self.subcmd = 'record'
         self.option = '--srcline'

--- a/tests/t236_replay_srcline.py
+++ b/tests/t236_replay_srcline.py
@@ -19,12 +19,6 @@ class TestCase(TestBase):
    2.644 us [ 19939] | } /* main at tests/s-abc.c:26 */
 """, cflags='-g')
 
-    def build(self, name, cflags='', ldflags=''):
-        if cflags.find('-finstrument-functions') >= 0:
-            return TestBase.TEST_SKIP
-
-        return TestBase.build(self, name, cflags, ldflags)
-
     def prepare(self):
         self.subcmd = 'record'
         self.option = '--srcline'


### PR DESCRIPTION
.dbg files are generated for binary files built with -g and -finstrument-functions
options together according to the latest changes.

It doesn't need to skip the test for case above in test cases for srcline anymore,
so it is deleted.

Signed-off-by: Eunseon Lee <esintospace@gmail.com>