### PR TITLE
tests: Fix various test failures in i386 and aarch64

### DIFF
--- a/arch/aarch64/mcount.S
+++ b/arch/aarch64/mcount.S
@@ -38,7 +38,7 @@ ENTRY(mcount_return)
 
 	/* save return values */
 	stp	x0, x1, [sp, #-16]!
-	stp	d0, d1, [sp, #-16]!
+	str	q0, [sp, #-16]!
 
 	/*
 	 * save indirect result location register
@@ -55,7 +55,7 @@ ENTRY(mcount_return)
 	ldr	x8, [sp], #16
 
 	/* restore return values */
-	ldp	d0, d1, [sp], #16
+	ldr	q0, [sp], #16
 	ldp	x0, x1, [sp], #16
 
 	/* restore frame pointer */

--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -1183,9 +1183,11 @@ int command_replay(int argc, char *argv[], struct opts *opts)
 
 	if (!opts->flat && peek_rstack(&handle, &task) == 0)
 		print_header(&output_fields, "#", "FUNCTION", 1, false);
-	if (opts->srcline)
-		pr_gray(" [SOURCE]");
-	pr_out("\n");
+	if (!list_empty(&output_fields)) {
+		if (opts->srcline)
+			pr_gray(" [SOURCE]");
+		pr_out("\n");
+	}
 
 	while (read_rstack(&handle, &task) == 0 && !uftrace_done) {
 		struct uftrace_record *rstack = task->rstack;

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -328,6 +328,7 @@ static const char *skip_syms[] = {
 	"__cxa_begin_catch",
 	"__cxa_end_catch",
 	"__cxa_finalize",
+	"__gxx_personality_v0",
 	"_Unwind_Resume",
 };
 

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -381,6 +381,8 @@ class TestBase:
         return os.path.exists('%s/check-deps/' % self.basedir + item)
 
     def check_perf_paranoid(self):
+        if not 'perf' in TestBase.feature:
+            return False
         try:
             f = open('/proc/sys/kernel/perf_event_paranoid')
             v = int(f.readline())

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -31,6 +31,7 @@ class TestBase:
 
     default_cflags = ['-fno-inline', '-fno-builtin', '-fno-ipa-cp',
                       '-fno-omit-frame-pointer', '-D_FORTIFY_SOURCE=0']
+    feature = set()
 
     def __init__(self, name, result, lang='C', cflags='', ldflags='', sort='task', serial=False):
         _tmp = tempfile.mkdtemp(prefix='test_%s_' % name)
@@ -46,6 +47,7 @@ class TestBase:
         self.subcmd = 'live'
         self.option = ''
         self.exearg = 't-' + name
+        self.test_feature()
 
     def set_debug(self, dbg):
         self.debug = dbg
@@ -56,6 +58,17 @@ class TestBase:
 
     def gen_port(self):
         self.port = random.randint(40000, 50000)
+
+    def test_feature(self):
+        try:
+            p = sp.Popen(self.uftrace_cmd + ' --version', shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
+            uftrace_version = p.communicate()[0].decode(errors='ignore')
+            s = uftrace_version.split()
+            for i in range(3, len(s) - 1):
+                self.feature.add(s[i])
+            return True
+        except:
+            return False
 
     def convert_abs_path(self, build_cmd):
         cmd = build_cmd.split()

--- a/tests/t051_return.py
+++ b/tests/t051_return.py
@@ -16,7 +16,8 @@ class TestCase(TestBase):
 """)
 
     def fixup(self, cflags, result):
-        if TestBase.get_elf_machine(self) == 'arm':
+        machine = TestBase.get_elf_machine(self)
+        if machine == 'arm' or machine == 'aarch64':
             return result.replace('memset', """memset();
    1.440 us [12703] |     memcpy""");
 

--- a/tests/t083_arg_float.py
+++ b/tests/t083_arg_float.py
@@ -31,3 +31,5 @@ class TestCase(TestBase):
             # argument count follows the size of type
             self.option = self.option.replace('float_mul@fparg1/64,fparg2/32',
                                               'float_mul@fparg1/64,fparg3/32')
+            self.option = self.option.replace('float_div@fparg1,fparg2',
+                                              'float_div@fparg1/64,fparg3/64')

--- a/tests/t201_arg_dwarf1.py
+++ b/tests/t201_arg_dwarf1.py
@@ -18,6 +18,8 @@ class TestCase(TestBase):
 """, cflags='-g')
 
     def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
         if cflags.find('-finstrument-functions') >= 0:
             return TestBase.TEST_SKIP
 

--- a/tests/t202_arg_dwarf2.py
+++ b/tests/t202_arg_dwarf2.py
@@ -15,6 +15,8 @@ class TestCase(TestBase):
 """, lang='C++', cflags='-g -std=c++11')
 
     def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
         if cflags.find('-finstrument-functions') >= 0:
             return TestBase.TEST_SKIP
 

--- a/tests/t203_arg_dwarf3.py
+++ b/tests/t203_arg_dwarf3.py
@@ -25,6 +25,8 @@ class TestCase(TestBase):
 """, lang='C++', cflags='-g')
 
     def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
         if cflags.find('-finstrument-functions') >= 0:
             return TestBase.TEST_SKIP
 

--- a/tests/t204_arg_dwarf4.py
+++ b/tests/t204_arg_dwarf4.py
@@ -14,6 +14,8 @@ class TestCase(TestBase):
 """, lang='C++', cflags='-g')
 
     def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
         if cflags.find('-finstrument-functions') >= 0:
             return TestBase.TEST_SKIP
 

--- a/tests/t205_arg_auto4.py
+++ b/tests/t205_arg_auto4.py
@@ -17,6 +17,8 @@ class TestCase(TestBase):
 """, cflags='-g')
 
     def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
         # cygprof doesn't support arguments now
         if cflags.find('-finstrument-functions') >= 0:
             return TestBase.TEST_SKIP

--- a/tests/t206_arg_enum2.py
+++ b/tests/t206_arg_enum2.py
@@ -15,6 +15,8 @@ class TestCase(TestBase):
 """, cflags='-g')
 
     def build(self, name, cflags='', ldflags=''):
+        if not "dwarf" in self.feature:
+            return TestBase.TEST_SKIP
         # cygprof doesn't support arguments now
         if cflags.find('-finstrument-functions') >= 0:
             return TestBase.TEST_SKIP

--- a/tests/t208_watch_cpu.py
+++ b/tests/t208_watch_cpu.py
@@ -37,3 +37,6 @@ class TestCase(TestBase):
             result.append(func)
 
         return '\n'.join(result)
+
+    def fixup(self, cflags, result):
+        return re.sub(r'.*/\* linux:schedule \*/\n', '', result)

--- a/tests/t213_arg_symbol.py
+++ b/tests/t213_arg_symbol.py
@@ -15,6 +15,8 @@ class TestCase(TestBase):
 """)
 
     def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
         # cygprof doesn't support arguments now
         if cflags.find('-finstrument-functions') >= 0:
             return TestBase.TEST_SKIP

--- a/tests/t235_report_srcline.py
+++ b/tests/t235_report_srcline.py
@@ -16,6 +16,11 @@ class TestCase(TestBase):
     0.186 us    0.186 us           1  __cxa_atexit
 """, cflags='-g')
 
+    def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
+        return TestBase.build(self, name, cflags, ldflags)
+
     def prepare(self):
         self.subcmd = 'record'
         self.option = '--srcline'

--- a/tests/t236_replay_srcline.py
+++ b/tests/t236_replay_srcline.py
@@ -19,6 +19,11 @@ class TestCase(TestBase):
    2.644 us [ 19939] | } /* main at tests/s-abc.c:26 */
 """, cflags='-g')
 
+    def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
+        return TestBase.build(self, name, cflags, ldflags)
+
     def prepare(self):
         self.subcmd = 'record'
         self.option = '--srcline'


### PR DESCRIPTION
This PR fixes various test failures in i386 and aarch64.

i386 failures:
```
  083 arg_float           : NG NG NG NG NG SK SK SK SK SK
  116 field_none          : NG NG NG NG NG NG NG NG NG NG
  185 exception2          : NG NG NG NG NG NG NG NG NG NG
  186 exception3          : NG NG NG NG NG NG NG NG NG NG
  201 arg_dwarf1          : NG NG NG NG NG SK SK SK SK SK
  202 arg_dwarf2          : NG NG NG NG NG SK SK SK SK SK
  203 arg_dwarf3          : NG NG NG NG NG SK SK SK SK SK
  204 arg_dwarf4          : NG NG NG NG NG SK SK SK SK SK
  205 arg_auto4           : NG NG NG NG NG SK SK SK SK SK
  206 arg_enum2           : NG NG NG NG NG SK SK SK SK SK
  213 arg_symbol          : NG NG NG NG NG SK SK SK SK SK
```
aarch64 failures:
```
  051 return              : NZ NZ NZ NZ NZ NG NG NG NG NG
```