### PR TITLE
graph: Show source location with --srcline option.

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -1133,7 +1133,7 @@ static void dump_flame_task_rstack(struct uftrace_dump_ops *ops,
 	if (graph->node == NULL)
 		graph->node = &flame_graph.root;
 
-	graph_add_node(graph, frs->type, name, sizeof(struct uftrace_graph_node));
+	graph_add_node(graph, frs->type, name, sizeof(struct uftrace_graph_node), NULL);
 }
 
 static void dump_flame_kernel_rstack(struct uftrace_dump_ops *ops,
@@ -1155,7 +1155,7 @@ static void dump_flame_kernel_rstack(struct uftrace_dump_ops *ops,
 	if (graph->node == NULL)
 		graph->node = &flame_graph.root;
 
-	graph_add_node(graph, rec->type, name, sizeof(struct uftrace_graph_node));
+	graph_add_node(graph, rec->type, name, sizeof(struct uftrace_graph_node), NULL);
 }
 
 static void dump_flame_footer(struct uftrace_dump_ops *ops,
@@ -1210,7 +1210,7 @@ static void dump_graphviz_task_rstack(struct uftrace_dump_ops *ops,
 	if (graph->node == NULL)
 		graph->node = &graphviz_graph.root;
 
-	graph_add_node(graph, frs->type, name, sizeof(struct uftrace_graph_node));
+	graph_add_node(graph, frs->type, name, sizeof(struct uftrace_graph_node), NULL);
 }
 
 static void dump_graphviz_kernel_rstack(struct uftrace_dump_ops *ops,
@@ -1232,7 +1232,7 @@ static void dump_graphviz_kernel_rstack(struct uftrace_dump_ops *ops,
 	if (graph->node == NULL)
 		graph->node = &graphviz_graph.root;
 
-	graph_add_node(graph, rec->type, name, sizeof(struct uftrace_graph_node));
+	graph_add_node(graph, rec->type, name, sizeof(struct uftrace_graph_node), NULL);
 }
 
 static void print_graph_to_graphviz(struct uftrace_graph_node *node,

--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -447,7 +447,7 @@ static int build_tui_node(struct uftrace_task_reader *task,
 	else  /* rec->type == UFTRACE_LOST */
 		return 0;
 
-	graph_add_node(tg, rec->type, name, sizeof(struct tui_graph_node));
+	graph_add_node(tg, rec->type, name, sizeof(struct tui_graph_node), NULL);
 	if (tg->node && tg->node != &graph->root) {
 		graph_node = (struct tui_graph_node *)tg->node;
 		graph_node->graph = graph;
@@ -507,7 +507,7 @@ static void add_remaining_node(struct opts *opts, struct uftrace_data *handle)
 
 			update_report_node(task, name, tg);
 			graph_add_node(tg, UFTRACE_EXIT, name,
-				       sizeof(struct tui_graph_node));
+				       sizeof(struct tui_graph_node), NULL);
 
 			symbol_putname(sym, name);
 		}

--- a/doc/uftrace-graph.md
+++ b/doc/uftrace-graph.md
@@ -32,6 +32,9 @@ GRAPH OPTIONS
 :   Print task graph instead of normal function graph.  The each node in the
     output shows process or thread(printed in green color).
 
+\--srcline
+:   Show source location of each function if available.
+
 
 COMMON OPTIONS
 ==============
@@ -242,6 +245,24 @@ created `t-abc` process, and also created many threads whose names are all
 
 Please note that the indentation depth of thread is different from process.
 
+Running the `graph` command with `--srcline` option shows source location
+in call graph like below:
+
+    $ uftrace record --srcline t-abc
+    $ uftrace graph --srcline
+    # Function Call Graph for 't-abc' (session: 60195bac953d8736)
+    ========== FUNCTION CALL GRAPH ==========
+    # TOTAL TIME   FUNCTION [SOURCE]
+      8.909 us : (1) t-abc
+      1.260 us :  +-(1) __monstartup
+               :  |
+      0.179 us :  +-(1) __cxa_atexit
+               :  |
+      7.470 us :  +-(1) main [tests/s-abc.c:26]
+      5.522 us :    (1) a [tests/s-abc.c:11]
+      4.912 us :    (1) b [tests/s-abc.c:16]
+      4.176 us :    (1) c [tests/s-abc.c:21]
+      0.794 us :    (1) getpid
 
 FIELDS
 ======

--- a/tests/t247_graph_srcline.py
+++ b/tests/t247_graph_srcline.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'sort', result="""
+# Function Call Graph for 'main' (session: de27777d0a966d5a)
+=============== BACKTRACE ===============
+ backtrace #0: hit 1, time  13.120 ms
+   [0] main (0x56366ebab7fc)
+
+========== FUNCTION CALL GRAPH ==========
+# TOTAL TIME   FUNCTION [SOURCE]
+   13.120 ms : (1) main
+  694.492 us :  +-(2) foo [/home/eslee/soft/uftrace/tests/s-sort.c:10]
+  688.800 us :  | (6) loop [/home/eslee/soft/uftrace/tests/s-sort.c:3]
+             :  | 
+   10.748 ms :  +-(1) bar [/home/eslee/soft/uftrace/tests/s-sort.c:17]
+   10.183 ms :    (1) usleep
+""", sort='graph', cflags='-g')
+
+    def prepare(self):
+        self.subcmd = 'record'
+        self.option = '--srcline'
+        self.exearg = 't-' + self.name
+        return self.runcmd()
+
+    def setup(self):
+        self.subcmd = 'graph'
+        self.option = '--srcline'
+        self.exearg = 'main'
+
+    def sort(self, output):
+        """ This function post-processes output of the test to be compared.
+            It ignores blank and comment (#) lines and header lines.  """
+        result = []
+        mode = 0
+        for ln in output.split('\n'):
+            if ln.strip() == '' or ln.startswith('#'):
+                continue
+            # A graph result consists of backtrace and calling functions
+            if ln.startswith('=============== BACKTRACE ==============='):
+                mode = 1
+                continue
+            if ln.startswith('========== FUNCTION CALL GRAPH =========='):
+                mode = 2
+                continue
+            if mode == 1:
+                if ln.startswith(' backtrace #'):
+                    result.append(ln.split(',')[0])  # remove time part
+                if ln.startswith('   ['):
+                    result.append(ln.split('(')[0])  # remove '(addr)' part
+            if mode == 2:
+                if " : " in ln:
+                    func = ln.split(':', 1)[1].split('[')  # remove time part
+                    if len(func) < 2 :
+                        result.append('%s' % (func[-1]))
+                    else :
+                        # extract basename and line number of source location
+                        result.append('%s %s' % (func[-2], func[-1][0:-1].split('/')[-1]))
+                else:
+                    result.append(ln)
+
+        return '\n'.join(result)

--- a/utils/graph.h
+++ b/utils/graph.h
@@ -19,6 +19,7 @@ struct uftrace_graph_node {
 	struct list_head		head;
 	struct list_head		list;
 	struct uftrace_graph_node	*parent;
+	struct debug_location		*loc;
 };
 
 enum uftrace_graph_node_type {
@@ -62,6 +63,7 @@ struct uftrace_task_graph * graph_get_task(struct uftrace_task_reader *task,
 void graph_remove_task(void);
 
 int graph_add_node(struct uftrace_task_graph *tg, int type, char *name,
-		   size_t node_size);
+		   size_t node_size,
+		   struct debug_location* loc);
 
 #endif /* UFTRACE_GRAPH_H */


### PR DESCRIPTION
Show source location of each function with loaded debug_info.

'-g' and '-pg' options are required when compiling an executable
to have source line information like this.
```
  $ gcc -o t-abc -g -pg tests/s-abc.c
```
The '--srcline' option is required when using record command.
```
  $ uftrace record --srcline t-abc
```
The '--srcline' option is also required when using graph command.
```
  $ uftrace graph --srcline
  # Function Call Graph for 't-abc' (session: 60195bac953d8736)
  ========== FUNCTION CALL GRAPH ==========
  # TOTAL TIME   FUNCTION [SOURCE]
    8.909 us : (1) t-abc
    1.260 us :  +-(1) __monstartup
             :  |
    0.179 us :  +-(1) __cxa_atexit
             :  |
    7.470 us :  +-(1) main [tests/s-abc.c:26]
    5.522 us :    (1) a [tests/s-abc.c:11]
    4.912 us :    (1) b [tests/s-abc.c:16]
    4.176 us :    (1) c [tests/s-abc.c:21]
    0.794 us :    (1) getpid
```
Signed-off-by: Eunseon Lee <esintospace@gmail.com>