### PR TITLE
build: Add -Wdeclaration-after-statement compiler flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ export ARCH CC AR LD RM srcdir objdir LDFLAGS
 
 COMMON_CFLAGS := -D_GNU_SOURCE $(CFLAGS) $(CPPFLAGS)
 COMMON_CFLAGS += -iquote $(srcdir) -iquote $(objdir) -iquote $(srcdir)/arch/$(ARCH)
+COMMON_CFLAGS += -Wdeclaration-after-statement
 #CFLAGS-DEBUG = -g -D_GNU_SOURCE $(CFLAGS_$@)
 COMMON_LDFLAGS := -lrt -ldl -pthread -Wl,-z,noexecstack $(LDFLAGS)
 ifneq ($(elfdir),)

--- a/arch/x86_64/mcount-insn.c
+++ b/arch/x86_64/mcount-insn.c
@@ -89,6 +89,9 @@ static int handle_pic(cs_insn *insn, uint8_t insns[],
 		      struct mcount_disasm_info *info)
 {
 	cs_x86 *x86 = &insn->detail->x86;
+	cs_x86_op *opnd1;
+	cs_x86_op *opnd2;
+	uint64_t PC_base;
 
 #define REX   0
 #define OPND  1
@@ -112,8 +115,8 @@ static int handle_pic(cs_insn *insn, uint8_t insns[],
 		goto out;
 
 	/* according to intel manual, lea instruction takes 2 operand */
-	cs_x86_op *opnd1 = &x86->operands[0];
-	cs_x86_op *opnd2 = &x86->operands[1];
+	opnd1 = &x86->operands[0];
+	opnd2 = &x86->operands[1];
 
 	/* check PC-relative addressing mode */
 	if (opnd2->type != X86_OP_MEM || opnd2->mem.base != X86_REG_RIP)
@@ -136,7 +139,7 @@ static int handle_pic(cs_insn *insn, uint8_t insns[],
 	/* convert LEA to MOV instruction */
 	mov_insns[OPND] = mov_operands[opnd_reg(opnd1->reg)];
 
-	uint64_t PC_base = insn->address + insn->size + opnd2->mem.disp;
+	PC_base = insn->address + insn->size + opnd2->mem.disp;
 	memcpy(&mov_insns[IMM], &PC_base, sizeof(PC_base));
 
 	memcpy(insns, mov_insns, sizeof(mov_insns));

--- a/cmds/recv.c
+++ b/cmds/recv.c
@@ -500,10 +500,12 @@ static void recv_trace_end(int sock, int efd)
 }
 
 static void execute_run_cmd(char **argv) {
+	int pid;
+
 	if (!argv)
 		return;
 
-	int pid = fork();
+	pid = fork();
 	if (pid < 0)
 		pr_err("cannot start child process");
 

--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -594,6 +594,7 @@ void get_argspec_string(struct uftrace_task_reader *task,
 				print_args("NULL");
 			else if (needs_json) {
 				char *p = str;
+
 				print_args("\\\"");
 				while (*p) {
 					char c = *p++;
@@ -602,10 +603,10 @@ void get_argspec_string(struct uftrace_task_reader *task,
 				print_args("\\\"");
 			}
 			else {
+				char *p = str;
+
 				print_args("%s", color_string);
 				print_args("\"");
-
-				char *p = str;
 				while (*p) {
 					char c = *p++;
 					if (c & 0x80) {

--- a/cmds/report.c
+++ b/cmds/report.c
@@ -491,8 +491,9 @@ char * convert_sort_keys(char *sort_keys)
 		return xstrdup(default_sort_key[avg_mode]);
 
 	if (avg_mode == AVG_NONE) {
-		new_keys = xstrdup(sort_keys);
-		char *s = new_keys;
+		char *s;
+
+		s = new_keys = xstrdup(sort_keys);
 		while (*s) {
 			if (*s == '-')
 				*s = '_';

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -177,12 +177,16 @@ setup:
 	handle->tasks = xmalloc(sizeof(*handle->tasks) * handle->nr_tasks);
 
 	for (i = 0; i < handle->nr_tasks; i++) {
+		bool found;
+		int tid;
+		struct uftrace_task_reader *task;
+
 		if (handle->info.tids == NULL)
 			pr_err_ns("The info file is broken: missing tids\n");
 
-		bool found = !tid_filter;
-		int tid = handle->info.tids[i];
-		struct uftrace_task_reader *task = &handle->tasks[i];
+		found = !tid_filter;
+		tid = handle->info.tids[i];
+		task = &handle->tasks[i];
 
 		prepare_task_handle(handle, task, tid);
 

--- a/utils/hashmap.c
+++ b/utils/hashmap.c
@@ -46,16 +46,19 @@ Hashmap* hashmap_create(size_t initial_capacity,
 			hash_t (*hash)(void* key),
 			bool (*equals)(void* keyA, void* keyB))
 {
+	Hashmap* map;
+	size_t minimum_bucket_count;
+
 	assert(hash != NULL);
 	assert(equals != NULL);
 
-	Hashmap* map = malloc(sizeof(Hashmap));
+	map = malloc(sizeof(Hashmap));
 	if (map == NULL) {
 		return NULL;
 	}
 
 	// 0.75 load factor.
-	size_t minimum_bucket_count = initial_capacity * 4 / 3;
+	minimum_bucket_count = initial_capacity * 4 / 3;
 	map->bucket_count = 1;
 	while (map->bucket_count <= minimum_bucket_count) {
 		// Bucket count must be power of 2.
@@ -102,14 +105,16 @@ static void expand_if_necessary(Hashmap* map)
 	if (map->size > (map->bucket_count * 3 / 4)) {
 		// Start off with a 0.33 load factor.
 		size_t new_bucket_count = map->bucket_count << 1;
-		Entry** new_buckets = calloc(new_bucket_count, sizeof(Entry*));
+		Entry** new_buckets;
+		size_t i;
+
+		new_buckets = calloc(new_bucket_count, sizeof(Entry*));
 		if (new_buckets == NULL) {
 			// Abort expansion.
 			return;
 		}
 
 		// Move over existing entries.
-		size_t i;
 		for (i = 0; i < map->bucket_count; i++) {
 			Entry* entry = map->buckets[i];
 			while (entry != NULL) {
@@ -272,12 +277,15 @@ void* hashmap_memoize(Hashmap* map, void* key,
 
 		// Add a new entry.
 		if (current == NULL) {
+			void* value;
+
 			*p = create_entry(key, hash, NULL);
 			if (*p == NULL) {
 				errno = ENOMEM;
 				return NULL;
 			}
-			void* value = initial_value(key, context);
+
+			value = initial_value(key, context);
 			(*p)->value = value;
 			map->size++;
 			expand_if_necessary(map);


### PR DESCRIPTION
The -Wdeclaration-after-statement option makes a warning when a
declaration is found after a statement in a block.  It makes easier to
identify when breaking the coding style showing the following warning.
```
  warning: ISO C90 forbids mixed declarations and code
```
It makes some warnings in the existing code so this patch also fixes
those warnings together.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>