### PR TITLE
Apply some misc fixes

### DIFF
--- a/arch/aarch64/mcount-dynamic.c
+++ b/arch/aarch64/mcount-dynamic.c
@@ -21,7 +21,6 @@ extern void __dentry__(void);
 
 static void save_orig_code(struct mcount_disasm_info *info)
 {
-	struct mcount_orig_insn *orig;
 	uint32_t jmp_insn[6] = {
 		0x58000050,     /* LDR  ip0, addr */
 		0xd61f0200,     /* BR   ip0 */
@@ -37,7 +36,7 @@ static void save_orig_code(struct mcount_disasm_info *info)
 
 	/* make sure info.addr same as when called from __dentry__ */
 	info->addr += CODE_SIZE;
-	orig = mcount_save_code(info, jmp_insn, jmp_insn_size);
+	mcount_save_code(info, jmp_insn, jmp_insn_size);
 	info->addr -= CODE_SIZE;
 }
 

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -50,7 +50,6 @@ struct code_page {
 
 static LIST_HEAD(code_pages);
 
-#define HASHMAP_INIT_VALUE 50000
 static struct Hashmap *code_hmap;
 
 static struct mcount_orig_insn *create_code(struct Hashmap *map,

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -73,8 +73,8 @@ static struct mcount_orig_insn *lookup_code(struct Hashmap *map,
 	return entry;
 }
 
-struct mcount_orig_insn *mcount_save_code(struct mcount_disasm_info *info,
-					  void *jmp_insn, unsigned jmp_size)
+void mcount_save_code(struct mcount_disasm_info *info,
+		      void *jmp_insn, unsigned jmp_size)
 {
 	struct code_page *cp = NULL;
 	struct mcount_orig_insn *orig;
@@ -123,7 +123,6 @@ struct mcount_orig_insn *mcount_save_code(struct mcount_disasm_info *info,
 	memcpy(orig->insn + info->copy_size, jmp_insn, jmp_size);
 
 	cp->pos += patch_size;
-	return orig;
 }
 
 void mcount_freeze_code(void)

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -449,8 +449,8 @@ struct mcount_disasm_info {
 	bool			has_jump;
 };
 
-struct mcount_orig_insn *mcount_save_code(struct mcount_disasm_info *info,
-					  void *jmp_insn, unsigned jmp_size);
+void mcount_save_code(struct mcount_disasm_info *info,
+		      void *jmp_insn, unsigned jmp_size);
 void *mcount_find_code(unsigned long addr);
 struct mcount_orig_insn * mcount_find_insn(unsigned long addr);
 void mcount_freeze_code(void);

--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -811,7 +811,7 @@ int record_kernel_tracing(struct uftrace_kernel_writer *kernel)
 		bytes += n;
 	}
 
-	pr_dbg2("kernel ftrace record wrote %zd bytes\n", bytes);
+	pr_dbg3("kernel ftrace record wrote %zd bytes\n", bytes);
 	return bytes;
 }
 


### PR DESCRIPTION
This PR applies some misc fixes as follows.
- mcount: Remove unused macro HASHMAP_INIT_VALUE
- kernel: Lower the debug level for record wrote message
- mcount: Make the return type of mcount_save_code to void