### PR TITLE
configure: check if make and gcc exist or not and change error message format

### DIFF
--- a/configure
+++ b/configure
@@ -120,7 +120,7 @@ if [ ! -z "$arch" ]; then
         export CFLAGS="-m32 $CFLAGS"
         export LDFLAGS="-m32 $LDFLAGS"
     else
-        echo "$arch is not a supported architecture"
+        echo "Error: '$arch' is not a supported architecture" >&2
         exit 1
     fi
 fi
@@ -168,7 +168,7 @@ export CC CFLAGS LD LDFLAGS
 check_command() {
 	if ! command -v $1 &>/dev/null
 	then
-		echo "'$1' command is not found"
+		echo "Error: '$1' command is not found" >&2
 		exit 1
 	fi
 }

--- a/configure
+++ b/configure
@@ -165,6 +165,17 @@ MAKEOVERRIDES=
 
 export CC CFLAGS LD LDFLAGS
 
+check_command() {
+	if ! command -v $1 &>/dev/null
+	then
+		echo "'$1' command is not found"
+		exit 1
+	fi
+}
+
+check_command make
+check_command ${CC}
+
 make -siC ${srcdir}/check-deps check-clean
 make -siC ${srcdir}/check-deps check-build
 


### PR DESCRIPTION
This is related issue #1137 

It checks if `make` and `${CC}` and adds `Error:` prefix to indicate explicit error.