### PR TITLE
script: Fix script_context initialization

### DIFF
--- a/cmds/script.c
+++ b/cmds/script.c
@@ -41,7 +41,7 @@ static int run_script_for_rstack(struct uftrace_data *handle,
 	task->timestamp = rstack->time;
 
 	if (rstack->type == UFTRACE_ENTRY) {
-		struct script_context sc_ctx;
+		struct script_context sc_ctx = { 0, };
 		struct fstack *fstack;
 		int depth;
 		struct uftrace_trigger tr = {
@@ -78,7 +78,7 @@ static int run_script_for_rstack(struct uftrace_data *handle,
 		script_uftrace_entry(&sc_ctx);
 	}
 	else if (rstack->type == UFTRACE_EXIT) {
-		struct script_context sc_ctx;
+		struct script_context sc_ctx = { 0, };
 		struct fstack *fstack;
 
 		/* function exit */


### PR DESCRIPTION
This patch fixes the regression for 169 script_args because of the
following commit.

  d8423932 build: Add -Wdeclaration-after-statement compiler flag

It initializes 'struct script_context' without designated initialization
, but missed to zero clear the other fields, so the following test fails
as follows.
```
  t169_script_args: diff result of -pg -O0
  --- expect      2020-09-13 10:55:23.717086273 +0100
  +++ result      2020-09-13 10:55:23.717086273 +0100
  @@ -1 +1,2 @@
   fopen(/dev/null)
  +fclose(/dev/null)

  169 script_args         : NG
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>