### PR TITLE
dwarf: Fix invalid enum spec error

### DIFF
--- a/utils/dwarf.c
+++ b/utils/dwarf.c
@@ -362,7 +362,7 @@ static char * make_enum_name(Dwarf_Die *die)
 
 	off = dwarf_cuoffset(die);
 
-	xasprintf(&enum_name, "%s_%lx", basename(cu_name), off);
+	xasprintf(&enum_name, "_%s_%lx", basename(cu_name), off);
 
 	/* replace forbidden characters */
 	tmp = enum_name;


### PR DESCRIPTION
The following anonymous enum type makes an invalid enum spec error.
```c
  $ cat 7zFile.c
  typedef enum {
    SZ_SEEK_SET = 0,
    SZ_SEEK_CUR = 1,
    SZ_SEEK_END = 2
  } ESzSeek;

  void File_Seek(ESzSeek origin) {}

  int main() {
    File_Seek(SZ_SEEK_CUR);
  }
```
The uftrace output shows error messages as follows.
```
  $ gcc -pg -g 7zFile.c
  $ uftrace -a a.out
  Usage: invalid enum spec: e:7zFile_c_2d
  Usage: invalid enum spec: e:7zFile_c_2d
  # DURATION     TID     FUNCTION
     1.066 us [ 20007] | __monstartup();
     0.431 us [ 20007] | __cxa_atexit();
              [ 20007] | main() {
     0.106 us [ 20007] |   File_Seek();
     0.528 us [ 20007] | } = 0; /* main */
```
It's because enum type name cannot begin with a number, but the
anonymous enum type can begin with a numberic number, which is not
possible for normal enum type names, but uftrace cannot properly parse
the following enum statement.
```
  enum 7zFile_c_2d { SZ_SEEK_SET=0,SZ_SEEK_CUR=1,SZ_SEEK_END=2 }
```
This patch fixes the parse erorr by making make_enum_name begins with
'_' for the first character so '7zFile_c_2d' will become '_7zFile_c_2d'.

Fixed: #1188

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>