### PR TITLE
dwarf: Fix the incorrect enum display problem

### DIFF
--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -714,12 +714,12 @@ void get_argspec_string(struct uftrace_task_reader *task,
 
 			map = find_map(&s->symtabs, task->rstack->addr);
 			if (map == NULL || map->mod == NULL) {
-				print_args("<ENUM?> %lx", val.i);
+				print_args("<ENUM?> %x", (int)val.i);
 				goto next;
 			}
 
 			dinfo = &map->mod->dinfo;
-			estr = get_enum_string(&dinfo->enums, spec->enum_str, val.i);
+			estr = get_enum_string(&dinfo->enums, spec->enum_str, (int)val.i);
 			if (strstr(estr, "|") && strcmp("|", color_enum_or)) {
 				struct strv enum_vals = STRV_INIT;
 

--- a/utils/auto-args.c
+++ b/utils/auto-args.c
@@ -511,7 +511,7 @@ struct enum_def * find_enum_def(struct rb_root *root, char *name)
 	return NULL;
 }
 
-char * convert_enum_val(struct enum_def *e_def, long val)
+char * convert_enum_val(struct enum_def *e_def, int val)
 {
 	struct enum_val *e_val;
 	char *str = NULL;
@@ -537,22 +537,22 @@ char * convert_enum_val(struct enum_def *e_def, long val)
 	if (str && val) {
 		char *tmp;
 
-		xasprintf(&tmp, "%s+%#lx", str, val);
+		xasprintf(&tmp, "%s+%#x", str, val);
 		free(str);
 		str = tmp;
 	}
 	else if (unlikely(str == NULL)) {
 		if (labs(val) > 100000)
-			xasprintf(&str, "%#lx", val);
+			xasprintf(&str, "%#x", val);
 		else
-			xasprintf(&str, "%ld", val);
+			xasprintf(&str, "%d", val);
 	}
 
 	return str;
 }
 
 /* caller should free the return value */
-char *get_enum_string(struct rb_root *root, char *name, long val)
+char *get_enum_string(struct rb_root *root, char *name, int val)
 {
 	struct enum_def *e_def;
 	char *ret;
@@ -562,7 +562,7 @@ char *get_enum_string(struct rb_root *root, char *name, long val)
 		e_def = find_enum_def(&auto_enum, name);
 
 	if (e_def == NULL)
-		xasprintf(&ret, "%ld", val);
+		xasprintf(&ret, "%d", val);
 	else
 		ret = convert_enum_val(e_def, val);
 

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -223,7 +223,7 @@ char *get_auto_retspec_str(void);
 char *get_auto_enum_str(void);
 int extract_trigger_args(char **pargs, char **prets, char *trigger);
 int parse_enum_string(char *enum_str, struct rb_root *root);
-char *get_enum_string(struct rb_root *root, char *name, long val);
+char *get_enum_string(struct rb_root *root, char *name, int val);
 void save_enum_def(struct rb_root *root, FILE *fp);
 void release_enum_def(struct rb_root *root);
 


### PR DESCRIPTION
The enum value can contain a negative value, but it's incorrectly
displayed in the current implementation.

Let's say there is a simple program as follows.
```c
  $ cat enum.c
  enum et {
          MINUS_ONE = -1,
          ZERO,
          ONE,
  };

  void foo(enum et e) {}

  int main() {
          foo(MINUS_ONE);
          return 0;
  }
```
The tracing output with auto-args is as follows.
```
  $ gcc -pg -g enum.c
  $ uftrace -a a.out
  # DURATION     TID     FUNCTION
              [ 56519] | main() {
     4.446 us [ 56519] |   foo(ONE|ZERO|MINUS_ONE+0xffffffff);
     4.957 us [ 56519] | } = 0; /* main */
```
The size of enum by default is 4, but uftrace currently expects the
sizes is to be sizeof(long) so 8.

So the negative value -1 in enum type is interpreted as 8 bytes so the
it reads more bytes than stored, but it can be interpreted incorrectly.

This patch assumes the size of enum is 4 so type casted as int type and
it fixes the problem.
```
  $ uftrace -a a.out
  # DURATION     TID     FUNCTION
              [ 22103] | main() {
     9.033 us [ 22103] |   foo(MINUS_ONE);
    11.284 us [ 22103] | } = 0; /* main */
```
Fixed: #1154

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>