### PR TITLE
i386: Fix a warning from -Wdeclaration-after-statement

### DIFF
--- a/arch/i386/mcount-support.c
+++ b/arch/i386/mcount-support.c
@@ -209,6 +209,8 @@ unsigned long *mcount_arch_parent_location(struct symtabs *symtabs,
 		};
 		unsigned long ret_addr;
 		unsigned long search_ret_addr;
+		bool found_main_ret = false;
+		int stack_index = 0;
 
 		ret_addr = *parent_loc;
 		parent_sym = find_symtabs(symtabs, ret_addr);
@@ -217,9 +219,6 @@ unsigned long *mcount_arch_parent_location(struct symtabs *symtabs,
 		child_name = symbol_getname(child_sym, child_ip);
 
 		// Assuming that this happens only in main..			
-		bool found_main_ret = false;
-		int stack_index = 0;
-
 		if (!(strcmp(find_main[0], parent_name) || 
 		      strcmp(find_main[1], child_name))) {
 			ret_addr = *parent_loc;


### PR DESCRIPTION
This patch fixes the following warning when building it for i386.
```
  .../arch/i386/mcount-support.c: In function ‘mcount_arch_parent_location’:
  .../arch/i386/mcount-support.c:220:3: warning: ISO C90 forbids mixed
    declarations and code [-Wdeclaration-after-statement]
    220 |   bool found_main_ret = false;
        |   ^~~~
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>