### PR TITLE
tests: Skip srcline tests when dwarf is not enabled

### DIFF
--- a/tests/t246_report_srcline2.py
+++ b/tests/t246_report_srcline2.py
@@ -15,6 +15,8 @@ class TestCase(TestBase):
 """, cflags='-g')
 
     def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
         if TestBase.build_libabc(self, cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
         return TestBase.build_libmain(self, name, 's-libmain.c',

--- a/tests/t247_graph_srcline.py
+++ b/tests/t247_graph_srcline.py
@@ -20,6 +20,10 @@ class TestCase(TestBase):
    10.183 ms :    (1) usleep
 """, sort='graph', cflags='-g')
 
+    def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
+
     def prepare(self):
         self.subcmd = 'record'
         self.option = '--srcline'


### PR DESCRIPTION
Before:
```
  246 report_srcline2     : NG NG NG NG NG NG NG NG NG NG
  247 graph_srcline       : NG NG NG NG NG NG NG NG NG NG
```
After:
```
  246 report_srcline2     : SK SK SK SK SK SK SK SK SK SK
  247 graph_srcline       : SK SK SK SK SK SK SK SK SK SK
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>