### PR TITLE
build: Hide stderr if python3-config not found

### DIFF
--- a/check-deps/Makefile
+++ b/check-deps/Makefile
@@ -21,7 +21,7 @@ CHECK_CFLAGS  = $(CFLAGS)  $(CFLAGS_$@) -Werror
 CHECK_LDFLAGS = $(LDFLAGS) $(LDFLAGS_$@)
 
 # python3.8 added --embed option
-ifneq ($(shell python3-config | grep embed),)
+ifneq ($(shell python3-config 2> /dev/null | grep embed),)
   EMBED := --embed
 endif
 


### PR DESCRIPTION
We get the following error messages when the system doesn't have
`python3-config` installed.
```
  $ ./configure
  /bin/sh: 1: python3-config: not found
  /bin/sh: 1: python3-config: not found
  uftrace detected system features:
          ...
```
So it'd be better to hide the stderr output to `/dev/null`.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>