### PR TITLE
kernel: Change kernel-cpuXX.dat from 600 to 644

### DIFF
--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -719,7 +719,7 @@ int start_kernel_tracing(struct uftrace_kernel_writer *kernel)
 		snprintf(buf, sizeof(buf), "%s/kernel-cpu%d.dat",
 			 kernel->output_dir, i);
 
-		kernel->fds[i] = open(buf, O_WRONLY | O_TRUNC | O_CREAT, 0600);
+		kernel->fds[i] = open(buf, O_WRONLY | O_TRUNC | O_CREAT, 0644);
 		if (kernel->fds[i] < 0) {
 			pr_dbg("failed to open output file: %s: %m\n", buf);
 			goto out;


### PR DESCRIPTION
The kernel tracing generates kernel-cpuXX.dat in 600 mode so it cannot
be read in other environments unlike other files that gives read
permission to other accounts.
```
  $ ls -l uftrace.data/
      ...
  -rw-r--r-- 1 root root   15910 Sep 29 09:15 info
  -rw-r--r-- 1 root root 4851625 Sep 29 09:15 kallsyms
  -rw------- 1 root root       0 Sep 29 09:15 kernel-cpu0.dat
  -rw------- 1 root root       0 Sep 29 09:15 kernel-cpu1.dat
      ...
```
It makes the recorded data not portable so the other user can see the
crash as follows.
```
  $ uftrace replay --no-pager
  Segmentation fault (core dumped)
```
The crash backtrace is as follows.
```
  $ uftrace replay --no-pager
  AddressSanitizer:DEADLYSIGNAL
  =================================================================
  ==37436==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000008
                  (pc 0x0000004afdad bp 0x7ffd328c53d0 sp 0x7ffd328c53c0 T0)
  ==37436==The signal is caused by a READ memory access.
  ==37436==Hint: address points to the zero page.
      #0 0x4afdac in list_del /home/honggyu/work/uftrace/utils/list.h:111
      #1 0x4b7428 in reset_rstack_list /home/honggyu/work/uftrace/utils/fstack.c:1079
      #2 0x46d4a1 in finish_kernel_data /home/honggyu/work/uftrace/utils/kernel.c:1322
      #3 0x46d060 in setup_kernel_data /home/honggyu/work/uftrace/utils/kernel.c:1284
      #4 0x483c87 in open_data_file /home/honggyu/work/uftrace/utils/data-file.c:605
      #5 0x4308e3 in command_replay /home/honggyu/work/uftrace/cmds/replay.c:1175
      #6 0x40c707 in main /home/honggyu/work/uftrace/uftrace.c:1345
      #7 0x7fef4dfe282f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
      #8 0x405e08 in _start (/home/honggyu/usr/bin/uftrace+0x405e08)
  AddressSanitizer can not provide additional info.
  SUMMARY: AddressSanitizer: SEGV /home/honggyu/work/uftrace/utils/list.h:111 in list_del
  ==37436==ABORTING
```
This patch changes the permission of kernel-cpuXX.dat file from 600 to
644 to avoid this kind of segfault.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>