### PR TITLE
script: Fix a heap buffer overflow in script-python

### DIFF
--- a/utils/script-python.c
+++ b/utils/script-python.c
@@ -495,7 +495,7 @@ static void setup_argument_context(PyObject **pDict, bool is_retval,
 			str[slen] = '\0';
 
 			/* NULL string is encoded as '0xffffffff' */
-			if (!memcmp(str, &null_str, sizeof(null_str)))
+			if (slen == 4 && !memcmp(str, &null_str, sizeof(null_str)))
 				strcpy(str, "NULL");
 
 			insert_tuple_string(args, count++, str);


### PR DESCRIPTION
This patch fixes the following heap buffer overflow.
```
  $ gcc -pg -g -o t-arg tests/s-arg.c

  $ uftrace record -a t-arg

  $ uftrace script -S scripts/dump.py --no-pager
  uftrace_begin(ctx)
    record  : False
    version : v0.9.4-129-g4be7 ( dwarf python luajit tui perf sched dynamic )
    cmds    :

  17910610.546322424  34457: [entry] __monstartup(4005b0) depth: 0
  17910610.546323121  34457: [exit ] __monstartup(4005b0) depth: 0
  17910610.546324914  34457: [entry] __cxa_atexit(4005d0) depth: 0
  17910610.546325298  34457: [exit ] __cxa_atexit(4005d0) depth: 0
  17910610.546325981  34457: [entry] main(400a6f) depth: 0
    args[0] <class 'int'>: 1
    args[1] <class 'int'>: 140727876517768
  17910610.546326972  34457: [entry] foo(40076c) depth: 1
    args[0] <class 'int'>: 3
  =================================================================
  ==34847==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020000a8892 at pc 0x7ffb47655260 bp 0x7ffe54f558d0 sp 0x7ffe54f55078
  READ of size 4 at 0x6020000a8892 thread T0
      #0 0x7ffb4765525f  (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xd925f)
      #1 0x489f7e in setup_argument_context /home/honggyu/uftrace/utils/script-python.c:498
      #2 0x48a7a7 in python_uftrace_entry /home/honggyu/uftrace/utils/script-python.c:592
      #3 0x41395a in run_script_for_rstack /home/honggyu/uftrace/cmds/script.c:78
      #4 0x4146de in command_script /home/honggyu/uftrace/cmds/script.c:192
      #5 0x40c820 in main /home/honggyu/uftrace/uftrace.c:1366
      #6 0x7ffb45f0d82f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
      #7 0x405e08 in _start (/home/honkim01/usr/bin/uftrace+0x405e08)

  0x6020000a8892 is located 0 bytes to the right of 2-byte region [0x6020000a8890,0x6020000a8892)
  allocated by thread T0 here:
      #0 0x7ffb47688078 in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x10c078)
      #1 0x489e85 in setup_argument_context /home/honggyu/uftrace/utils/script-python.c:491
      #2 0x48a7a7 in python_uftrace_entry /home/honggyu/uftrace/utils/script-python.c:592
      #3 0x41395a in run_script_for_rstack /home/honggyu/uftrace/cmds/script.c:78
      #4 0x4146de in command_script /home/honggyu/uftrace/cmds/script.c:192
      #5 0x40c820 in main /home/honggyu/uftrace/uftrace.c:1366
      #6 0x7ffb45f0d82f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>