### PR TITLE
Support patternized module name for dynamic patch

### DIFF
--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -310,6 +310,13 @@ struct patt_list {
 	bool positive;
 };
 
+struct module_patt_list {
+	struct list_head list;
+	struct list_head func_patt;
+	struct uftrace_pattern module_patt;
+	char *module;
+};
+
 static bool match_pattern_list(struct list_head *patterns,
 			       struct uftrace_mmap *map,
 			       char *sym_name)

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -390,6 +390,29 @@ static int do_dynamic_update(struct symtabs *symtabs, char *patch_funcs,
 	LIST_HEAD(patterns);
 	struct func_patt_list *pl;
 	bool all_negative = true;
+	const char *skip_libs[] = {
+		/* uftrace internal libraries */
+		"libmcount.so",
+		"libmcount-fast.so",
+		"libmcount-single.so",
+		"libmcount-fast-single.so",
+		/* used by uftrace for dynamic tracing */
+		"libcapstone.so.3",
+		/* system base libraries */
+		"libpthread.so.0",
+		"libpthread-2.*.so",
+		"ld-*.so",
+		"libc.so.6",
+		"libc-2.*.so",
+		"libm.so.6",
+		"libm-2.*.so",
+		"libgcc_s.so.1",
+		"linux-vdso.so.1",
+		"linux-gate.so.1",
+		"ld-linux-*.so.*",
+		"libdl.so.2",
+		"libdl-2.*.so",
+	};
 
 	if (patch_funcs == NULL)
 		return 0;

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -537,13 +537,22 @@ NEXT:
 	}
 
 	while (!list_empty(&patterns)) {
-		struct func_patt_list *pl;
+		struct module_patt_list *ml;
 
-		pl = list_first_entry(&patterns, struct func_patt_list, list);
+		ml = list_first_entry(&patterns, struct module_patt_list, list);
+		while (!list_empty(&ml->func_patt)) {
+			struct func_patt_list *pl;
 
-		list_del(&pl->list);
-		free(pl->module);
-		free(pl);
+			pl = list_first_entry(&ml->func_patt, struct func_patt_list, list);
+
+			list_del(&pl->list);
+			free(pl->module);
+			free(pl);
+		}
+
+		list_del(&ml->list);
+		free(ml->module);
+		free(ml);
 	}
 
 	strv_free(&funcs);

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -303,7 +303,7 @@ struct mcount_dynamic_info *setup_trampoline(struct uftrace_mmap *map)
 	return mdi;
 }
 
-struct patt_list {
+struct func_patt_list {
 	struct list_head list;
 	struct uftrace_pattern patt;
 	char *module;
@@ -321,7 +321,7 @@ static bool match_pattern_list(struct list_head *patterns,
 			       struct uftrace_mmap *map,
 			       char *sym_name)
 {
-	struct patt_list *pl;
+	struct func_patt_list *pl;
 	bool ret = false;
 
 	list_for_each_entry(pl, patterns, list) {
@@ -355,7 +355,7 @@ static int do_dynamic_update(struct symtabs *symtabs, char *patch_funcs,
 		"__libc_csu_fini",
 	};
 	LIST_HEAD(patterns);
-	struct patt_list *pl;
+	struct func_patt_list *pl;
 	bool all_negative = true;
 
 	if (patch_funcs == NULL)
@@ -465,9 +465,9 @@ static int do_dynamic_update(struct symtabs *symtabs, char *patch_funcs,
 	}
 
 	while (!list_empty(&patterns)) {
-		struct patt_list *pl;
+		struct func_patt_list *pl;
 
-		pl = list_first_entry(&patterns, struct patt_list, list);
+		pl = list_first_entry(&patterns, struct func_patt_list, list);
 
 		list_del(&pl->list);
 		free(pl->module);


### PR DESCRIPTION
uftrace provides pattern matching on function names However, that is not supported for module names.
so, I added it. 