### PR TITLE
dynamic: Support soname for patch option

### DIFF
--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -318,9 +318,11 @@ static bool match_pattern_list(struct list_head *patterns,
 	bool ret = false;
 
 	list_for_each_entry(pl, patterns, list) {
+		char *soname = get_soname(map->libname);
 		char *libname = basename(map->libname);
 
-		if (strncmp(libname, pl->module, strlen(pl->module)))
+		if (!(strncmp(libname, pl->module, strlen(pl->module)) == 0 ||
+		    strncmp(soname, pl->module, strlen(pl->module) == 0)))
 			continue;
 
 		if (match_filter_pattern(&pl->patt, sym_name))

--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -83,6 +83,33 @@ static int namefind(const void *a, const void *b)
 	return strcmp(name, sym->name);
 }
 
+char *get_soname(const char *filename)
+{
+	struct uftrace_elf_data elf;
+	struct uftrace_elf_iter iter;
+	char *soname = NULL;
+
+	if (elf_init(filename, &elf) < 0) {
+		pr_dbg("error during open symbol file: %s: %m\n", filename);
+		return false;
+	}
+
+	elf_for_each_shdr(&elf, &iter) {
+		if (iter.shdr.sh_type == SHT_DYNAMIC)
+			break;
+	}
+
+	elf_for_each_dynamic(&elf, &iter) {
+		if (iter.dyn.d_tag != DT_SONAME)
+			continue;
+
+		soname = elf_get_name(&elf, &iter, iter.dyn.d_un.d_ptr);
+	}
+
+	elf_finish(&elf);
+	return soname;
+}
+
 bool has_dependency(const char *filename, const char *libname)
 {
 	bool ret = false;

--- a/utils/symbol.h
+++ b/utils/symbol.h
@@ -147,6 +147,7 @@ enum uftrace_trace_type {
 	TRACE_FENTRY,
 };
 
+char *get_soname(const char *filename);
 bool has_dependency(const char *filename, const char *libname);
 enum uftrace_trace_type check_trace_functions(const char *filename);
 int check_static_binary(const char *filename);


### PR DESCRIPTION
some libraries that required to run executable are linked with symbolic
link. so, user who want to trace shared object that required for
executable need to know actually loaded file name of shared object.

this works can be omitted by use soname field in dynamic section of
shared object. because soname represent its symbolic linked name.

Signed-off-by: hanbum <hbpark@stealien.com>