### PR TITLE
Support soname

### DIFF
--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -368,7 +368,8 @@ static bool match_pattern_module(char *pathname)
 	return ret;
 }
 
-static bool match_pattern_list(struct uftrace_mmap *map, char *sym_name)
+static bool match_pattern_list(struct uftrace_mmap *map, char *sym_name,
+			       char* soname)
 {
 	struct patt_list *pl;
 	bool ret = false;
@@ -420,7 +421,7 @@ static void patch_func_matched(struct mcount_dynamic_info *mdi,
 		    sym->type != ST_GLOBAL_FUNC)
 			continue;
 
-		if (!match_pattern_list(map, sym->name)) {
+		if (!match_pattern_list(map, sym->name, soname)) {
 			if (mcount_unpatch_func(mdi, sym, &disasm) == 0)
 				stats.unpatch++;
 			continue;

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -399,6 +399,7 @@ static void patch_func_matched(struct mcount_dynamic_info *mdi,
 		"__libc_csu_init",
 		"__libc_csu_fini",
 	};
+	char *soname = get_soname(map->libname);
 
 	symtab = &map->mod->symtab;
 
@@ -442,6 +443,9 @@ static void patch_func_matched(struct mcount_dynamic_info *mdi,
 
 	if (!found)
 		stats.nomatch++;
+
+	if (soname != NULL)
+		free(soname);
 }
 
 static int do_dynamic_update(struct symtabs *symtabs, char *patch_funcs,

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -376,10 +376,16 @@ static bool match_pattern_list(struct uftrace_mmap *map, char *sym_name,
 	char *libname = basename(map->libname);
 
 	list_for_each_entry(pl, &patterns, list) {
-		if (strncmp(libname, pl->module, strlen(pl->module)))
-			continue;
+		int len = strlen(pl->module);
+		bool matched = false;
 
-		if (match_filter_pattern(&pl->patt, sym_name))
+		if (soname != NULL)
+			matched = (strncmp(soname, pl->module, len) == 0);
+
+		if (!matched)
+			matched = (strncmp(libname, pl->module, len) == 0);
+
+		if (matched && match_filter_pattern(&pl->patt, sym_name))
 			ret = pl->positive;
 	}
 

--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -83,6 +83,33 @@ static int namefind(const void *a, const void *b)
 	return strcmp(name, sym->name);
 }
 
+char *get_soname(const char *filename)
+{
+	struct uftrace_elf_data elf;
+	struct uftrace_elf_iter iter;
+	char *soname = NULL;
+
+	if (elf_init(filename, &elf) < 0) {
+		pr_dbg("error during open symbol file: %s: %m\n", filename);
+		return false;
+	}
+
+	elf_for_each_shdr(&elf, &iter) {
+		if (iter.shdr.sh_type == SHT_DYNAMIC)
+			break;
+	}
+
+	elf_for_each_dynamic(&elf, &iter) {
+		if (iter.dyn.d_tag != DT_SONAME)
+			continue;
+
+		soname = xstrdup(elf_get_name(&elf, &iter, iter.dyn.d_un.d_ptr));
+	}
+
+	elf_finish(&elf);
+	return soname;
+}
+
 bool has_dependency(const char *filename, const char *libname)
 {
 	bool ret = false;

--- a/utils/symbol.h
+++ b/utils/symbol.h
@@ -147,6 +147,7 @@ enum uftrace_trace_type {
 	TRACE_FENTRY,
 };
 
+char *get_soname(const char *filename);
 bool has_dependency(const char *filename, const char *libname);
 enum uftrace_trace_type check_trace_functions(const char *filename);
 int check_static_binary(const char *filename);


### PR DESCRIPTION
some libraries that required to run executable are linked with symbolic
link. so, user who want to trace shared object that required for
executable need to know actually loaded file name of shared object.

this works can be omitted by use soname field in dynamic section of
shared object. because soname represent its symbolic linked name.

here is the usage case:
```
m@LAPTOP-G3M5JJUQ:~/uftrace_soname$ ./uftrace -v -L. -P.@libc.so.6 test
uftrace: checking binary test
uftrace: skipping perf event due to error: Invalid argument
uftrace: creating 2 thread(s) for recording
uftrace: using ./libmcount/libmcount.so library for tracing
mcount: initializing mcount library
dynamic: dynamic patch type: test: 0 (none)
dynamic: dynamic patch type: libc-2.27.so: 1 (pg)
dynamic: dynamic patch type: librt-2.27.so: 0 (none)
dynamic: dynamic patch type: libdl-2.27.so: 0 (none)
dynamic: dynamic patch type: libelf-0.170.so: 0 (none)
dynamic: dynamic patch type: libdw-0.170.so: 0 (none)
dynamic: dynamic patch type: libcapstone.so.3: 0 (none)
dynamic: dynamic patch type: libpthread-2.27.so: 0 (none)
dynamic: dynamic patch type: ld-2.27.so: 0 (none)
dynamic: dynamic patch type: libm-2.27.so: 0 (none)
dynamic: dynamic patch type: libgcc_s.so.1: 0 (none)
dynamic: dynamic patch type: libz.so.1.2.11: 0 (none)
dynamic: dynamic patch type: liblzma.so.5.2.2: 0 (none)
dynamic: dynamic patch type: libbz2.so.1.0.4: 0 (none)
dynamic: libc.so.6 libc.so.6 libc-2.27.so __libc_init_first matched
dynamic: libc.so.6 libc.so.6 libc-2.27.so __libc_start_main matched
dynamic: libc.so.6 libc.so.6 libc-2.27.so __errno_location matched
dynamic: libc.so.6 libc.so.6 libc-2.27.so iconv_open matched
dynamic: libc.so.6 libc.so.6 libc-2.27.so iconv matched
```

as you can see, actually libc-2.27.so has been loaded instead libc.so.6. but it keep the libc.so.6 in the soname field. so, user can use soname which will be printed by ldd.