### PR TITLE
uftrace: Do not use C++ keywords as variable names

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -551,7 +551,7 @@ static void dump_raw_header(struct uftrace_dump_ops *ops,
 	pr_out("uftrace file header: endian        = %u (%s)\n",
 	       handle->hdr.endian, handle->hdr.endian == 1 ? "little" : "big");
 	pr_out("uftrace file header: class         = %u (%s bit)\n",
-	       handle->hdr.class, handle->hdr.class == 2 ? "64" : "32");
+	       handle->hdr.elf_class, handle->hdr.elf_class == 2 ? "64" : "32");
 	get_feature_string(buf, sizeof(buf), handle->hdr.feat_mask);
 	pr_out("uftrace file header: features      = %#"PRIx64" (%s)\n",
 	       handle->hdr.feat_mask, buf);

--- a/cmds/record.c
+++ b/cmds/record.c
@@ -435,7 +435,7 @@ static int fill_file_header(struct opts *opts, int status, struct rusage *rusage
 	hdr.version = UFTRACE_FILE_VERSION;
 	hdr.header_size = sizeof(hdr);
 	hdr.endian = elf_ident[EI_DATA];
-	hdr.class = elf_ident[EI_CLASS];
+	hdr.elf_class = elf_ident[EI_CLASS];
 	hdr.feat_mask = calc_feat_mask(opts);
 	hdr.info_mask = 0;
 	hdr.max_stack = opts->max_stack;

--- a/uftrace.h
+++ b/uftrace.h
@@ -39,7 +39,7 @@ struct uftrace_file_header {
 	uint32_t version;
 	uint16_t header_size;
 	uint8_t  endian;
-	uint8_t  class;
+	uint8_t  elf_class;
 	uint64_t feat_mask;
 	uint64_t info_mask;
 	uint16_t max_stack;

--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -408,7 +408,7 @@ static bool check_data_file(struct uftrace_data *handle,
 
 bool data_is_lp64(struct uftrace_data *handle)
 {
-	return handle->hdr.class == ELFCLASS64;
+	return handle->hdr.elf_class == ELFCLASS64;
 }
 
 int open_info_file(struct opts *opts, struct uftrace_data *handle)

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -92,7 +92,7 @@ struct uftrace_filter_setting {
 	bool				lp64;
 	bool				plt_only;
 	/* caller-defined data */
-	void				*private;
+	void				*info_str;
 };
 
 /* please see man proc(5) for /proc/[pid]/statm */

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -222,7 +222,7 @@ static int setup_filters(struct uftrace_session *s, void *arg)
 {
 	struct uftrace_filter_setting *setting = arg;
 
-	uftrace_setup_filter(setting->private, &s->symtabs, &s->filters,
+	uftrace_setup_filter(setting->info_str, &s->symtabs, &s->filters,
 			     &fstack_filter_mode, setting);
 	return 0;
 }
@@ -231,7 +231,7 @@ static int setup_trigger(struct uftrace_session *s, void *arg)
 {
 	struct uftrace_filter_setting *setting = arg;
 
-	uftrace_setup_trigger(setting->private, &s->symtabs, &s->filters,
+	uftrace_setup_trigger(setting->info_str, &s->symtabs, &s->filters,
 			      &fstack_filter_mode, setting);
 	return 0;
 }
@@ -240,7 +240,7 @@ static int setup_callers(struct uftrace_session *s, void *arg)
 {
 	struct uftrace_filter_setting *setting = arg;
 
-	uftrace_setup_caller_filter(setting->private, &s->symtabs, &s->filters,
+	uftrace_setup_caller_filter(setting->info_str, &s->symtabs, &s->filters,
 				    setting);
 	return 0;
 }
@@ -285,7 +285,7 @@ static int setup_fstack_filters(struct uftrace_data *handle, char *filter_str,
 	struct uftrace_session_link *sessions = &handle->sessions;
 
 	if (filter_str) {
-		setting->private = filter_str;
+		setting->info_str = filter_str;
 		walk_sessions(sessions, setup_filters, setting);
 		walk_sessions(sessions, count_filters, &count);
 
@@ -298,7 +298,7 @@ static int setup_fstack_filters(struct uftrace_data *handle, char *filter_str,
 	if (trigger_str) {
 		int prev = count;
 
-		setting->private = trigger_str;
+		setting->info_str = trigger_str;
 		walk_sessions(sessions, setup_trigger, setting);
 		walk_sessions(sessions, count_filters, &count);
 
@@ -311,7 +311,7 @@ static int setup_fstack_filters(struct uftrace_data *handle, char *filter_str,
 	if (caller_str) {
 		int prev = count;
 
-		setting->private = caller_str;
+		setting->info_str = caller_str;
 		walk_sessions(sessions, setup_callers, setting);
 		walk_sessions(sessions, count_filters, &count);
 
@@ -373,8 +373,8 @@ static int build_arg_spec(struct uftrace_session *s, void *arg)
 {
 	struct uftrace_filter_setting *setting = arg;
 
-	if (setting->private)
-		uftrace_setup_argument(setting->private, &s->symtabs, &s->filters,
+	if (setting->info_str)
+		uftrace_setup_argument(setting->info_str, &s->symtabs, &s->filters,
 				       setting);
 
 	return 0;
@@ -384,8 +384,8 @@ static int build_ret_spec(struct uftrace_session *s, void *arg)
 {
 	struct uftrace_filter_setting *setting = arg;
 
-	if (setting->private)
-		uftrace_setup_retval(setting->private, &s->symtabs, &s->filters,
+	if (setting->info_str)
+		uftrace_setup_retval(setting->info_str, &s->symtabs, &s->filters,
 				     setting);
 
 	return 0;
@@ -411,15 +411,15 @@ void setup_fstack_args(char *argspec, char *retspec,
 
 	pr_dbg("setup argspec and/or retspec\n");
 
-	setting->private = argspec;
+	setting->info_str = argspec;
 	walk_sessions(&handle->sessions, build_arg_spec, setting);
 
-	setting->private = retspec;
+	setting->info_str = retspec;
 	walk_sessions(&handle->sessions, build_ret_spec, setting);
 
 	/* old data does not have separated retspec */
 	if (argspec && strstr(argspec, "retval")) {
-		setting->private = argspec;
+		setting->info_str = argspec;
 		walk_sessions(&handle->sessions, build_ret_spec, setting);
 	}
 }

--- a/utils/list.h
+++ b/utils/list.h
@@ -18,8 +18,8 @@ struct list_head {
 	struct list_head *next;
 };
 
-#define LIST_POISON1  ((void *)0x00100100)
-#define LIST_POISON2  ((void *)0x00200200)
+#define LIST_POISON1  ((struct list_head*)0x00100100)
+#define LIST_POISON2  ((struct list_head*)0x00200200)
 
 #define LIST_HEAD_INIT(name) { &(name), &(name) }
 
@@ -39,46 +39,46 @@ static inline void INIT_LIST_HEAD(struct list_head *list)
  * the prev/next entries already!
  */
 #ifndef CONFIG_DEBUG_LIST
-static inline void __list_add(struct list_head *new,
+static inline void __list_add(struct list_head *new_entry,
 			      struct list_head *prev,
 			      struct list_head *next)
 {
-	next->prev = new;
-	new->next = next;
-	new->prev = prev;
-	prev->next = new;
+	next->prev = new_entry;
+	new_entry->next = next;
+	new_entry->prev = prev;
+	prev->next = new_entry;
 }
 #else
-extern void __list_add(struct list_head *new,
+extern void __list_add(struct list_head *new_entry,
 			      struct list_head *prev,
 			      struct list_head *next);
 #endif
 
 /**
  * list_add - add a new entry
- * @new: new entry to be added
+ * @new_entry: new entry to be added
  * @head: list head to add it after
  *
  * Insert a new entry after the specified head.
  * This is good for implementing stacks.
  */
-static inline void list_add(struct list_head *new, struct list_head *head)
+static inline void list_add(struct list_head *new_entry, struct list_head *head)
 {
-	__list_add(new, head, head->next);
+	__list_add(new_entry, head, head->next);
 }
 
 
 /**
  * list_add_tail - add a new entry
- * @new: new entry to be added
+ * @new_entry: new entry to be added
  * @head: list head to add it before
  *
  * Insert a new entry before the specified head.
  * This is useful for implementing queues.
  */
-static inline void list_add_tail(struct list_head *new, struct list_head *head)
+static inline void list_add_tail(struct list_head *new_entry, struct list_head *head)
 {
-	__list_add(new, head->prev, head);
+	__list_add(new_entry, head->prev, head);
 }
 
 /*
@@ -119,25 +119,25 @@ extern void list_del(struct list_head *entry);
 
 /**
  * list_replace - replace old entry by new one
- * @old : the element to be replaced
- * @new : the new element to insert
+ * @old_entry : the element to be replaced
+ * @new_entry : the new element to insert
  *
- * If @old was empty, it will be overwritten.
+ * If @old_entry was empty, it will be overwritten.
  */
-static inline void list_replace(struct list_head *old,
-				struct list_head *new)
+static inline void list_replace(struct list_head *old_entry,
+				struct list_head *new_entry)
 {
-	new->next = old->next;
-	new->next->prev = new;
-	new->prev = old->prev;
-	new->prev->next = new;
+	new_entry->next = old_entry->next;
+	new_entry->next->prev = new_entry;
+	new_entry->prev = old_entry->prev;
+	new_entry->prev->next = new_entry;
 }
 
-static inline void list_replace_init(struct list_head *old,
-					struct list_head *new)
+static inline void list_replace_init(struct list_head *old_entry,
+					struct list_head *new_entry)
 {
-	list_replace(old, new);
-	INIT_LIST_HEAD(old);
+	list_replace(old_entry, new_entry);
+	INIT_LIST_HEAD(old_entry);
 }
 
 /**

--- a/utils/rbtree.c
+++ b/utils/rbtree.c
@@ -359,7 +359,7 @@ struct rb_node *rb_prev(const struct rb_node *node)
 	return parent;
 }
 
-void rb_replace_node(struct rb_node *victim, struct rb_node *new,
+void rb_replace_node(struct rb_node *victim, struct rb_node *new_entry,
 		     struct rb_root *root)
 {
 	struct rb_node *parent = rb_parent(victim);
@@ -367,17 +367,17 @@ void rb_replace_node(struct rb_node *victim, struct rb_node *new,
 	/* Set the surrounding nodes to point to the replacement */
 	if (parent) {
 		if (victim == parent->rb_left)
-			parent->rb_left = new;
+			parent->rb_left = new_entry;
 		else
-			parent->rb_right = new;
+			parent->rb_right = new_entry;
 	} else {
-		root->rb_node = new;
+		root->rb_node = new_entry;
 	}
 	if (victim->rb_left)
-		rb_set_parent(victim->rb_left, new);
+		rb_set_parent(victim->rb_left, new_entry);
 	if (victim->rb_right)
-		rb_set_parent(victim->rb_right, new);
+		rb_set_parent(victim->rb_right, new_entry);
 
 	/* Copy the pointers/colour from the victim to the replacement */
-	*new = *victim;
+	*new_entry = *victim;
 }

--- a/utils/rbtree.h
+++ b/utils/rbtree.h
@@ -84,7 +84,7 @@ extern struct rb_node *rb_first(const struct rb_root *);
 extern struct rb_node *rb_last(const struct rb_root *);
 
 /* Fast replacement of a single node without remove/rebalance/add/rebalance */
-extern void rb_replace_node(struct rb_node *victim, struct rb_node *new,
+extern void rb_replace_node(struct rb_node *victim, struct rb_node *new_entry,
 			    struct rb_root *root);
 
 static inline void rb_link_node(struct rb_node * node, struct rb_node * parent,


### PR DESCRIPTION
Since list.h and rbtree.h internally uses 'new' as a variable name, it
cannot be compiled by C++ compilers.

Besides those, there are more places that use C++ keywords so this
patch also renames those names as follows.
```
  s/new/new_entry/g
  s/old/old_entry/g
  s/class/elf_class/g
  s/private/info_str/g
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>