### PR TITLE
misc: Fix a warning from dbginfo in i386 build

### DIFF
--- a/misc/dbginfo.c
+++ b/misc/dbginfo.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <getopt.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 #include "utils/symbol.h"
 #include "utils/dwarf.h"
@@ -29,7 +30,7 @@ void print_debug_info(struct debug_info *dinfo, bool auto_args)
 			continue;
 
 		symname = demangle(loc->sym->name);
-		printf("%s [addr: %lx]\n", symname, loc->sym->addr);
+		printf("%s [addr: %"PRIx64"]\n", symname, loc->sym->addr);
 		free(symname);
 
 		/* skip common parts with compile directory  */


### PR DESCRIPTION
This patch fixes the following warning in i386 build.
```
  /home/honggyu/uftrace/misc/dbginfo.c: In function ‘print_debug_info’:
  /home/honggyu/uftrace/misc/dbginfo.c:32:23: warning: format ‘%lx’
      expects argument of type ‘long unsigned int’, but argument 3 has type
      ‘uint64_t’ {aka ‘long long unsigned int’} [-Wformat=]
     32 |   printf("%s [addr: %lx]\n", symname, loc->sym->addr);
        |                     ~~^               ~~~~~~~~~~~~~~
        |                       |                       |
        |                       long unsigned int       uint64_t {aka long long unsigned int}
        |                     %llx
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>