### PR TITLE
uftrace: Suggest to report a bug when segfault happens

### DIFF
--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -719,7 +719,7 @@ static void segv_handler(int sig, siginfo_t *si, void *ctx)
 			" please consider -e/--estimate-return option.\n\n");
 	}
 
-	pr_warn("Backtrace from uftrace:\n");
+	pr_warn("Backtrace from uftrace " UFTRACE_VERSION "\n");
 	pr_warn("=====================================\n");
 
 	while (rstack >= mtdp->rstack) {
@@ -739,6 +739,8 @@ static void segv_handler(int sig, siginfo_t *si, void *ctx)
 
 		rstack--;
 	}
+
+	pr_red("\nPlease report this bug to https://github.com/namhyung/uftrace/issues.\n\n");
 
 out:
 	sigaction(sig, &old_sigact[(sig == SIGSEGV)], NULL);


### PR DESCRIPTION
This patch suggests to report a bug when the program gets segfault.

The output contains uftrace version info and it looks as follows.
```
  $ uftrace record -l a.out
  WARN: Segmentation fault: address not mapped (addr: 0x523e66c8)
  WARN:  if this happens only with uftrace, please consider
  -e/--estimate-return option.

  WARN: Backtrace from uftrace v0.9.4-174-g0fce3 ( perf sched )
  WARN: =====================================
  WARN: [1] (___tls_get_addr[f7dc18d0] <= __cxa_get_globals[f7dd15eb])
  WARN: [0] (__cxa_get_globals[f7dc2720] <= __cxa_throw[f7dd27d5])

  Please report this bug to https://github.com/namhyung/uftrace/issues.

  WARN: child terminated by signal: 11: Segmentation fault
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>