### PR TITLE
uftrace: Add arch info to uftrace version and show it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ $(filter-out $(objdir)/uftrace.o, $(UFTRACE_OBJS)): $(objdir)/%.o: $(srcdir)/%.c
 	$(QUIET_CC)$(CC) $(UFTRACE_CFLAGS) -c -o $@ $<
 
 $(objdir)/version.h: PHONY
-	@$(srcdir)/misc/version.sh $@ $(VERSION_GIT) $(srcdir)
+	@$(srcdir)/misc/version.sh $@ $(VERSION_GIT) $(ARCH) $(srcdir)
 
 $(srcdir)/utils/auto-args.h: $(srcdir)/misc/prototypes.h $(srcdir)/misc/gen-autoargs.py
 	$(QUIET_GEN)$(srcdir)/misc/gen-autoargs.py -i $< -o $@

--- a/misc/version.sh
+++ b/misc/version.sh
@@ -2,8 +2,8 @@
 
 VERSION_FILE=$1
 
-if [ $# -ne 3 ]; then
-    echo "Usage: $0 <filename> <version> <srcdir>"
+if [ $# -ne 4 ]; then
+    echo "Usage: $0 <filename> <version> <arch> <srcdir>"
     exit 1
 fi
 
@@ -11,7 +11,9 @@ CURR_VERSION=$2
 FILE_VERSION=
 GIT_VERSION=
 
-SRCDIR=$3
+ARCH=$3
+
+SRCDIR=$4
 
 if test -f ${VERSION_FILE}; then
     FILE_VERSION=$(cut -d'"' -f2 ${VERSION_FILE})
@@ -28,7 +30,7 @@ if test -z "${GIT_VERSION}" -a -n "${FILE_VERSION}"; then
     exit 0
 fi
 
-DEPS=""
+DEPS=" ${ARCH}"
 if test -f ${SRCDIR}/check-deps/have_libdw; then
     DEPS="${DEPS} dwarf"
 fi

--- a/uftrace.c
+++ b/uftrace.c
@@ -1310,6 +1310,8 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	pr_dbg("running %s\n", uftrace_version);
+
 	opts.range.kernel_skip_out = opts.kernel_skip_out;
 	opts.range.event_skip_out  = opts.event_skip_out;
 


### PR DESCRIPTION
This patch adds arch info to uftrace version string as follows.

Before:
```
  uftrace v0.9.4-201-g6801 ( dwarf python luajit tui perf sched dynamic )
```
After:
```
  uftrace v0.9.4-201-g6801 ( x86_64 dwarf python luajit tui perf sched dynamic )
```
It also adds a debugging output that shows version info at the
beginning of execution.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>