### PR TITLE
doc: Fix grammar errors for -H option in man pages

### DIFF
--- a/doc/uftrace-dump.md
+++ b/doc/uftrace-dump.md
@@ -56,7 +56,7 @@ COMMON OPTIONS
 
 -H *FUNC*, \--hide=*FUNC*
 :   Set filter not to trace selected functions.
-    It doesn't affects their subtrees, but hides only the given functions.
+    It doesn't affect their subtrees, but hides only the given functions.
     This option can be used more than once.
     See `uftrace-replay`(1) for an explanation of filters.
 

--- a/doc/uftrace-graph.md
+++ b/doc/uftrace-graph.md
@@ -50,7 +50,7 @@ COMMON OPTIONS
 
 -H *FUNC*, \--hide=*FUNC*
 :   Set filter not to trace selected functions.
-    It doesn't affects their subtrees, but hides only the given functions.
+    It doesn't affect their subtrees, but hides only the given functions.
     This option can be used more than once.
     See `uftrace-replay`(1) for an explanation of filters.
 

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -32,7 +32,7 @@ COMMON OPTIONS
 
 -H *FUNC*, \--hide=*FUNC*
 :   Set filter not to trace selected functions.
-    It doesn't affects their subtrees, but hides only the given functions.
+    It doesn't affect their subtrees, but hides only the given functions.
     This option can be used more than once.  See *FILTERS*.
 
 -C *FUNC*, \--caller-filter=*FUNC*

--- a/doc/uftrace-replay.md
+++ b/doc/uftrace-replay.md
@@ -61,7 +61,7 @@ COMMON OPTIONS
 
 -H *FUNC*, \--hide=*FUNC*
 :   Set filter not to trace selected functions.
-    It doesn't affects their subtrees, but hides only the given functions.
+    It doesn't affect their subtrees, but hides only the given functions.
     This option can be used more than once.  See *FILTERS*.
 
 -C *FUNC*, \--caller-filter=*FUNC*

--- a/doc/uftrace-report.md
+++ b/doc/uftrace-report.md
@@ -89,7 +89,7 @@ COMMON OPTIONS
 
 -H *FUNC*, \--hide=*FUNC*
 :   Set filter not to trace selected functions.
-    It doesn't affects their subtrees, but hides only the given functions.
+    It doesn't affect their subtrees, but hides only the given functions.
     This option can be used more than once.
     See `uftrace-replay`(1) for an explanation of filters.
 

--- a/doc/uftrace-script.md
+++ b/doc/uftrace-script.md
@@ -45,7 +45,7 @@ COMMON OPTIONS
 
 -H *FUNC*, \--hide=*FUNC*
 :   Set filter not to trace selected functions.
-    It doesn't affects their subtrees, but hides only the given functions.
+    It doesn't affect their subtrees, but hides only the given functions.
     This option can be used more than once.
     See `uftrace-replay`(1) for an explanation of filters.
 

--- a/doc/uftrace-tui.md
+++ b/doc/uftrace-tui.md
@@ -43,7 +43,7 @@ COMMON OPTIONS
 
 -H *FUNC*, \--hide=*FUNC*
 :   Set filter not to trace selected functions.
-    It doesn't affects their subtrees, but hides only the given functions.
+    It doesn't affect their subtrees, but hides only the given functions.
     This option can be used more than once.
     See `uftrace-replay`(1) for an explanation of filters.
 


### PR DESCRIPTION
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>