### PR TITLE
uftrace: Refactor replay print functions and reuse it in dump

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -885,18 +885,7 @@ static void dump_chrome_header(struct uftrace_dump_ops *ops,
 	chrome->last_comma = false;
 }
 
-static void escape_func_name(char *name_buf, const char *name)
-{
-	size_t namelen = strlen(name);
-	size_t i, j;
-
-	for (i = 0, j = 0; i < namelen; i++) {
-		if (name[i] == '"')
-			name_buf[j++] = '\\';
-		name_buf[j++] = name[i];
-	}
-	name_buf[j] = '\0';
-}
+void print_json_escaped_char(char **args, size_t *len, const char c);
 
 static void dump_chrome_task_rstack(struct uftrace_dump_ops *ops,
 				     struct uftrace_task_reader *task, char *name)
@@ -909,6 +898,10 @@ static void dump_chrome_task_rstack(struct uftrace_dump_ops *ops,
 	struct uftrace_chrome_dump *chrome = container_of(ops, typeof(*chrome), ops);
 	bool is_process = task->t->pid == task->tid;
 	int rec_type = frs->type;
+	size_t namelen = strlen(name);
+	char *p = name_buf;
+	size_t len = sizeof(name_buf) - 1;
+	size_t i;
 
 	if (rec_type == UFTRACE_EVENT) {
 		switch (frs->addr) {
@@ -930,7 +923,9 @@ static void dump_chrome_task_rstack(struct uftrace_dump_ops *ops,
 	}
 
 	/* escape the function name */
-	escape_func_name(name_buf, name);
+	for (i = 0; i < namelen; i++)
+		print_json_escaped_char(&p, &len, name[i]);
+	*p = '\0';
 
 	if (chrome->last_comma)
 		pr_out(",\n");

--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -464,7 +464,7 @@ static void print_args(char **args, size_t *len, const char *fmt, ...)
 	*len -= x;
 }
 
-static void print_json_escaped_char(char **args, size_t *len, const char c)
+void print_json_escaped_char(char **args, size_t *len, const char c)
 {
 	if (c == '\n')
 		print_args(args, len, "\\\\n");

--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -750,7 +750,8 @@ void get_argspec_string(struct uftrace_task_reader *task,
 		}
 		else if (spec->fmt == ARG_FMT_STRUCT) {
 			if (spec->type_name)
-				print_args(&args, &len, "%s", spec->type_name);
+				print_args(&args, &len, "%s%s%s", color_struct,
+						spec->type_name, color_reset);
 			if (spec->size)
 				print_args(&args, &len, "{...}");
 			else

--- a/utils/debug.c
+++ b/utils/debug.c
@@ -38,6 +38,7 @@ const char *color_reset   = TERM_COLOR_RESET;
 const char *color_bold    = TERM_COLOR_BOLD;
 const char *color_string  = TERM_COLOR_MAGENTA;
 const char *color_symbol  = TERM_COLOR_CYAN;
+const char *color_struct  = TERM_COLOR_CYAN;
 const char *color_enum    = TERM_COLOR_BLUE;
 const char *color_enum_or = TERM_COLOR_RESET TERM_COLOR_BOLD "|" TERM_COLOR_RESET TERM_COLOR_BLUE;
 
@@ -141,6 +142,7 @@ void setup_color(enum color_setting color, char *pager)
 		color_bold    = "";
 		color_string  = "";
 		color_symbol  = "";
+		color_struct  = "";
 		color_enum    = "";
 		color_enum_or = "|";
 	}

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -53,6 +53,7 @@ extern const char *color_reset;
 extern const char *color_bold;
 extern const char *color_string;
 extern const char *color_symbol;
+extern const char *color_struct;
 extern const char *color_enum;
 extern const char *color_enum_or;
 


### PR DESCRIPTION
This patch refactors replay print macros to normal functions and reuse
it in dump command to replace existing escape_func_name() to
print_json_escaped_char() in replay.c.

In addition, the struct type info brings another useful information so
this PR also highlights the type name in yellow color.

Fixed: #1129

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>