### PR TITLE
tui: Customize fields in graph mode interactively

### DIFF
--- a/doc/uftrace-tui.md
+++ b/doc/uftrace-tui.md
@@ -170,6 +170,7 @@ Following keys can be used in the TUI window:
  * `<`/`P`:               Search previous match
  * `>`/`N`:               Search next match
  * `v`:                   Show debug message
+ * `f`:                   Customize fields in graph mode
  * `h`/`?`:               Show help window
  * `q`:                   Quit
 

--- a/utils/field.c
+++ b/utils/field.c
@@ -88,6 +88,17 @@ void add_field(struct list_head *output_fields, struct display_field *field)
 	list_add_tail(&field->list, output_fields);
 }
 
+void del_field(struct display_field *field)
+{
+	if (!field->used)
+		return;
+
+	pr_dbg("delete field \"%s\"\n", field->name);
+
+	field->used = false;
+	list_del(&field->list);
+}
+
 static bool check_field_name(struct display_field *field, const char *name)
 {
 	if (!strcmp(field->name, name))

--- a/utils/field.h
+++ b/utils/field.h
@@ -81,6 +81,7 @@ int print_field_data(struct list_head *output_fields, struct field_data *fd,
 		     int space);
 int print_empty_field(struct list_head *output_fields, int space);
 void add_field(struct list_head *output_fields, struct display_field *field);
+void del_field(struct display_field *field);
 void setup_field(struct list_head *output_fields, struct opts *opts,
 		 setup_default_field_t setup_default_field,
 		 struct display_field *field_table[],


### PR DESCRIPTION
Hello!

This PR supports users to customize fields for graph mode in interactive mode.

When you press f key, a menu is displayed like h key for help message.

You can see three fields, and each field has a checkbox.
If a field is checked, then the checkbox is checked with 'x'.

If you run uftrace tui by default, 'total' field is already checked.
Depending on using -f option, fields can be already checked differently.

If you press SPACE key, you can (un) check the field.

If you want to move to another field, press DOWN/UP arrow keys or j/k keys.

If you want to apply your customization, press f or ENTER key.

If you want to revoke your customization, press q key.

Fixed: #1013

Signed-off-by: Sangwon Hong <qpakzk@gmail.com>