### PR TITLE
aarch64: dynamic: Add debug messages for patched function

### DIFF
--- a/arch/aarch64/mcount-dynamic.c
+++ b/arch/aarch64/mcount-dynamic.c
@@ -111,6 +111,9 @@ int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym,
 	if ((call & 0xfc000000) != 0)
 		return INSTRUMENT_FAILED;
 
+	pr_dbg2("patch normal func: %s (patch size: %d)\n",
+		sym->name, info.orig_size);
+
 	/* make a "BL" insn with 26-bit offset */
 	call |= 0x94000000;
 


### PR DESCRIPTION
Unlike x86_64, aarch64 doesn't print debug messages for patched
function so this patch adds it same as x86_64.
```
  $ gcc -o t-abc tests/s-abc.c

  $ uftrace record -P. --debug-domain dynamic:2 t-abc
  dynamic: patch normal func: call_weak_fn (patch size: 8)
  dynamic: patch normal func: a (patch size: 8)
  dynamic: patch normal func: b (patch size: 8)
  dynamic: patch normal func: c (patch size: 8)
  dynamic: patch normal func: main (patch size: 8)
  dynamic: patched all (5) functions in 't-abc'
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>