### PR TITLE
Fix tests built by clang in aarch64

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -846,4 +846,5 @@ if __name__ == "__main__":
     sys.stdout.write("\n")
     sys.stdout.flush()
 
-    print_test_report(color, shared)
+    if shared.total >= 30:
+        print_test_report(color, shared)

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -432,6 +432,9 @@ class TestBase:
 
         return False
 
+    def get_machine(self):
+        return os.uname()[4]
+
     def get_elf_machine(self):
         EI_NIDENT = 16
 

--- a/tests/s-return.c
+++ b/tests/s-return.c
@@ -20,12 +20,18 @@ struct large return_large(char patt)
 	return l;
 }
 
+#if __clang__
+__attribute__((optnone))
+#endif
 struct small return_small(void)
 {
 	struct small s = { .bit = 1 };
 	return s;
 }
 
+#if __clang__
+__attribute__((optnone))
+#endif
 long double return_long_double(void)
 {
 	return LDBL_MAX;

--- a/tests/t002_argument.py
+++ b/tests/t002_argument.py
@@ -24,3 +24,7 @@ class TestCase(TestBase):
    0.427 us [16325] |   } /* pass */
   42.161 us [16325] | } /* main */
 """)
+
+    def setup(self):
+        # to avoid unexpected memcpy in aarch64
+        self.option = '-N memcpy '

--- a/tests/t051_return.py
+++ b/tests/t051_return.py
@@ -15,12 +15,6 @@ class TestCase(TestBase):
    4.097 us [12703] | } /* main */
 """)
 
-    def fixup(self, cflags, result):
-        machine = TestBase.get_elf_machine(self)
-        if machine == 'arm' or machine == 'aarch64':
-            return result.replace('memset', """memset();
-   1.440 us [12703] |     memcpy""");
-
-        return result.replace("""return_large() {
-   1.440 us [12703] |     memset();
-   2.533 us [12703] |   } /* return_large */""", 'return_large();')
+    def setup(self):
+        # to avoid unexpected memcpy in aarch64
+        self.option = '-N memcpy '

--- a/tests/t052_nested_func.py
+++ b/tests/t052_nested_func.py
@@ -20,6 +20,12 @@ class TestCase(TestBase):
    3.623 us [13348] | } /* main */
 """)
 
+    def build(self, name, cflags='', ldflags=''):
+        if self.supported_lang['C']['cc'] == 'clang':
+            # clang doesn't allow nested function.
+            return TestBase.TEST_SKIP
+        return TestBase.build(self, name, cflags, ldflags)
+
     def sort(self, output, ignore_children=False):
         """ This function post-processes output of the test to be compared .
             It ignores blank and comment (#) lines and remaining functions.  """

--- a/tests/t136_dynamic.py
+++ b/tests/t136_dynamic.py
@@ -12,12 +12,11 @@ class TestCase(TestBase):
    3.005 us [28141] | } /* main */
 """)
 
-    def prerun(self, timeout):
-        if TestBase.get_elf_machine(self) == 'arm':
-            return TestBase.TEST_SKIP
-        return TestBase.TEST_SUCCESS
-
     def build(self, name, cflags='', ldflags=''):
+        if TestBase.get_machine(self) != 'x86_64':
+            return TestBase.TEST_SKIP
+        if self.supported_lang['C']['cc'] == 'clang':
+            return TestBase.TEST_SKIP
         cflags += ' -mfentry -mnop-mcount'
         cflags += ' -fno-pie -fno-plt'  # workaround of build failure
         return TestBase.build(self, name, cflags, ldflags)


### PR DESCRIPTION
This PR fixes the following test failures when building them with clang in aarch64.
```
  002 argument            : OK OK OK OK NG OK OK OK OK NG
  051 return              : NG NG NG NG NG NG OK OK OK OK
  052 nested_func         : BI BI BI BI BI BI BI BI BI BI
  136 dynamic             : BI BI BI BI BI BI BI BI BI BI
```
It also makes the `runtest.py` show statistics summary only when more than
30 tests are executed.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>