### PR TITLE
Fix error on aarch64 with binutils2.35.1 and later versions.

### DIFF
--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -560,6 +560,8 @@ int load_elf_dynsymtab(struct symtab *dsymtab, struct uftrace_elf_data *elf,
 	}
 	else if (elf->ehdr.e_machine == EM_AARCH64) {
 		plt_addr += 16;    /* AARCH64 PLT0 size is 32 */
+		if (plt_entsize == 0)
+			plt_entsize = 16;
 	}
 	else if (elf->ehdr.e_machine == EM_386) {
 		plt_entsize += 12;


### PR DESCRIPTION
Signed-off-by: Lei Maohui <leimaohui@cn.fujitsu.com>