### PR TITLE
build: Relocate bash completion script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ $(objdir)/misc/dbginfo: $(DBGINFO_OBJS)
 install: all
 	$(Q)$(INSTALL) -d -m 755 $(DESTDIR)$(bindir)
 	$(Q)$(INSTALL) -d -m 755 $(DESTDIR)$(libdir)
-	$(Q)$(INSTALL) -d -m 755 $(DESTDIR)$(etcdir)/bash_completion.d
+	$(Q)$(INSTALL) -d -m 755 $(DESTDIR)$(compldir)
 ifneq ($(wildcard $(elfdir)/lib/libelf.so),)
 ifeq ($(wildcard $(prefix)/lib/libelf.so),)
 	# install libelf only when it's not in the install directory.
@@ -339,7 +339,7 @@ endif
 	$(Q)$(INSTALL) $(objdir)/libmcount/libmcount-single.so $(DESTDIR)$(libdir)/libmcount-single.so
 	$(Q)$(INSTALL) $(objdir)/libmcount/libmcount-fast-single.so $(DESTDIR)$(libdir)/libmcount-fast-single.so
 	$(call QUIET_INSTALL, bash-completion)
-	$(Q)$(INSTALL) -m 644 $(srcdir)/misc/bash-completion.sh $(DESTDIR)$(etcdir)/bash_completion.d/uftrace
+	$(Q)$(INSTALL) -m 644 $(srcdir)/misc/bash-completion.sh $(DESTDIR)$(compldir)/uftrace
 	@$(MAKE) -sC $(docdir) install DESTDIR=$(DESTDIR)$(mandir)
 	@if [ `id -u` = 0 ]; then ldconfig $(DESTDIR)$(libdir) || echo "ldconfig failed"; fi
 
@@ -357,7 +357,7 @@ uninstall:
 	$(call QUIET_UNINSTALL, libmcount-fast-single)
 	$(Q)$(RM) $(DESTDIR)$(libdir)/libmcount-fast-single.so
 	$(call QUIET_UNINSTALL, bash-completion)
-	$(Q)$(RM) $(DESTDIR)$(etcdir)/bash_completion.d/uftrace
+	$(Q)$(RM) $(DESTDIR)$(compldir)/uftrace
 	@$(MAKE) -sC $(docdir) uninstall DESTDIR=$(DESTDIR)$(mandir)
 
 test: all

--- a/configure
+++ b/configure
@@ -139,6 +139,7 @@ bindir=${bindir:-${prefix}/bin}
 libdir=${libdir:-${prefix}/lib}
 etcdir=${etcdir:-${prefix}/etc}
 mandir=${mandir:-${prefix}/share/man}
+compldir=${compldir:-${prefix}/share/bash-completion/completions}
 
 if [ "$etcdir" = /usr/etc ]; then
     etcdir=/etc
@@ -268,6 +269,7 @@ override bindir := $bindir
 override libdir := $libdir
 override mandir := $mandir
 override etcdir := $etcdir
+override compldir := $compldir
 EOF
 
 if [ ! -z $with_elfutils ]; then


### PR DESCRIPTION
This commit fixes bash completion feature,
which is not working right now.

misc/bash_completion.sh should be relocated, and
we can get recommended location of the script wq!:with
`pkg-config --variable=completionsdir bash-completion`.

Other directories, including /usr/local/etc/bash_completions.d
are only present for backwords compatibility, so its usage is
no longer recommended.

Fixed: #873

Signed-off-by: Kang Minchul <tegongkang@gmail.com>