### PR TITLE
misc: Replace libpython2.7 to libpython3 in install-deps.sh

### DIFF
--- a/misc/install-deps.sh
+++ b/misc/install-deps.sh
@@ -13,24 +13,24 @@ distro=$(grep "^ID=" /etc/os-release | cut -d\= -f2 | sed -e 's/"//g')
 
 case $distro in
     "ubuntu" | "debian" | "raspbian" | "kali" | "linuxmint")
-        apt-get $OPT install pandoc libdw-dev libpython2.7-dev libncursesw5-dev pkg-config
+        apt-get $OPT install pandoc libdw-dev libpython3-dev libncursesw5-dev pkg-config
         apt-get $OPT install libluajit-5.1-dev || true
         apt-get $OPT install libcapstone-dev || true ;;
     "fedora")
-        dnf install $OPT pandoc elfutils-devel python2-devel ncurses-devel pkgconf-pkg-config
+        dnf install $OPT pandoc elfutils-devel python3-devel ncurses-devel pkgconf-pkg-config
         dnf install $OPT luajit-devel || true
         dnf install $OPT capstone-devel || true ;;
     "rhel" | "centos")
         rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-        yum install $OPT pandoc elfutils-devel python2-devel ncurses-devel pkgconfig
+        yum install $OPT pandoc elfutils-devel python3-devel ncurses-devel pkgconfig
         yum install $OPT luajit-devel || true
         yum install $OPT capstone-devel || true ;;
     "arch" | "manjaro")
-        pacman $OPT -S pandoc libelf python2 ncurses pkgconf
+        pacman $OPT -S pandoc libelf python3 ncurses pkgconf
         pacman $OPT -S luajit || true
         pacman $OPT -S capstone || true ;;
     "alpine")
-        apk $OPT add elfutils-dev python2-dev ncurses-dev pkgconf
+        apk $OPT add elfutils-dev python3-dev ncurses-dev pkgconf
         apk $OPT add luajit-dev || true
         apk $OPT add capstone-dev || true ;;
     *) # we can add more install command for each distros.


### PR DESCRIPTION
The current misc/install-deps.sh installs libpython2.7-dev but
libpython3-dev is better to be used so this patch changes it.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>