### PR TITLE
script: Fix a crash for struct type handling in script

### DIFF
--- a/scripts/strings.lua
+++ b/scripts/strings.lua
@@ -12,7 +12,7 @@ function uftrace_entry(ctx)
             if type(arg) == 'string' then
                 arg = string.gsub(arg, '^%s+', '')
                 arg = string.gsub(arg, '%s+$', '')
-                if arg ~= '' then
+                if arg ~= '' and arg:sub(1, 8) ~= 'struct: ' then
                     strset[arg] = true
                 end
             end
@@ -22,11 +22,11 @@ end
 
 function uftrace_exit(ctx)
     if ctx['retval'] ~= nil then
-        local ret = ctx['retval'] 
+        local ret = ctx['retval']
         if type(ctx['retval']) == 'string' then
             ret = string.gsub(ret, '^%s+', '')
             ret = string.gsub(ret, '%s+$', '')
-            if ret ~= '' then
+            if ret ~= '' and ret:sub(1, 8) ~= 'struct: ' then
                 strset[ret] = true
             end
         end

--- a/scripts/strings.py
+++ b/scripts/strings.py
@@ -13,7 +13,7 @@ def uftrace_entry(ctx):
         for arg in args:
             if isinstance(arg, str):
                 arg = arg.strip()
-                if arg is not "":
+                if arg != "" and arg[:8] != "struct: ":
                     strset.add(arg)
 
 def uftrace_exit(ctx):
@@ -22,7 +22,7 @@ def uftrace_exit(ctx):
         ret = ctx["retval"]
         if isinstance(ret, str):
             ret = ret.strip()
-            if ret is not "":
+            if ret != "" and ret[:8] != "struct: ":
                 strset.add(ret)
 
 def uftrace_end():

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -319,17 +319,26 @@ class TestBase:
     def dump_sort(self, output, ignored):
         """ This function post-processes output of the test to be compared .
             It ignores blank and comment (#) lines and remaining functions.  """
+        mode = 1
+        result = []
 
         # A (raw) dump result consists of following data
         # <timestamp> <tid>: [<type>] <func>(<addr>) depth: <N>
-        mode = 1
         patt = re.compile(r'[^[]*(?P<type>\[(entry|exit )\]) (?P<func>[_a-z0-9]*)\([0-9a-f]+\) (?P<depth>.*)')
-        result = []
+
+        # A (raw) dump argument patter
+        arg_patt = re.compile(r'^  args')
+
         for ln in output.split('\n'):
             if ln.startswith('uftrace'):
                 #result.append(ln)
                 pass
             else:
+                m = arg_patt.match(ln)
+                if m is not None:
+                    result.append(ln)
+                    continue
+
                 m = patt.match(ln)
                 if m is None:
                     continue

--- a/tests/s-struct.c
+++ b/tests/s-struct.c
@@ -1,0 +1,35 @@
+// The sizeof(Option) is 11 in 64-bit, 7 in 32-bit.
+struct __attribute__((packed)) Option {
+        char m;     // 1
+        long n;     // 8 or 4
+        short k;    // 2
+};
+
+// empty struct
+struct StringRef {};
+
+// global variables to suppress compiler optimization
+struct Option g_opt;
+struct StringRef g_sr;
+unsigned g_index;
+int g_value1;
+int g_value2;
+
+__attribute__((noinline))
+void foo(const struct Option Opt, struct StringRef S, unsigned Index,
+         const int Value1, const int Value2) {
+        g_opt = Opt;
+        g_sr = S;
+        g_index = Index;
+        g_value1 = Value1;
+        g_value2 = Value2;
+}
+
+int main(void)
+{
+        struct Option Opt = { 11, 22, 33 };
+        struct StringRef S;
+
+        foo(Opt, S, 44, 55, 66);
+        return 0;
+}

--- a/tests/t257_arg_struct_replay.py
+++ b/tests/t257_arg_struct_replay.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'struct', """
+# DURATION     TID     FUNCTION
+            [ 54277] | main() {
+ 207.329 us [ 54277] |   foo(Option{...}, StringRef{}, 44, 55, 66);
+ 208.750 us [ 54277] | } = 0; /* main */
+""", cflags='-g')
+
+    def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
+        # cygprof doesn't support arguments now
+        if cflags.find('-finstrument-functions') >= 0:
+            return TestBase.TEST_SKIP
+        return TestBase.build(self, name, cflags, ldflags)
+
+    def setup(self):
+        self.option = '-a --no-libcall'

--- a/tests/t258_arg_struct_dump.py
+++ b/tests/t258_arg_struct_dump.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'struct', """
+uftrace file header: magic         = 4674726163652100
+uftrace file header: version       = 4
+uftrace file header: header size   = 40
+uftrace file header: endian        = 1 (little)
+uftrace file header: class         = 2 (64 bit)
+uftrace file header: features      = 0x67a (TASK_SESSION | ARGUMENT | RETVAL | SYM_REL_ADDR | MAX_STACK | AUTO_ARGS | DEBUG_INFO)
+uftrace file header: info          = 0x3fff
+
+reading 3121.dat
+11431966.432931623   3121: [entry] main(400673) depth: 0
+11431966.432932393   3121: [entry] foo(40061f) depth: 1
+11431966.432932393   3121: [args ] length = 36
+  args[0] struct Option:
+        0b 16 00 00 00 00 00 00  00 00 00
+  args[1] struct StringRef:
+  args[2] d64: 0x000000000000002c
+  args[3] d64: 0x0000000000000037
+  args[4] d64: 0x0000000000000042
+11431966.433134239   3121: [exit ] foo(40061f) depth: 1
+11431966.433135754   3121: [exit ] main(400673) depth: 0
+11431966.433135754   3121: [retval] length = 8
+  retval d64: 0x0000000000000000
+""", cflags='-g', sort='dump')
+
+    def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
+        # cygprof doesn't support arguments now
+        if cflags.find('-finstrument-functions') >= 0:
+            return TestBase.TEST_SKIP
+        return TestBase.build(self, name, cflags, ldflags)
+
+    def prepare(self):
+        self.subcmd = 'record'
+        self.option = '-a --no-libcall'
+        return self.runcmd()
+
+    def setup(self):
+        self.subcmd = 'dump'
+
+    def fixup(self, cflags, result):
+        # 32-bit will show the output differently
+        return result.replace('d64: 0x00000000', 'd32: 0x')

--- a/tests/t259_arg_struct_script.py
+++ b/tests/t259_arg_struct_script.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+import subprocess as sp
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'struct', """
+uftrace_begin(ctx)
+  record  : False
+  version : v0.10-17-g8d1b ( x86_64 dwarf python luajit tui perf sched dynamic )
+  cmds    : t-struct
+
+11332966.196463691  50529: [entry] main(4006ef) depth: 0
+11332966.196464540  50529: [entry] foo(40068f) depth: 1
+  args[0] <class 'str'>: struct: Option{}
+  args[1] <class 'str'>: struct: StringRef{}
+  args[2] <class 'int'>: 44
+  args[3] <class 'int'>: 55
+  args[4] <class 'int'>: 66
+11332966.196670289  50529: [exit ] foo(40068f) depth: 1
+11332966.196671664  50529: [exit ] main(4006ef) depth: 0
+  retval  <class 'int'>: 0
+
+uftrace_end()
+""", cflags='-g', sort='dump')
+
+    def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature or not 'python' in self.feature:
+            return TestBase.TEST_SKIP
+        # cygprof doesn't support arguments now
+        if cflags.find('-finstrument-functions') >= 0:
+            return TestBase.TEST_SKIP
+        return TestBase.build(self, name, cflags, ldflags)
+
+    def prerun(self, timeout):
+        script_cmd = '%s script' % (TestBase.uftrace_cmd)
+        p = sp.Popen(script_cmd.split(), stdout=sp.PIPE, stderr=sp.PIPE)
+        if p.communicate()[1].decode(errors='ignore').startswith('WARN:'):
+            return TestBase.TEST_SKIP
+        return TestBase.TEST_SUCCESS
+
+    def setup(self):
+        self.subcmd = 'script'
+        self.option = '-S %s/scripts/dump.py -a --no-libcall --no-event --record' % self.basedir
+
+    def fixup(self, cflags, result):
+        # handle the difference between python2 and python3 output
+        result = result.replace(" <class 'int'", " <type 'long'")
+        return result.replace(" <class ", " <type ")

--- a/tests/t260_arg_struct_luajit.py
+++ b/tests/t260_arg_struct_luajit.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+import subprocess as sp
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'struct', """
+uftrace_begin(ctx)
+  record  : false
+  version : v0.10-17-g8d1b ( x86_64 dwarf python luajit tui perf sched dynamic )
+  cmds    : t-struct
+
+514662126420.5094  29459: [entry] main(40067f) depth: 0
+514662126420.5754  29459: [entry] foo(40061f) depth: 1
+  args[1] string: struct: Option{}
+  args[2] string: struct: StringRef{}
+  args[3] number: 44
+  args[4] number: 55
+  args[5] number: 66
+514662126427.20138  29459: [exit ] foo(40061f) depth: 1
+514662126427.21036  29459: [exit ] main(40067f) depth: 0
+  retval  number: 0
+
+uftrace_end()
+""", cflags='-g', sort='dump')
+
+    def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature or not 'luajit' in self.feature:
+            return TestBase.TEST_SKIP
+        # cygprof doesn't support arguments now
+        if cflags.find('-finstrument-functions') >= 0:
+            return TestBase.TEST_SKIP
+        return TestBase.build(self, name, cflags, ldflags)
+
+    def prerun(self, timeout):
+        script_cmd = '%s script' % (TestBase.uftrace_cmd)
+        p = sp.Popen(script_cmd.split(), stdout=sp.PIPE, stderr=sp.PIPE)
+        if p.communicate()[1].decode(errors='ignore').startswith('WARN:'):
+            return TestBase.TEST_SKIP
+        return TestBase.TEST_SUCCESS
+
+    def setup(self):
+        self.subcmd = 'script'
+        self.option = '-S %s/scripts/dump.lua -a --no-libcall --no-event --record' % self.basedir

--- a/utils/script-luajit.c
+++ b/utils/script-luajit.c
@@ -116,22 +116,22 @@ static void setup_argument_context(bool is_retval, struct script_context *sc_ctx
 			memcpy(val.v, data, spec->size);
 			switch (spec->size) {
 			case 1:
-				dllua_pushinteger(L, 1 + count++);
+				dllua_pushinteger(L, ++count);
 				dllua_pushinteger(L, val.c);
 				dllua_settable(L, -3);
 				break;
 			case 2:
-				dllua_pushinteger(L, 1 + count++);
+				dllua_pushinteger(L, ++count);
 				dllua_pushinteger(L, val.s);
 				dllua_settable(L, -3);
 				break;
 			case 4:
-				dllua_pushinteger(L, 1 + count++);
+				dllua_pushinteger(L, ++count);
 				dllua_pushinteger(L, val.i);
 				dllua_settable(L, -3);
 				break;
 			case 8:
-				dllua_pushinteger(L, 1 + count++);
+				dllua_pushinteger(L, ++count);
 				dllua_pushinteger(L, val.L);
 				dllua_settable(L, -3);
 				break;
@@ -159,7 +159,7 @@ static void setup_argument_context(bool is_retval, struct script_context *sc_ctx
 				dval = 0;
 				break;
 			}
-			dllua_pushinteger(L, 1 + count++);
+			dllua_pushinteger(L, ++count);
 			dllua_pushnumber(L, dval);
 			dllua_settable(L, -3);
 			data += ALIGN(spec->size, 4);
@@ -180,7 +180,7 @@ static void setup_argument_context(bool is_retval, struct script_context *sc_ctx
 			if (slen == 4 && !memcmp(str, &null_str, sizeof(null_str)))
 				strcpy(str, "NULL");
 
-			dllua_pushinteger(L, 1 + count++);
+			dllua_pushinteger(L, ++count);
 			dllua_pushstring(L, str);
 			dllua_settable(L, -3);
 			free(str);
@@ -191,13 +191,24 @@ static void setup_argument_context(bool is_retval, struct script_context *sc_ctx
 			/* make it a string */
 			memcpy(ch_str, data, 1);
 			ch_str[1] = '\0';
-			dllua_pushinteger(L, 1 + count++);
+			dllua_pushinteger(L, ++count);
 			dllua_pushstring(L, ch_str);
 			dllua_settable(L, -3);
 			data += 4;
 			break;
 
+		case ARG_FMT_STRUCT:
+			str = NULL;
+			xasprintf(&str, "struct: %s{}", spec->type_name ? spec->type_name : "");
+			dllua_pushinteger(L, ++count);
+			dllua_pushstring(L, str);
+			dllua_settable(L, -3);
+			free(str);
+			data += ALIGN(spec->size, 4);
+			break;
+
 		default:
+			pr_warn("invalid argument format: %d\n", spec->fmt);
 			break;
 		}
 	}

--- a/utils/script-python.c
+++ b/utils/script-python.c
@@ -511,6 +511,14 @@ static void setup_argument_context(PyObject **pDict, bool is_retval,
 			data += 4;
 			break;
 
+		case ARG_FMT_STRUCT:
+			str = NULL;
+			xasprintf(&str, "struct: %s{}", spec->type_name ? spec->type_name : "");
+			insert_tuple_string(args, count++, str);
+			free(str);
+			data += ALIGN(spec->size, 4);
+			break;
+
 		default:
 			pr_warn("invalid argument format: %d\n", spec->fmt);
 			break;


### PR DESCRIPTION
We didn't handle struct type for scripting, so it crashes as follows.
```
  $ g++ -pg -g -O2 tests/s-dwarf7.cpp
  $ uftrace record -a --no-libcall a.out
  $ uftrace script --no-pager -S scripts/dump.py
        ...
  4981.341259000   4788: [entry] main(7fd7928006cd) depth: 0
  WARN: invalid argument format: 10
  WARN: invalid argument format: 10
  4981.341264100   4788: [entry] compare_iters(7fd79280088a) depth: 1
  Segmentation fault (core dumped)
```
This patch fixes this problem for both python and luajit, but print the
struct type name in string type as follows.
```
  $ uftrace script -S scripts/dump.py
        ...
  4981.341259000   4788: [entry] main(7fd7928006cd) depth: 0
  4981.341264100   4788: [entry] compare_iters(7fd79280088a) depth: 1
    args[0] <type 'str'>: __normal_iterator
    args[1] <type 'str'>: __normal_iterator
  4981.342013200   4788: [exit ] compare_iters(7fd79280088a) depth: 1
    retval  <type 'long'>: 0
  4981.342024300   4788: [exit ] main(7fd7928006cd) depth: 0
    retval  <type 'long'>: 0
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>