### PR TITLE
event: Fix a crash by adding PROT_READ along with PROT_EXEC

### DIFF
--- a/arch/x86_64/mcount-event.c
+++ b/arch/x86_64/mcount-event.c
@@ -50,10 +50,11 @@ int mcount_arch_enable_event(struct mcount_event_info *mei)
 		return -1;
 	}
 
-	/* replace NOP to an invalid OP so that it can catch SIGILL */
+	/* replace NOP to an invalid OP so that it can catch SIGILL,
+	   then it will fall into sdt_handler() above. */
 	memset((void *)mei->addr, INVALID_OPCODE, 1);
 
-	if (mprotect(PAGE_ADDR(mei->addr), PAGE_SIZE, PROT_EXEC))
+	if (mprotect(PAGE_ADDR(mei->addr), PAGE_SIZE, PROT_READ | PROT_EXEC))
 		pr_err("cannot setup event due to protection");
 
 	return 0;

--- a/tests/t150_recv_event.py
+++ b/tests/t150_recv_event.py
@@ -40,7 +40,7 @@ class TestCase(TestBase):
 
     def setup(self):
         self.subcmd = 'replay'
-        self.option = '-d ' + os.path.join(TDIR, 'uftrace.data')
+        self.option = '-E uftrace:event -d ' + os.path.join(TDIR, 'uftrace.data')
         self.exearg = ''
 
     def postrun(self, ret):

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -1045,7 +1045,7 @@ bool fstack_check_opts(struct uftrace_task_reader *task, struct opts *opts)
 			return false;
 	}
 
-	if (opts->no_event && rec->type == UFTRACE_EVENT)
+	if (opts->no_event && !opts->event && rec->type == UFTRACE_EVENT)
 		return false;
 
 	if (opts->no_sched && is_sched_event(rec->addr))


### PR DESCRIPTION
Currently, uftrace gets segfault when patching SDT events into the
target binary.
```
  $ gcc -pg -o t-sdt s-sdt.c

  $ uftrace -E uftrace:* --match glob t-sdt
  WARN: child terminated by signal: 11: Segmentation fault
  WARN: cannot open record data: /tmp/uftrace-live-CCoVbF: No data available
```
The reason of the segfault is because the access permission of the
SDT memory region becomes PROT_EXEC only without having PROT_READ.

It might be okay in some environments but some are not so this patch
explicitly adds PROT_READ along with PROT_EXEC.

Before:
```
  147 event_sdt           : SG SG SG SG SG SG SG SG SG SG
  150 recv_event          : NZ NZ NZ NZ NZ NZ NZ NZ NZ NZ
```
After:
```
  147 event_sdt           : OK OK OK OK OK OK OK OK OK OK
  150 recv_event          : OK OK OK OK OK OK OK OK OK OK
```
Fixed: #1286

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>