### PR TITLE
Apply tests fixes in various environments

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -477,6 +477,12 @@ class TestBase:
 
         return None
 
+    def check_arch_mfentry_mnop_mcount_support(self):
+        machine = TestBase.get_machine(self)
+        if machine == 'x86_64' or machine == 'i386':
+            return True
+        return False
+
     def prerun(self, timeout):
         self.subcmd = 'live'
         self.option = ''

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -477,6 +477,12 @@ class TestBase:
 
         return None
 
+    def check_arch_full_dynamic_support(self):
+        elf_machine = TestBase.get_elf_machine(self)
+        if elf_machine == 'x86_64' or elf_machine == 'aarch64':
+            return True
+        return False
+
     def check_arch_mfentry_mnop_mcount_support(self):
         machine = TestBase.get_machine(self)
         if machine == 'x86_64' or machine == 'i386':

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -491,6 +491,12 @@ class TestBase:
             return True
         return False
 
+    def check_arch_sdt_support(self):
+        machine = TestBase.get_machine(self)
+        if machine == 'x86_64':
+            return True
+        return False
+
     def prerun(self, timeout):
         self.subcmd = 'live'
         self.option = ''

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -468,7 +468,9 @@ class TestBase:
             f.read(EI_NIDENT + 2)
 
             # read e_machine
-            e_machine = ord(f.read(2)[0])
+            e_machine = f.read(2)[0]
+            if type(e_machine) is str:
+                e_machine = ord(e_machine)
             f.close()
 
             return machine[e_machine]

--- a/tests/t136_dynamic.py
+++ b/tests/t136_dynamic.py
@@ -13,7 +13,7 @@ class TestCase(TestBase):
 """)
 
     def build(self, name, cflags='', ldflags=''):
-        if TestBase.get_machine(self) != 'x86_64':
+        if not TestBase.check_arch_mfentry_mnop_mcount_support(self):
             return TestBase.TEST_SKIP
         if cflags.find('-finstrument-functions') >= 0:
              return TestBase.TEST_SKIP

--- a/tests/t136_dynamic.py
+++ b/tests/t136_dynamic.py
@@ -15,6 +15,8 @@ class TestCase(TestBase):
     def build(self, name, cflags='', ldflags=''):
         if TestBase.get_machine(self) != 'x86_64':
             return TestBase.TEST_SKIP
+        if cflags.find('-finstrument-functions') >= 0:
+             return TestBase.TEST_SKIP
         if self.supported_lang['C']['cc'] == 'clang':
             return TestBase.TEST_SKIP
         cflags += ' -mfentry -mnop-mcount'

--- a/tests/t147_event_sdt.py
+++ b/tests/t147_event_sdt.py
@@ -15,5 +15,10 @@ class TestCase(TestBase):
    3.017 us [28141] | } /* main */
 """)
 
+    def build(self, name, cflags='', ldflags=''):
+        if not TestBase.check_arch_sdt_support(self):
+            return TestBase.TEST_SKIP
+        return TestBase.build(self, name, cflags, ldflags)
+
     def setup(self):
         self.option = '-E uftrace:* --match glob'

--- a/tests/t150_recv_event.py
+++ b/tests/t150_recv_event.py
@@ -38,6 +38,11 @@ class TestCase(TestBase):
 
         return TestBase.TEST_SUCCESS
 
+    def build(self, name, cflags='', ldflags=''):
+        if not TestBase.check_arch_sdt_support(self):
+            return TestBase.TEST_SKIP
+        return TestBase.build(self, name, cflags, ldflags)
+
     def setup(self):
         self.subcmd = 'replay'
         self.option = '-E uftrace:event -d ' + os.path.join(TDIR, 'uftrace.data')

--- a/tests/t216_no_libcall_report.py
+++ b/tests/t216_no_libcall_report.py
@@ -7,10 +7,10 @@ class TestCase(TestBase):
         TestBase.__init__(self, 'signal', """
   Total time   Self time       Calls  Function
   ==========  ==========  ==========  ====================
-   18.227 us    1.991 us           1  main
-    0.734 us    0.590 us           1  sighandler
-    0.353 us    0.353 us           2  foo
-    0.144 us    0.144 us           1  bar
+    0.125 us    0.125 us           2  foo
+    9.500 us    0.459 us           1  main
+    0.209 us    0.126 us           1  sighandler
+    0.083 us    0.083 us           1  bar
 """, sort='report')
 
     def prepare(self):
@@ -19,4 +19,4 @@ class TestCase(TestBase):
 
     def setup(self):
         self.subcmd = 'report'
-        self.option = '--no-libcall'
+        self.option = '--no-libcall -s call,total'

--- a/tests/t223_dynamic_full.py
+++ b/tests/t223_dynamic_full.py
@@ -13,7 +13,7 @@ class TestCase(TestBase):
 """)
 
     def prerun(self, timeout):
-        if TestBase.get_elf_machine(self) == 'arm':
+        if not TestBase.check_arch_full_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 

--- a/tests/t224_dynamic_lib.py
+++ b/tests/t224_dynamic_lib.py
@@ -20,6 +20,11 @@ class TestCase(TestBase):
 7.607 us [ 26661] | } /* main */
 """)
 
+    def prerun(self, timeout):
+        if not TestBase.check_arch_full_dynamic_support(self):
+            return TestBase.TEST_SKIP
+        return TestBase.TEST_SUCCESS
+
     def build(self, name, cflags='', ldflags=''):
         if TestBase.build_notrace_lib(self, 'dyn1', 'libdyn1', cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL

--- a/tests/t225_dynamic_size.py
+++ b/tests/t225_dynamic_size.py
@@ -12,6 +12,11 @@ class TestCase(TestBase):
 
 """)
 
+    def prerun(self, timeout):
+        if not TestBase.check_arch_full_dynamic_support(self):
+            return TestBase.TEST_SKIP
+        return TestBase.TEST_SUCCESS
+
     def build(self, name, cflags='', ldflags=''):
         cflags = cflags.replace('-pg', '')
         cflags = cflags.replace('-finstrument-functions', '')

--- a/tests/t232_dynamic_unpatch.py
+++ b/tests/t232_dynamic_unpatch.py
@@ -14,11 +14,6 @@ class TestCase(TestBase):
    3.005 us [28141] | } /* main */
 """)
 
-    def prerun(self, timeout):
-        if TestBase.get_elf_machine(self) == 'arm':
-            return TestBase.TEST_SKIP
-        return TestBase.TEST_SUCCESS
-
     def build(self, name, cflags='', ldflags=''):
         if not TestBase.check_arch_mfentry_mnop_mcount_support(self):
             return TestBase.TEST_SKIP

--- a/tests/t232_dynamic_unpatch.py
+++ b/tests/t232_dynamic_unpatch.py
@@ -20,7 +20,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def build(self, name, cflags='', ldflags=''):
-        if TestBase.get_machine(self) != 'x86_64':
+        if not TestBase.check_arch_mfentry_mnop_mcount_support(self):
             return TestBase.TEST_SKIP
         if cflags.find('-finstrument-functions') >= 0:
              return TestBase.TEST_SKIP

--- a/tests/t232_dynamic_unpatch.py
+++ b/tests/t232_dynamic_unpatch.py
@@ -20,6 +20,12 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def build(self, name, cflags='', ldflags=''):
+        if TestBase.get_machine(self) != 'x86_64':
+            return TestBase.TEST_SKIP
+        if cflags.find('-finstrument-functions') >= 0:
+             return TestBase.TEST_SKIP
+        if self.supported_lang['C']['cc'] == 'clang':
+            return TestBase.TEST_SKIP
         cflags += ' -mfentry -mnop-mcount'
         cflags += ' -fno-pie -fno-plt'  # workaround of build failure
         return TestBase.build(self, name, cflags, ldflags)

--- a/tests/t233_dynamic_unpatch2.py
+++ b/tests/t233_dynamic_unpatch2.py
@@ -12,7 +12,7 @@ class TestCase(TestBase):
 """)
 
     def prerun(self, timeout):
-        if TestBase.get_elf_machine(self) == 'arm':
+        if not TestBase.check_arch_full_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 

--- a/tests/t244_report_task_field.py
+++ b/tests/t244_report_task_field.py
@@ -4,24 +4,19 @@ from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'thread-name', """
+        TestBase.__init__(self, 'thread', """
      TID   Num funcs  Task name
   ======  ==========  ====================
-   22038           9  t-thread-name
-   22040           3  t-thread-name
-   22042           3  t-thread-name
-   22041           3  t-thread-name
-   22043           3  t-thread-name
+   36562           1  t-thread
+   36578           4  t-thread
+   36577           4  t-thread
+   36580           4  t-thread
+   36579           4  t-thread
 """, ldflags='-pthread')
-
-    def build(self, name, cflags='', ldflags=''):
-        if cflags.find('-pg') >= 0:
-            return TestBase.TEST_SKIP
-
-        return TestBase.build(self, name, cflags, ldflags)
 
     def prepare(self):
         self.subcmd = 'record'
+        self.option = '--no-libcall'
         return self.runcmd()
 
     def setup(self):

--- a/tests/t248_dynamic_dlopen.py
+++ b/tests/t248_dynamic_dlopen.py
@@ -22,6 +22,11 @@ class TestCase(TestBase):
 488.088 us [108977] | } /* main */
 """)
 
+    def prerun(self, timeout):
+        if not TestBase.check_arch_full_dynamic_support(self):
+            return TestBase.TEST_SKIP
+        return TestBase.TEST_SUCCESS
+
     def build(self, name, cflags='', ldflags=''):
         cflags = cflags.replace('-pg', '')
         cflags = cflags.replace('-finstrument-functions', '')

--- a/utils/field.h
+++ b/utils/field.h
@@ -48,8 +48,8 @@ enum display_field_id {
 
 	REPORT_F_TASK_TOTAL_TIME = 0,
 	REPORT_F_TASK_SELF_TIME,
-	REPORT_F_TASK_NR_FUNC,
 	REPORT_F_TASK_TID,
+	REPORT_F_TASK_NR_FUNC,
 };
 
 struct display_field {

--- a/utils/report.c
+++ b/utils/report.c
@@ -634,8 +634,8 @@ static struct sort_task_key task_name = {
 static struct sort_task_key * all_task_keys[] = {
 	&task_total,
 	&task_self,
-	&task_func,
 	&task_tid,
+	&task_func,
 	&task_name,
 };
 
@@ -876,8 +876,8 @@ FIELD_CALL_DIFF_FULL(REPORT_F_CALL, call, call, call_diff_full_percent, "Calls (
 
 FIELD_TIME(REPORT_F_TASK_TOTAL_TIME, total, total.sum, task_total, "Total time");
 FIELD_TIME(REPORT_F_TASK_SELF_TIME, self, self.sum, task_self, "Self time");
-FIELD_CALL(REPORT_F_TASK_NR_FUNC, func, call, task_nr_func, "Num funcs");
 FIELD_TID(REPORT_F_TASK_TID, tid, task_tid, "TID");
+FIELD_CALL(REPORT_F_TASK_NR_FUNC, func, call, task_nr_func, "Num funcs");
 
 /* index of this table should be matched to display_field_id */
 static struct display_field *field_table[] = {
@@ -935,8 +935,8 @@ static struct display_field *field_diff_full_percent_table[] = {
 static struct display_field *field_task_table[] = {
 	&field_task_total,
 	&field_task_self,
-	&field_task_nr_func,
 	&field_task_tid,
+	&field_task_nr_func,
 };
 
 static void setup_default_field(struct list_head *fields, struct opts *opts,
@@ -968,8 +968,8 @@ static void setup_default_task_field(struct list_head *fields, struct opts *opts
 {
 	add_field(fields, p_field_table[REPORT_F_TASK_TOTAL_TIME]);
 	add_field(fields, p_field_table[REPORT_F_TASK_SELF_TIME]);
-	add_field(fields, p_field_table[REPORT_F_TASK_NR_FUNC]);
 	add_field(fields, p_field_table[REPORT_F_TASK_TID]);
+	add_field(fields, p_field_table[REPORT_F_TASK_NR_FUNC]);
 }
 
 void setup_report_field(struct list_head *output_fields, struct opts *opts,


### PR DESCRIPTION
This PR is to fix some tests with the following commits.
- tests: Skip -finstrument-functions builds in dynamic tests
- tests: Add TestBase.check_arch_mfentry_mnop_mcount_support
- tests: Introduce TestBase.check_arch_full_dynamic_support and use it
- tests: Fix get_elf_machine for both python2 and python3
- tests: Enable SDT tests only for x86_64
- tests: Fix random failures in 216 no_libcall_report
- report: Change the order of TID and Num funcs in report --task