### PR TITLE
build: Add undefined flag in ASAN=1 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ ifeq ($(COVERAGE), 1)
 endif
 
 ifeq ($(ASAN), 1)
-  ASAN_CFLAGS       := -O0 -g -fsanitize=address,leak
+  ASAN_CFLAGS       := -O0 -g -fsanitize=address,leak,undefined
   UFTRACE_CFLAGS    += $(ASAN_CFLAGS)
   DEMANGLER_CFLAGS  += $(ASAN_CFLAGS)
   SYMBOLS_CFLAGS    += $(ASAN_CFLAGS)

--- a/libmcount/wrap.c
+++ b/libmcount/wrap.c
@@ -581,6 +581,7 @@ TEST_CASE(mcount_env_check)
 	char **uftrace_envp;
 	char **new_envp;
 	int old1_cnt, old2_cnt, new_cnt;
+	int i;
 
 	pr_dbg("collecting environ related to uftrace\n");
 	uftrace_envp = collect_uftrace_envp();
@@ -593,6 +594,8 @@ TEST_CASE(mcount_env_check)
 
 	TEST_EQ(old1_cnt + old2_cnt, new_cnt);
 
+	for (i = 0; i < old1_cnt; i++)
+		free(uftrace_envp[i]);
 	free(uftrace_envp);
 	free(new_envp);
 

--- a/libtraceevent/kbuffer-parse.c
+++ b/libtraceevent/kbuffer-parse.c
@@ -24,8 +24,8 @@
 
 #include "kbuffer.h"
 
-#define MISSING_EVENTS (1 << 31)
-#define MISSING_STORED (1 << 30)
+#define MISSING_EVENTS (1UL << 31)
+#define MISSING_STORED (1UL << 30)
 
 #define COMMIT_MASK ((1 << 27) - 1)
 


### PR DESCRIPTION
This commit adds undefined flag in ASAN build.
This is to catch not only memory errors and leaks
but also undefined behaviors.

Signed-off-by: Kang Minchul <tegongkang@gmail.com>