### PR TITLE
i386: Support -mfentry -mnop-mcount compiled binary

### DIFF
--- a/arch/i386/mcount-arch.h
+++ b/arch/i386/mcount-arch.h
@@ -31,4 +31,6 @@ unsigned long * mcount_arch_parent_location(struct symtabs *symtabs,
 
 #define ARCH_CAN_RESTORE_PLTHOOK   1
 
+#define CALL_INSN_SIZE 5
+
 #endif /* __MCOUNT_ARCH_H__ */

--- a/arch/i386/mcount-dynamic.c
+++ b/arch/i386/mcount-dynamic.c
@@ -15,6 +15,25 @@
 /* target instrumentation function it needs to call */
 extern void __fentry__(void);
 
+enum mcount_i386_dynamic_type {
+	DYNAMIC_NONE,		/* not supported */
+	DYNAMIC_PG,
+	DYNAMIC_FENTRY,
+	DYNAMIC_FENTRY_NOP,
+};
+
+static const char *adi_type_names[] = {
+	"none", "pg", "fentry", "fentry-nop",
+};
+
+struct arch_dynamic_info {
+	enum mcount_i386_dynamic_type	type;
+	struct xray_instr_map		*xrmap;
+	unsigned long			*mcount_loc;
+	unsigned			xrmap_count;
+	unsigned			nr_mcount_loc;
+};
+
 int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
 {
 	unsigned char trampoline[] = { 0xe8, 0x00, 0x00, 0x00, 0x00, 0x58, 0xff, 0x60, 0x04 };
@@ -59,7 +78,51 @@ void mcount_cleanup_trampoline(struct mcount_dynamic_info *mdi)
 		pr_err("cannot restore trampoline due to protection");
 }
 
-#define CALL_INSN_SIZE 5
+void mcount_arch_find_module(struct mcount_dynamic_info *mdi,
+			     struct symtab *symtab)
+{
+	struct arch_dynamic_info *adi;
+	unsigned char fentry_nop_patt[] = { 0x0f, 0x1f, 0x44, 0x00, 0x00 };
+	unsigned i = 0;
+
+	adi = xzalloc(sizeof(*adi));  /* DYNAMIC_NONE */
+
+	/* check first few functions have fentry signature */
+	for (i = 0; i < symtab->nr_sym; i++) {
+		struct sym *sym = &symtab->sym[i];
+		void *code_addr = (unsigned char *)((uintptr_t)(sym->addr + mdi->map->start));
+
+		if (sym->type != ST_LOCAL_FUNC && sym->type != ST_GLOBAL_FUNC)
+			continue;
+
+		/* dont' check special functions */
+		if (sym->name[0] == '_')
+			continue;
+
+		/* only support calls to __fentry__ at the beginning */
+		if (!memcmp(code_addr, fentry_nop_patt, CALL_INSN_SIZE)) {
+			adi->type = DYNAMIC_FENTRY_NOP;
+			goto out;
+		}
+	}
+
+	switch (check_trace_functions(mdi->map->libname)) {
+	case TRACE_MCOUNT:
+		adi->type = DYNAMIC_PG;
+		break;
+	case TRACE_FENTRY:
+		adi->type = DYNAMIC_FENTRY;
+		break;
+	default:
+		break;
+	}
+
+out:
+	pr_dbg("dynamic patch type: %s: %d (%s)\n", basename(mdi->map->libname),
+	       adi->type, adi_type_names[adi->type]);
+
+	mdi->arch = adi;
+}
 
 static unsigned long get_target_addr(struct mcount_dynamic_info *mdi, unsigned long addr)
 {
@@ -77,7 +140,7 @@ static int patch_fentry_func(struct mcount_dynamic_info *mdi, struct sym *sym)
 	// In case of "gcc" which is not patched because of old version, 
 	// it may not create 5 byte nop.
 	unsigned char nop[] = { 0x0f, 0x1f, 0x44, 0x00, 0x00 };
-	unsigned char *insn = (unsigned char *)((uintptr_t)sym->addr);
+	unsigned char *insn = (unsigned char *)((uintptr_t)(sym->addr + mdi->map->start));
 	unsigned int target_addr;
 
 	/* only support calls to __fentry__ at the beginning */
@@ -87,7 +150,7 @@ static int patch_fentry_func(struct mcount_dynamic_info *mdi, struct sym *sym)
 	}
 
 	/* get the jump offset to the trampoline */
-	target_addr = get_target_addr(mdi, sym->addr);
+	target_addr = get_target_addr(mdi, (unsigned long)insn);
 	if (target_addr == 0)
 		return -2;
 
@@ -105,6 +168,22 @@ static int patch_fentry_func(struct mcount_dynamic_info *mdi, struct sym *sym)
 int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym,
 		      struct mcount_disasm_engine *disasm, unsigned min_size)
 {
-	return patch_fentry_func(mdi, sym);
+	struct arch_dynamic_info *adi = mdi->arch;
+	int result = INSTRUMENT_SKIPPED;
+
+	if (min_size < CALL_INSN_SIZE)
+		min_size = CALL_INSN_SIZE;
+
+	if (sym->size < min_size)
+		return result;
+
+	switch (adi->type) {
+	case DYNAMIC_FENTRY_NOP:
+		result = patch_fentry_func(mdi, sym);
+		break;
+	default:
+		break;
+	}
+	return result;
 }
 

--- a/arch/i386/mcount-dynamic.c
+++ b/arch/i386/mcount-dynamic.c
@@ -55,7 +55,7 @@ int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
 
 void mcount_cleanup_trampoline(struct mcount_dynamic_info *mdi)
 {
-	if (mprotect((void *)mdi->text_addr, mdi->text_size, PROT_EXEC))
+	if (mprotect((void *)mdi->text_addr, mdi->text_size, PROT_READ | PROT_EXEC))
 		pr_err("cannot restore trampoline due to protection");
 }
 

--- a/arch/x86_64/mcount-noplt.c
+++ b/arch/x86_64/mcount-noplt.c
@@ -118,7 +118,7 @@ struct plthook_data * mcount_arch_hook_no_plt(struct uftrace_elf_data *elf,
 		tramp += TRAMP_ENT_SIZE;
 	}
 
-	mprotect(trampoline, tramp_len, PROT_READ|PROT_EXEC);
+	mprotect(trampoline, tramp_len, PROT_READ | PROT_EXEC);
 
 	pd->mod_name = xstrdup(modname);
 

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -164,7 +164,7 @@ void mcount_freeze_code(void)
 		if (cp->frozen)
 			continue;
 
-		if (mprotect(cp->page, CODE_CHUNK, PROT_READ|PROT_EXEC) < 0)
+		if (mprotect(cp->page, CODE_CHUNK, PROT_READ | PROT_EXEC) < 0)
 			pr_err("mprotect to freeze code page failed");
 		cp->frozen = true;
 	}


### PR DESCRIPTION
This PR allows `-mfentry -mnop-mcount` compiled binary in i386 arch.
Unlike x86_64, i386 doesn't support xray nor full dynamic tracing.
```
  $ gcc -pg -mfentry -mnop-mcount -m32 -o t-abc s-abc.c

  $ uftrace -P. -f +addr t-abc
  # DURATION     TID    ADDRESS   FUNCTION
     0.870 us [ 39676]  80483d0 | __monstartup();
     0.757 us [ 39676]  80483f0 | __cxa_atexit();
              [ 39676]  80485c4 | main() {
              [ 39676]  8048567 |   a() {
              [ 39676]  804857c |     b() {
              [ 39676]  8048591 |       c() {
     0.541 us [ 39676]  80483e0 |         getpid();
     1.394 us [ 39676]  8048591 |       } /* c */
     1.840 us [ 39676]  804857c |     } /* b */
     2.157 us [ 39676]  8048567 |   } /* a */
     2.629 us [ 39676]  80485c4 | } /* main */
```
Before:
```
  Test case                 pg
  ------------------------: O0 O1 O2 O3 Os
  136 dynamic             : SG SG SG SG SG
```
After:
```
  Test case                 pg
  ------------------------: O0 O1 O2 O3 Os
  136 dynamic             : OK OK OK OK OK
```