### PR TITLE
utils: Use only libunwind without using execinfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,8 @@ TEST_LDFLAGS       = $(COMMON_LDFLAGS) -L$(objdir)/libtraceevent -ltraceevent
 
 ifeq ($(DEBUG), 1)
   COMMON_CFLAGS += -O0 -g -DDEBUG_MODE=1
-  COMMON_LDFLAGS += -lunwind
 else
-  COMMON_CFLAGS += -O2 -g -DDEBUG_MODE=0 -rdynamic
+  COMMON_CFLAGS += -O2 -g -DDEBUG_MODE=0
 endif
 
 ifeq ($(TRACE), 1)

--- a/check-deps/Makefile
+++ b/check-deps/Makefile
@@ -11,6 +11,7 @@ CHECK_LIST += perf_context_switch
 CHECK_LIST += arm_has_hardfp
 CHECK_LIST += have_libncurses
 CHECK_LIST += have_libdw
+CHECK_LIST += have_libunwind
 CHECK_LIST += have_libcapstone
 CHECK_LIST += cc_has_minline_all_stringops
 
@@ -41,6 +42,8 @@ CFLAGS_have_libdw  = $(shell pkg-config --cflags libdw 2> /dev/null)
 LDFLAGS_have_libdw = $(shell pkg-config --libs   libdw 2> /dev/null || echo "-ldw")
 CFLAGS_have_libcapstone  = $(shell pkg-config --cflags capstone 2> /dev/null)
 LDFLAGS_have_libcapstone = $(shell pkg-config --libs   capstone 2> /dev/null)
+CFLAGS_have_libunwind  = $(shell pkg-config --cflags libunwind 2> /dev/null)
+LDFLAGS_have_libunwind = $(shell pkg-config --libs   libunwind 2> /dev/null)
 CFLAGS_cc_has_minline_all_stringops = -minline-all-stringops
 
 check-build: check-tstamp $(CHECK_LIST)

--- a/check-deps/Makefile.check
+++ b/check-deps/Makefile.check
@@ -64,6 +64,14 @@ ifneq ($(wildcard $(srcdir)/check-deps/have_libdw),)
   COMMON_LDFLAGS += $(shell pkg-config --libs libdw 2> /dev/null || echo "-ldw")
 endif
 
+ifneq ($(wildcard $(srcdir)/check-deps/have_libunwind),)
+ifeq ($(DEBUG), 1)
+  COMMON_CFLAGS  += -DHAVE_LIBUNWIND
+  COMMON_CFLAGS  += $(shell pkg-config --cflags libunwind 2> /dev/null)
+  COMMON_LDFLAGS += $(shell pkg-config --libs   libunwind 2> /dev/null)
+endif
+endif
+
 ifneq ($(wildcard $(srcdir)/check-deps/have_libcapstone),)
   COMMON_CFLAGS  += -DHAVE_LIBCAPSTONE
   COMMON_CFLAGS  += $(shell pkg-config --cflags capstone 2> /dev/null)

--- a/check-deps/__have_libunwind.c
+++ b/check-deps/__have_libunwind.c
@@ -1,0 +1,13 @@
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
+
+int main(void)
+{
+	unw_cursor_t cursor;
+	unw_context_t context;
+
+	unw_getcontext(&context);
+	unw_init_local(&cursor, &context);
+
+	return 0;
+}

--- a/configure
+++ b/configure
@@ -31,6 +31,7 @@ usage() {
   --without-libpython   build without libpython              (even if found on the system)
   --without-libluajit   build without libluajit              (even if found on the system)
   --without-libncurses  build without libncursesw            (even if found on the system)
+  --without-libunwind   build without libunwind              (even if found on the system)
   --without-capstone    build without libcapstone            (even if found on the system)
   --without-perf        build without perf event             (even if available)
   --without-schedule    build without scheduler event        (even if available)
@@ -187,6 +188,7 @@ for dep in $IGNORE; do
         libpython*)  TARGET='have_libpython*'  ;;
         libluajit*)  TARGET=have_libluajit     ;;
         libncurse*)  TARGET=have_libncurses    ;;
+        libunwind)   TARGET=have_libunwind     ;;
         libstdc++)   TARGET=cxa_demangle       ;;
         capstone)    TARGET=have_libcapstone   ;;
         perf*)       TARGET=perf_clockid       ;;
@@ -257,6 +259,7 @@ print_feature "cxa_demangle" "cxa_demangle" "full demangler support with libstdc
 print_feature "perf_event" "perf_clockid" "perf (PMU) event support"
 print_feature "schedule" "perf_context_switch" "scheduler event support"
 print_feature "capstone" "have_libcapstone" "full dynamic tracing support"
+print_feature "libunwind" "have_libunwind" "libunwind support"
 
 cat >$output <<EOF
 # this file is generated automatically

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -8,9 +8,7 @@
 #include <sys/stat.h>
 #include <libgen.h>
 
-#if !DEBUG_MODE
-#include <execinfo.h>
-#else
+#ifdef HAVE_LIBUNWIND
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
 #endif
@@ -890,23 +888,7 @@ char *absolute_dirname(const char *path, char *resolved_path)
 
 void stacktrace(void)
 {
-#if !DEBUG_MODE
-	void *buffer[64];
-	int nptrs = backtrace(buffer, 64);
-
-	int i;
-	char **strings;
-
-	pr_yellow("Stack trace:\n");
-	strings = backtrace_symbols(buffer, nptrs);
-	for (i = 1; i < nptrs; i++) {
-		if (strings)
-			pr_yellow("  #%-2d %s\n", i, strings[i]);
-		else
-			pr_yellow("  #%-2d %p\n", i, buffer[i]);
-	}
-	free(strings);
-#else
+#ifdef HAVE_LIBUNWIND
 	const int max_depth = 64;
 	int i = 0;
 	bool out = false;


### PR DESCRIPTION
The current stacktrace in release mode uses backtrace() in execinfo.h,
but it can't show static function names and it doesn't work reliable in
libmcount*.so libraries during record time.

Moreover, execinfo.h is not well supported in some environments such as
alpine Linux.

So we better use only libunwind when it's available. If not, we just do
not print anything in stacktrace().

This PR also contains build check routine for libunwind as follows.
```
  $ ./configure
  uftrace detected system features:
  ...         prefix: /usr/local
                ...
  ...      libunwind: [ on  ] - libunwind support
```
Fixed: #1298

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>