### PR TITLE
utils: Fix runtime errors caught by ubsan

### DIFF
--- a/utils/dwarf.c
+++ b/utils/dwarf.c
@@ -2182,11 +2182,15 @@ void load_debug_info(struct symtabs *symtabs, bool needs_srcline)
 	struct uftrace_mmap *map;
 
 	for_each_map(symtabs, map) {
-		struct symtab *stab = &map->mod->symtab;
-		struct debug_info *dinfo = &map->mod->dinfo;
+		struct uftrace_module *mod = map->mod;
+		struct symtab *stab;
+		struct debug_info *dinfo;
 
 		if (map->mod == NULL)
 			continue;
+
+		stab = &mod->symtab;
+		dinfo = &mod->dinfo;
 
 		if (!debug_info_has_location(dinfo) && !debug_info_has_argspec(dinfo)) {
 			load_debug_file(dinfo, stab, symtabs->dirname,


### PR DESCRIPTION
This patch fixes the following runtime errors generated by ubsan,
UndefinedBehaviorSanitizer.
```
  $ make SAN=all install

  $ gcc -pg tests/s-exp-float.c

  $ uftrace -F main -D 1 a.out
  /home/honggyu/uftrace/utils/dwarf.c:2185:18: runtime error: member access within null pointer of type 'struct uftrace_module'
  /home/honggyu/uftrace/utils/dwarf.c:2186:22: runtime error: member access within null pointer of type 'struct uftrace_module'
  # DURATION     TID     FUNCTION
     0.721 us [ 41456] | main();
```
Fixed: #1300

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>