### PR TITLE
uftrace: Make option struct 'opts' as a global variable

### DIFF
--- a/uftrace.h
+++ b/uftrace.h
@@ -282,36 +282,37 @@ struct opts {
 	enum uftrace_pattern_type patt_type;
 };
 
+extern struct opts opts;
+
 extern struct strv default_opts;
 
-static inline bool opts_has_filter(struct opts *opts)
+static inline bool opts_has_filter(void)
 {
-	return opts->filter || opts->trigger || opts->threshold ||
-		opts->depth != OPT_DEPTH_DEFAULT;
+	return opts.filter || opts.trigger || opts.threshold ||
+		opts.depth != OPT_DEPTH_DEFAULT;
 }
 
-void parse_script_opt(struct opts *opts);
+void parse_script_opt(void);
 
-int command_record(int argc, char *argv[], struct opts *opts);
-int command_replay(int argc, char *argv[], struct opts *opts);
-int command_live(int argc, char *argv[], struct opts *opts);
-int command_report(int argc, char *argv[], struct opts *opts);
-int command_info(int argc, char *argv[], struct opts *opts);
-int command_recv(int argc, char *argv[], struct opts *opts);
-int command_dump(int argc, char *argv[], struct opts *opts);
-int command_graph(int argc, char *argv[], struct opts *opts);
-int command_script(int argc, char *argv[], struct opts *opts);
-int command_tui(int argc, char *argv[], struct opts *opts);
+int command_record(int argc, char *argv[]);
+int command_replay(int argc, char *argv[]);
+int command_live(int argc, char *argv[]);
+int command_report(int argc, char *argv[]);
+int command_info(int argc, char *argv[]);
+int command_recv(int argc, char *argv[]);
+int command_dump(int argc, char *argv[]);
+int command_graph(int argc, char *argv[]);
+int command_script(int argc, char *argv[]);
+int command_tui(int argc, char *argv[]);
 
 extern volatile bool uftrace_done;
 
-int open_data_file(struct opts *opts, struct uftrace_data *handle);
-int open_info_file(struct opts *opts, struct uftrace_data *handle);
-void __close_data_file(struct opts *opts, struct uftrace_data *handle,
-		       bool unload_modules);
-static inline void close_data_file(struct opts *opts, struct uftrace_data *handle)
+int open_data_file(struct uftrace_data *handle);
+int open_info_file(struct uftrace_data *handle);
+void __close_data_file(struct uftrace_data *handle, bool unload_modules);
+static inline void close_data_file(struct uftrace_data *handle)
 {
-	__close_data_file(opts, handle, true);
+	__close_data_file(handle, true);
 }
 
 int read_task_file(struct uftrace_session_link *sess, char *dirname,
@@ -319,7 +320,7 @@ int read_task_file(struct uftrace_session_link *sess, char *dirname,
 int read_task_txt_file(struct uftrace_session_link *sess, char *dirname,
 		       bool needs_symtab, bool sym_rel_addr, bool needs_srcline);
 
-char * get_libmcount_path(struct opts *opts);
+char * get_libmcount_path(void);
 void put_libmcount_path(char *libpath);
 
 #define SESSION_ID_LEN  16
@@ -463,7 +464,7 @@ typedef int (*walk_tasks_cb_t)(struct uftrace_task *task, void *arg);
 void walk_tasks(struct uftrace_session_link *sess,
 		walk_tasks_cb_t callback, void *arg);
 
-int setup_client_socket(struct opts *opts);
+int setup_client_socket(void);
 void send_trace_dir_name(int sock, char *name);
 void send_trace_data(int sock, int tid, void *data, size_t len);
 void send_trace_kernel_data(int sock, int cpu, void *data, size_t len);
@@ -550,10 +551,10 @@ static inline bool has_event_data(struct uftrace_data *handle)
 
 struct rusage;
 
-void fill_uftrace_info(uint64_t *info_mask, int fd, struct opts *opts, int status,
+void fill_uftrace_info(uint64_t *info_mask, int fd, int status,
 		      struct rusage *rusage, char *elapsed_time);
 int read_uftrace_info(uint64_t info_mask, struct uftrace_data *handle);
-void process_uftrace_info(struct uftrace_data *handle, struct opts *opts,
+void process_uftrace_info(struct uftrace_data *handle,
 			  void (*process)(void *data, const char *fmt, ...),
 			  void *data);
 void clear_uftrace_info(struct uftrace_info *info);

--- a/utils/extern.c
+++ b/utils/extern.c
@@ -25,7 +25,7 @@
 
 #define DEFAULT_FILENAME  "extern.dat"
 
-int setup_extern_data(struct uftrace_data *handle, struct opts *opts)
+int setup_extern_data(struct uftrace_data *handle)
 {
 	struct uftrace_extern_reader *extn;
 	char *filename;
@@ -33,13 +33,13 @@ int setup_extern_data(struct uftrace_data *handle, struct opts *opts)
 
 	handle->extn = NULL;
 
-	filename = opts->extern_data;
+	filename = opts.extern_data;
 	if (filename == NULL)
-		xasprintf(&filename, "%s/%s", opts->dirname, DEFAULT_FILENAME);
+		xasprintf(&filename, "%s/%s", opts.dirname, DEFAULT_FILENAME);
 
 	fp = fopen(filename, "r");
 
-	if (opts->extern_data == NULL)
+	if (opts.extern_data == NULL)
 		free(filename);
 
 	if (fp == NULL) {
@@ -138,12 +138,11 @@ TEST_CASE(fstack_extern_data)
 	struct uftrace_data handle = {
 		.dirname = "extern.test",
 	};
-	struct opts opts = {
-		.dirname = "extern.test",
-	};
 	const char extern_data[] = "# test data\n"
 		"1234.987654321 first data\n"
 		"1234.123456789 second data\n";
+
+	opts.dirname = "extern.test",
 
 	pr_dbg("creating external data file\n");
 	mkdir("extern.test", 0755);
@@ -152,7 +151,7 @@ TEST_CASE(fstack_extern_data)
 	write(fd, extern_data, sizeof(extern_data)-1);
 	close(fd);
 
-	setup_extern_data(&handle, &opts);
+	setup_extern_data(&handle);
 
 	pr_dbg("first read should return first data\n");
 	read_extern_data(handle.extn);

--- a/utils/field.c
+++ b/utils/field.c
@@ -110,7 +110,7 @@ static bool check_field_name(struct display_field *field, const char *name)
 	return false;
 }
 
-void setup_field(struct list_head *output_fields, struct opts *opts,
+void setup_field(struct list_head *output_fields,
 		 setup_default_field_t setup_default_field,
 		 struct display_field *field_table[], size_t field_table_size)
 {
@@ -122,21 +122,21 @@ void setup_field(struct list_head *output_fields, struct opts *opts,
 	bool *field_flags;
 
 	/* default fields */
-	if (opts->fields == NULL) {
-		setup_default_field(output_fields, opts, field_table);
+	if (opts.fields == NULL) {
+		setup_default_field(output_fields, field_table);
 		return;
 	}
 
-	if (!strcmp(opts->fields, "none"))
+	if (!strcmp(opts.fields, "none"))
 		return;
 
 	field_flags = xcalloc(field_table_size, sizeof(*field_flags));
 
-	str = opts->fields;
+	str = opts.fields;
 
 	if (*str == '+') {
 		/* prepend default fields */
-		setup_default_field(output_fields, opts, field_table);
+		setup_default_field(output_fields, field_table);
 		for (i = 0; i < field_table_size; i++) {
 			if (field_table[i]->used)
 				field_flags[i] = true;
@@ -184,7 +184,7 @@ void setup_field(struct list_head *output_fields, struct opts *opts,
 
 static void print_nothing(struct field_data* fd) {}
 
-static void setup_first_field(struct list_head *head, struct opts *opts,
+static void setup_first_field(struct list_head *head,
 			      struct display_field *p_field_table[])
 {
 	add_field(head, p_field_table[0]);
@@ -207,10 +207,10 @@ static struct display_field *test_field_table[] = {
 TEST_CASE(field_setup_default)
 {
 	LIST_HEAD(output_fields);
-	struct opts opts = { .fields = NULL, };
+	opts.fields = NULL;
 
 	pr_dbg("calling setup_default_field\n");
-	setup_field(&output_fields, &opts, setup_first_field,
+	setup_field(&output_fields, setup_first_field,
 		    test_field_table, ARRAY_SIZE(test_field_table));
 
 	TEST_EQ(output_fields.next, &field1.list);
@@ -224,10 +224,10 @@ TEST_CASE(field_setup_default)
 TEST_CASE(field_setup_default_plus)
 {
 	LIST_HEAD(output_fields);
-	struct opts opts = { .fields = "+abc", };
+	opts.fields = "+abc";
 
 	pr_dbg("add 'abc' field after the default\n");
-	setup_field(&output_fields, &opts, setup_first_field,
+	setup_field(&output_fields, setup_first_field,
 		    test_field_table, ARRAY_SIZE(test_field_table));
 
 	TEST_EQ(output_fields.next, &field1.list);
@@ -242,10 +242,10 @@ TEST_CASE(field_setup_default_plus)
 TEST_CASE(field_setup_list)
 {
 	LIST_HEAD(output_fields);
-	struct opts opts = { .fields = "bar,foo", };
+	opts.fields = "bar,foo";
 
 	pr_dbg("setup fields in a given order\n");
-	setup_field(&output_fields, &opts, setup_first_field,
+	setup_field(&output_fields, setup_first_field,
 		    test_field_table, ARRAY_SIZE(test_field_table));
 
 	TEST_EQ(output_fields.next, &field1.list);
@@ -260,10 +260,10 @@ TEST_CASE(field_setup_list)
 TEST_CASE(field_setup_list_alias)
 {
 	LIST_HEAD(output_fields);
-	struct opts opts = { .fields = "baz,xyz", };
+	opts.fields = "baz,xyz";
 
 	pr_dbg("setup fields with alias name\n");
-	setup_field(&output_fields, &opts, setup_first_field,
+	setup_field(&output_fields, setup_first_field,
 		    test_field_table, ARRAY_SIZE(test_field_table));
 
 	TEST_EQ(output_fields.next, &field2.list);

--- a/utils/field.h
+++ b/utils/field.h
@@ -63,7 +63,7 @@ struct display_field {
 	const char *alias;
 };
 
-typedef void (*setup_default_field_t)(struct list_head *fields, struct opts*,
+typedef void (*setup_default_field_t)(struct list_head *fields,
 				      struct display_field *p_field_table[]);
 
 static inline uint64_t effective_addr(uint64_t addr)
@@ -82,7 +82,7 @@ int print_field_data(struct list_head *output_fields, struct field_data *fd,
 int print_empty_field(struct list_head *output_fields, int space);
 void add_field(struct list_head *output_fields, struct display_field *field);
 void del_field(struct display_field *field);
-void setup_field(struct list_head *output_fields, struct opts *opts,
+void setup_field(struct list_head *output_fields,
 		 setup_default_field_t setup_default_field,
 		 struct display_field *field_table[],
 		 size_t field_table_size);

--- a/utils/fstack.h
+++ b/utils/fstack.h
@@ -150,7 +150,7 @@ static inline bool is_extern_record(struct uftrace_task_reader *task,
 void setup_fstack_args(char *argspec, char *retspec,
 		       struct uftrace_data *handle,
 		       struct uftrace_filter_setting *setting);
-int fstack_setup_filters(struct opts *opts, struct uftrace_data *handle);
+int fstack_setup_filters(struct uftrace_data *handle);
 
 struct fstack * fstack_get(struct uftrace_task_reader *task, int idx);
 int fstack_entry(struct uftrace_task_reader *task,
@@ -161,9 +161,9 @@ int fstack_update(int type, struct uftrace_task_reader *task,
 		  struct fstack *fstack);
 struct uftrace_task_reader *fstack_skip(struct uftrace_data *handle,
 				       struct uftrace_task_reader *task,
-				       int curr_depth, struct opts *opts);
+				       int curr_depth);
 bool fstack_check_filter(struct uftrace_task_reader *task);
-bool fstack_check_opts(struct uftrace_task_reader *task, struct opts *opts);
+bool fstack_check_opts(struct uftrace_task_reader *task);
 void fstack_check_filter_done(struct uftrace_task_reader *task);
 
 bool is_sched_event(uint64_t addr);
@@ -182,7 +182,7 @@ struct uftrace_extern_reader {
 	struct uftrace_record	rec;
 };
 
-int setup_extern_data(struct uftrace_data *handle, struct opts *opts);
+int setup_extern_data(struct uftrace_data *handle);
 int read_extern_data(struct uftrace_extern_reader *extn);
 struct uftrace_record * get_extern_record(struct uftrace_extern_reader *extn,
 					  struct uftrace_record *rec);

--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -622,12 +622,11 @@ static void skip_kernel_functions(struct uftrace_kernel_writer *kernel)
 /**
  * setup_kernel_tracing - prepare to record kernel ftrace data (binary)
  * @kernel : kernel ftrace handle
- * @opts: option related to kernel tracing
  *
  * This function sets up all necessary data structures and configure
  * kernel ftrace subsystem.
  */
-int setup_kernel_tracing(struct uftrace_kernel_writer *kernel, struct opts *opts)
+int setup_kernel_tracing(struct uftrace_kernel_writer *kernel)
 {
 	int i, n;
 	int ret;
@@ -638,22 +637,22 @@ int setup_kernel_tracing(struct uftrace_kernel_writer *kernel, struct opts *opts
 	INIT_LIST_HEAD(&kernel->nopatch);
 	INIT_LIST_HEAD(&kernel->events);
 
-	build_kernel_filter(kernel, opts->filter, opts->patt_type,
+	build_kernel_filter(kernel, opts.filter, opts.patt_type,
 			    &kernel->filters, &kernel->notrace);
-	build_kernel_filter(kernel, opts->patch, opts->patt_type,
+	build_kernel_filter(kernel, opts.patch, opts.patt_type,
 			    &kernel->patches, &kernel->nopatch);
-	build_kernel_event(kernel, opts->event, opts->patt_type,
+	build_kernel_event(kernel, opts.event, opts.patt_type,
 			   &kernel->events);
 
-	if (opts->kernel)
+	if (opts.kernel)
 		kernel->tracer = KERNEL_GRAPH_TRACER;
 	else
 		kernel->tracer = KERNEL_NOP_TRACER;
 
 	/* mark kernel tracing is enabled (for event tracing) */
-	opts->kernel = true;
+	opts.kernel = true;
 
-	if (opts->kernel_skip_out)
+	if (opts.kernel_skip_out)
 		skip_kernel_functions(kernel);
 
 	ret = __setup_kernel_tracing(kernel);

--- a/utils/kernel.h
+++ b/utils/kernel.h
@@ -47,8 +47,7 @@ struct uftrace_kernel_reader {
 };
 
 /* these functions will be used at record time */
-int setup_kernel_tracing(struct uftrace_kernel_writer *kernel,
-			 struct opts *opts);
+int setup_kernel_tracing(struct uftrace_kernel_writer *kernel);
 int start_kernel_tracing(struct uftrace_kernel_writer *kernel);
 int record_kernel_tracing(struct uftrace_kernel_writer *kernel);
 int record_kernel_trace_pipe(struct uftrace_kernel_writer *kernel,

--- a/utils/report.c
+++ b/utils/report.c
@@ -939,7 +939,7 @@ static struct display_field *field_task_table[] = {
 	&field_task_nr_func,
 };
 
-static void setup_default_field(struct list_head *fields, struct opts *opts,
+static void setup_default_field(struct list_head *fields,
 				struct display_field *p_field_table[])
 {
 	add_field(fields, p_field_table[REPORT_F_TOTAL_TIME]);
@@ -947,7 +947,7 @@ static void setup_default_field(struct list_head *fields, struct opts *opts,
 	add_field(fields, p_field_table[REPORT_F_CALL]);
 }
 
-static void setup_avg_total_field(struct list_head *fields, struct opts *opts,
+static void setup_avg_total_field(struct list_head *fields,
 				  struct display_field *p_field_table[])
 {
 	add_field(fields, p_field_table[REPORT_F_TOTAL_TIME_AVG]);
@@ -955,7 +955,7 @@ static void setup_avg_total_field(struct list_head *fields, struct opts *opts,
 	add_field(fields, p_field_table[REPORT_F_TOTAL_TIME_MAX]);
 }
 
-static void setup_avg_self_field(struct list_head *fields, struct opts *opts,
+static void setup_avg_self_field(struct list_head *fields,
 				 struct display_field *p_field_table[])
 {
 	add_field(fields, p_field_table[REPORT_F_SELF_TIME_AVG]);
@@ -963,7 +963,7 @@ static void setup_avg_self_field(struct list_head *fields, struct opts *opts,
 	add_field(fields, p_field_table[REPORT_F_SELF_TIME_MAX]);
 }
 
-static void setup_default_task_field(struct list_head *fields, struct opts *opts,
+static void setup_default_task_field(struct list_head *fields,
 				struct display_field *p_field_table[])
 {
 	add_field(fields, p_field_table[REPORT_F_TASK_TOTAL_TIME]);
@@ -972,8 +972,7 @@ static void setup_default_task_field(struct list_head *fields, struct opts *opts
 	add_field(fields, p_field_table[REPORT_F_TASK_NR_FUNC]);
 }
 
-void setup_report_field(struct list_head *output_fields, struct opts *opts,
-			enum avg_mode avg_mode)
+void setup_report_field(struct list_head *output_fields, enum avg_mode avg_mode)
 {
 	struct display_field **f_table;
 	int table_size;
@@ -981,14 +980,14 @@ void setup_report_field(struct list_head *output_fields, struct opts *opts,
 				       &setup_avg_total_field,
 				       &setup_avg_self_field };
 
-	if (opts->show_task) {
-		setup_field(output_fields, opts, setup_default_task_field,
+	if (opts.show_task) {
+		setup_field(output_fields, setup_default_task_field,
 			    field_task_table, ARRAY_SIZE(field_task_table));
 		return;
 	}
 
-	if (opts->diff) {
-		if (opts->diff_policy && diff_policy.full) {
+	if (opts.diff) {
+		if (opts.diff_policy && diff_policy.full) {
 			if (diff_policy.percent) {
 				f_table = field_diff_full_percent_table;
 				table_size = ARRAY_SIZE(field_diff_full_percent_table);
@@ -1008,7 +1007,7 @@ void setup_report_field(struct list_head *output_fields, struct opts *opts,
 		table_size = ARRAY_SIZE(field_table);
 	}
 
-	setup_field(output_fields, opts, fn[avg_mode], f_table, table_size);
+	setup_field(output_fields, fn[avg_mode], f_table, table_size);
 }
 
 #ifdef UNIT_TEST

--- a/utils/report.h
+++ b/utils/report.h
@@ -73,7 +73,7 @@ int report_setup_task(const char *key_str);
 void report_sort_tasks(struct uftrace_data *handle, struct rb_root *name_root,
 		       struct rb_root *sort_root);
 
-void setup_report_field(struct list_head *output_fields, struct opts *opts,
+void setup_report_field(struct list_head *output_fields,
 			enum avg_mode avg_mode);
 
 #endif /* UFTRACE_REPORT_H */


### PR DESCRIPTION
We currently pass 'struct opts *opts` many places around but sometimes
it's annoying or tricky to add an extra arguments for option handling.

Rather than doing this, we better make 'struct opts' a global variable
and use everywhere.

Test results looks same as before and the failed tests are known issues.
```
  $ make test
        ...
  unit test stats
  ====================
   74 ran successfully
    0 failed
    0 skipped
    0 signal caught
    0 unknown result
        ...
  runtime test stats
  ====================
  total  2600  Tests executed (success: 80.15%)
    OK:  2019  Test succeeded
    OK:    65  Test succeeded (with some fixup)
    NG:    36  Different test result
    NZ:     0  Non-zero return value
    SG:     0  Abnormal exit by signal
    TM:     0  Test ran too long
    BI:    10  Build failed
    LA:     0  Unsupported Language
    SK:   470  Skipped
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>