### PR TITLE
utils: Change strerror_r into wrapper function

### DIFF
--- a/libtraceevent/event-parse.c
+++ b/libtraceevent/event-parse.c
@@ -32,6 +32,7 @@
 #include <stdint.h>
 #include <limits.h>
 
+#include "utils/utils.h"
 #include "event-parse.h"
 #include "event-utils.h"
 
@@ -5353,7 +5354,7 @@ int pevent_strerror(struct pevent *pevent __maybe_unused,
 	const char *msg;
 
 	if (errnum >= 0) {
-		msg = strerror_r(errnum, buf, buflen);
+		msg = uftrace_strerror(errnum, buf, buflen);
 		if (msg != buf) {
 			size_t len = strlen(msg);
 			memcpy(buf, msg, min(buflen - 1, len));

--- a/utils/debug.c
+++ b/utils/debug.c
@@ -187,7 +187,7 @@ void __pr_err_s(const char *fmt, ...)
 	vfprintf(logfp, fmt, ap);
 	va_end(ap);
 
-	fprintf(logfp, ": %s\n", strerror_r(saved_errno, buf, sizeof(buf)));
+	fprintf(logfp, ": %s\n", uftrace_strerror(saved_errno, buf, sizeof(buf)));
 
 	color(TERM_COLOR_RESET, logfp);
 

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -886,6 +886,23 @@ char *absolute_dirname(const char *path, char *resolved_path)
 	return resolved_path;
 }
 
+char *uftrace_strerror(int errnum, char *buf, size_t buflen)
+{
+	long result = (long) strerror_r(errnum, buf, buflen);
+
+	if (result == 0)
+		/* XSI-compliant strerror_r succeed */
+		return buf;
+	else if (result < 4096) {
+		/* XSI-compliant strerror_r failed */
+		snprintf(buf, buflen, "error: %d", errnum);
+		return buf;
+	}
+	else
+		/* GNU-specific strerror_r */
+		return (char *)result;
+}
+
 void stacktrace(void)
 {
 #ifdef HAVE_LIBUNWIND

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -370,6 +370,8 @@ struct uftrace_data;
 char *get_event_name(struct uftrace_data *handle, unsigned evt_id);
 char *absolute_dirname(const char *path, char *resolved_path);
 
+char * uftrace_strerror(int errnum, char *buf, size_t buflen);
+
 void stacktrace(void);
 
 #define ASSERT(cond) 							\


### PR DESCRIPTION
This commit change `strerror_r` into wrapper function called
`uftrace_strerror`, because return value of the function can be
either string, or int depending on the system.

Fixed: #1303

Signed-off-by: Kang Minchul <tegongkang@gmail.com>