### PR TITLE
doc: Change ci logo link from travis-ci.org to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/namhyung/uftrace.svg?branch=master)](https://travis-ci.org/namhyung/uftrace)
+[![Build Status](https://app.travis-ci.com/namhyung/uftrace.svg?branch=master)](https://app.travis-ci.com/namhyung/uftrace)
 [![Coverity scan](https://scan.coverity.com/projects/12421/badge.svg)](https://scan.coverity.com/projects/namhyung-uftrace)
 
 uftrace

--- a/doc/ko/README.md
+++ b/doc/ko/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/namhyung/uftrace.svg?branch=master)](https://travis-ci.org/namhyung/uftrace)
+[![Build Status](https://app.travis-ci.com/namhyung/uftrace.svg?branch=master)](https://app.travis-ci.com/namhyung/uftrace)
 [![Coverity scan](https://scan.coverity.com/projects/12421/badge.svg)](https://scan.coverity.com/projects/namhyung-uftrace)
 
 uftrace


### PR DESCRIPTION
This commit changes the link of ci logo because
building on travis-ci.org is currently not supported.

Signed-off-by: Kang Minchul <tegongkang@gmail.com>