### PR TITLE
Fix spelling of errors on missung libmcount.so

### DIFF
--- a/cmds/live.c
+++ b/cmds/live.c
@@ -79,7 +79,7 @@ static void setup_child_environ(struct opts *opts)
 
 	libpath = get_libmcount_path(opts);
 	if (libpath == NULL)
-		pr_err_ns("cannot found libmcount.so\n");
+		pr_err_ns("uftrace could not find libmcount.so for live-tracing\n");
 
 	old_preload = getenv("LD_PRELOAD");
 	if (old_preload) {

--- a/cmds/record.c
+++ b/cmds/record.c
@@ -337,7 +337,7 @@ static void setup_child_environ(struct opts *opts, int argc, char *argv[])
 
 	libpath = get_libmcount_path(opts);
 	if (libpath == NULL)
-		pr_err_ns("cannot found libmcount.so\n");
+		pr_err_ns("uftrace could not find libmcount.so for record-tracing\n");
 
 	pr_dbg("using %s library for tracing\n", libpath);
 


### PR DESCRIPTION
Just a suggestion to fix those messages, I saw them during autotest run because of some error in starting the autotest.

The commits from Paul were here in error, removed, only the single remaining commit is what I wanted to send.