### PR TITLE
replay: Do not print "<lambda" as struct type name

### DIFF
--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -748,9 +748,17 @@ void get_argspec_string(struct uftrace_task_reader *task,
 			free(estr);
 		}
 		else if (spec->fmt == ARG_FMT_STRUCT) {
-			if (spec->type_name)
-				print_args(&args, &len, "%s%s%s", color_struct,
-						spec->type_name, color_reset);
+			if (spec->type_name) {
+				/*
+				 * gcc puts "<lambda" to annoymous lambda
+				 * but let's ignore to make it same as clang.
+				 */
+				if (strcmp(spec->type_name, "<lambda")) {
+					print_args(&args, &len, "%s%s%s",
+						   color_struct, spec->type_name,
+						   color_reset);
+				}
+			}
 			if (spec->size)
 				print_args(&args, &len, "{...}");
 			else


### PR DESCRIPTION
gcc puts "<lambda" to annoymous lambda but it'd be better to ignore
to make it same as clang.

It would make less troublesome in format html output.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>