### PR TITLE
tests: Fix 228_read_pmu_cycle3 test

### DIFF
--- a/tests/t228_read_pmu_cycle3.py
+++ b/tests/t228_read_pmu_cycle3.py
@@ -4,37 +4,28 @@ from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'thread-name', """
+        TestBase.__init__(self, 'fork', """
 # DURATION     TID     FUNCTION
-            [256519] | thread_first() {
-            [256519] |   foo() {
-            [256519] |     /* read:pmu-cycle (cycle=752, instructions=50) */
-            [256519] |     /* diff:pmu-cycle (cycle=+8074, instructions=+3581, IPC=0.44) */
-  84.405 us [256519] |   } /* foo */
-   0.467 us [256519] |   bar();
- 110.107 us [256519] | } /* thread_first */
-            [256520] | thread_second() {
-            [256520] |   foo() {
-            [256520] |     /* read:pmu-cycle (cycle=862, instructions=50) */
-            [256520] |     /* diff:pmu-cycle (cycle=+7697, instructions=+3581, IPC=0.47) */
-  63.753 us [256520] |   } /* foo */
-   0.385 us [256520] |   bar();
-  90.445 us [256520] | } /* thread_second */
-            [256521] | thread_third() {
-            [256521] |   foo() {
-            [256521] |     /* read:pmu-cycle (cycle=853, instructions=50) */
-            [256521] |     /* diff:pmu-cycle (cycle=+8113, instructions=+3581, IPC=0.44) */
-  74.033 us [256521] |   } /* foo */
-   0.600 us [256521] |   bar();
- 131.233 us [256521] | } /* thread_third */
-            [256522] | thread_fourth() {
-            [256522] |   foo() {
-            [256522] |     /* read:pmu-cycle (cycle=511, instructions=50) */
-            [256522] |     /* diff:pmu-cycle (cycle=+7308, instructions=+3581, IPC=0.49) */
-  39.475 us [256522] |   } /* foo */
-   0.209 us [256522] |   bar();
-  55.132 us [256522] | } /* thread_fourth */
-""", ldflags='-pthread')
+            [  3309] | main() {
+            [  3324] | a() {
+            [  3324] |   b() {
+            [  3324] |     c() {
+            [  3324] |       /* read:pmu-cycle (cycle=688, instructions=30) */
+            [  3324] |       /* diff:pmu-cycle (cycle=+5739, instructions=+1338, IPC=0.23) */
+  99.968 us [  3324] |     } /* c */
+ 120.909 us [  3324] |   } /* b */
+ 122.103 us [  3324] | } /* a */
+ 122.390 us [  3324] | } /* main */
+            [  3309] |   a() {
+            [  3309] |     b() {
+            [  3309] |       c() {
+            [  3309] |         /* read:pmu-cycle (cycle=664, instructions=30) */
+            [  3309] |         /* diff:pmu-cycle (cycle=+3649, instructions=+1338, IPC=0.37) */
+ 109.272 us [  3309] |       } /* c */
+ 124.879 us [  3309] |     } /* b */
+ 125.839 us [  3309] |   } /* a */
+   2.630 ms [  3309] | } /* main */
+""")
 
     def prerun(self, timeout):
         if not TestBase.check_perf_paranoid(self):
@@ -42,36 +33,20 @@ class TestCase(TestBase):
         return TestCase.TEST_SUCCESS
 
     def setup(self):
-        self.option = '-T foo@read=pmu-cycle'
+        self.option = '-T c@read=pmu-cycle --no-libcall'
 
     def sort(self, output):
-        import re
-        pid_patt = re.compile('[^[]+\[ *(\d+)\] |')
-        pid_list = {}
+        result = []
         for ln in output.split('\n'):
             # ignore blank lines and comments
             if ln.strip() == '' or ln.startswith('#'):
                 continue
-            m = pid_patt.match(ln)
-            try:
-                pid = int(m.group(1))
-            except:
-                continue
-
             func = ln.split('|', 1)[-1]
             # remove actual numbers in pmu-cycle
             if func.find('read:pmu-cycle') > 0:
-                func = '     /* read:pmu-cycle */'
+                func = '       /* read:pmu-cycle */'
             if func.find('diff:pmu-cycle') > 0:
-                func = '     /* diff:pmu-cycle */'
+                func = '       /* diff:pmu-cycle */'
+            result.append(func)
 
-            if pid not in pid_list:
-                pid_list[pid] = []
-            pid_list[pid].append(func)
-
-        result = ''
-        for n in ['first', 'second', 'third', 'fourth']:
-            for pid in pid_list:
-                if pid_list[pid][0].find('thread_'+n) > 0:
-                    result += '\n'.join(pid_list[pid]) + '\n'
-        return result
+        return '\n'.join(result)


### PR DESCRIPTION
Some gcc generates totally incorrect binary for s-thread-name.c when
optimized and it makes 228_read_pmu_cycle3 test fails as follows.
```
  228 read_pmu_cycle3     : OK OK NG NG NG OK NG OK OK OK
```
We can just avoid this failure by changing the target program to
s-fork.c instead.
```
  228 read_pmu_cycle3     : OK OK OK OK OK OK OK OK OK OK
```
Link: https://github.com/namhyung/uftrace/pull/1288#discussion_r680653086
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>