### PR TITLE
doc: Fix grammatical error in doc

### DIFF
--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -455,7 +455,7 @@ The supported colors are `red`, `green`, `blue`, `yellow`, `magenta`, `cyan`,
 
 The following example shows how triggers work.  The global filter maximum depth
 is 5, but when function `b()` is called, it is changed to 1, so functions below
-`b()` will not shown.
+`b()` will not be shown.
 
     $ uftrace -D 5 -T 'b@depth=1' ./abc
     # DURATION    TID     FUNCTION

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -380,7 +380,7 @@ It can be used to apply different filter depths for different functions.
 
 The following example shows how triggers work.  The global filter maximum depth
 is 5, but when function `b()` is called, it is changed to 1, so functions below
-`b()` will not shown.
+`b()` will not be shown.
 
     $ uftrace record -D 5 -T 'b@depth=1' ./abc
     $ uftrace replay


### PR DESCRIPTION
This commit fixes grammatical error in
uftrace-live.md and uftrace-record.md,
from 'will not shown' to 'will not be shown'.

Fixed: #1322

Signed-off-by: Kang Minchul <tegongkang@gmail.com>