### PR TITLE
build: Use pkg-config to get compiler options of libpython3

### DIFF
--- a/check-deps/Makefile
+++ b/check-deps/Makefile
@@ -22,9 +22,9 @@ CHECK_LIST += cc_has_minline_all_stringops
 CHECK_CFLAGS  = $(CFLAGS)  $(CFLAGS_$@) -Werror
 CHECK_LDFLAGS = $(LDFLAGS) $(LDFLAGS_$@)
 
-# python3.8 added --embed option
-ifneq ($(shell python3-config 2> /dev/null | grep embed),)
-  EMBED := --embed
+# libpython3 provides an embed verison of pkg-config file since python3.8
+ifeq ($(shell pkg-config python3-embed --exists 2> /dev/null; echo $$?), 0)
+  EMBED := -embed
 endif
 
 CFLAGS_cc_has_mfentry = -mfentry
@@ -32,8 +32,8 @@ LDFLAGS_cxa_demangle = -lstdc++
 LDFLAGS_have_libelf = -lelf
 CFLAGS_cc_has_mno_sse2 = -mno-sse2
 LDFLAGS_have_libpython2.7 = -lpython2.7
-CFLAGS_have_libpython3 = $(shell python3-config --cflags 2> /dev/null)
-LDFLAGS_have_libpython3 = $(shell python3-config $(EMBED) --libs 2> /dev/null)
+CFLAGS_have_libpython3 = $(shell pkg-config python3$(EMBED) --cflags 2> /dev/null)
+LDFLAGS_have_libpython3 = $(shell pkg-config python3$(EMBED) --libs 2> /dev/null)
 CFLAGS_have_libluajit = $(shell pkg-config --cflags luajit 2> /dev/null)
 LDFLAGS_have_libluajit = $(shell pkg-config --libs  luajit 2> /dev/null)
 CFLAGS_have_libncurses  = $(shell pkg-config --cflags ncursesw 2> /dev/null)

--- a/check-deps/Makefile.check
+++ b/check-deps/Makefile.check
@@ -16,14 +16,13 @@ ifneq ($(wildcard $(srcdir)/check-deps/cc_has_mno_sse2),)
 endif
 
 ifneq ($(wildcard $(srcdir)/check-deps/have_libpython3),)
-  # python3.8 added --embed option
-  ifneq ($(shell python3-config | grep embed),)
-    EMBED := --embed
+  # libpython3 provides an embed verison of pkg-config file since python3.8
+  ifeq ($(shell pkg-config python3-embed --exists 2> /dev/null; echo $$?), 0)
+    EMBED := -embed
   endif
-  PYTHON3 := $(shell python3-config $(EMBED) --libs | sed 's/-l\(python[0-9\.m]\+\) .*/\1/g')
   COMMON_CFLAGS += -DHAVE_LIBPYTHON3
-  COMMON_CFLAGS += -I $(shell $(PYTHON3) -c 'import sysconfig; print(sysconfig.get_config_vars()["INCLUDEPY"])')
-  COMMON_CFLAGS += -DLIBPYTHON_VERSION=$(shell $(PYTHON3) -c 'import sysconfig; print(sysconfig.get_config_vars()["LDVERSION"])')
+  COMMON_CFLAGS += $(shell pkg-config python3$(EMBED) --cflags)
+  COMMON_CFLAGS += -DLIBPYTHON_VERSION=$(shell pkg-config python3$(EMBED) --modversion)
 else ifneq ($(wildcard $(srcdir)/check-deps/have_libpython2.7),)
   COMMON_CFLAGS += -DHAVE_LIBPYTHON2
   COMMON_CFLAGS += -I/usr/include/python2.7


### PR DESCRIPTION
In a cross-compilation scenario, it might not have python executable.
Even if it exists, the compiler options are for the host environment.
Not for the build target environment.

Using pkg-config to get compiler options of libpython3 fixes
libpython in the cross-compilation scenario.

Signed-off-by: Kun-Chuan Hsieh <jetswayss@gmail.com>