### PR TITLE
test: solve warning messages

### DIFF
--- a/utils/dwarf.c
+++ b/utils/dwarf.c
@@ -2458,7 +2458,8 @@ TEST_CASE(dwarf_same_file_name1)
 	int ret;
 
 	/* recover from earlier failures */
-	system("rm -f name*.dbg");
+	if (system("rm -f name*.dbg"))
+		return TEST_NG;
 
 	pr_dbg("init debug info and save .dbg files (no build-id)\n");
 	init_test_module_info(&save_mod[0], &save_mod[1], true);
@@ -2494,7 +2495,8 @@ TEST_CASE(dwarf_same_file_name1)
 	free(load_mod[0]);
 	free(load_mod[1]);
 
-	system("rm -f name*.dbg");
+	if (system("rm -f name*.dbg"))
+		return TEST_NG;
 
 	return ret;
 }
@@ -2506,7 +2508,8 @@ TEST_CASE(dwarf_same_file_name2)
 	int ret;
 
 	/* recover from earlier failures */
-	system("rm -f name*.dbg");
+	if (system("rm -f name*.dbg"))
+		return TEST_NG;
 
 	pr_dbg("init debug info and save .dbg files (with build-id)\n");
 	init_test_module_info(&save_mod[0], &save_mod[1], true);
@@ -2545,7 +2548,8 @@ TEST_CASE(dwarf_same_file_name2)
 	free(load_mod[0]);
 	free(load_mod[1]);
 
-	system("rm -f name*.dbg");
+	if (system("rm -f name*.dbg"))
+		return TEST_NG;
 
 	return ret;
 }

--- a/utils/extern.c
+++ b/utils/extern.c
@@ -149,7 +149,8 @@ TEST_CASE(fstack_extern_data)
 	mkdir("extern.test", 0755);
 	fd = creat("extern.test/" DEFAULT_FILENAME, 0644);
 	TEST_NE(fd, -1);
-	write(fd, extern_data, sizeof(extern_data)-1);
+	if (!write(fd, extern_data, sizeof(extern_data)-1))
+		return TEST_NG;
 	close(fd);
 
 	setup_extern_data(&handle, &opts);

--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -1937,7 +1937,8 @@ TEST_CASE(symbol_same_file_name1) {
 	size_t i;
 
 	/* recover from earlier failures */
-	system("rm -f name*.sym");
+	if (system("rm -f name*.sym"))
+		return TEST_NG;
 
 	pr_dbg("allocating modules\n");
 	init_test_module_info(&save_mod[0], &save_mod[1], false, true);
@@ -1985,7 +1986,8 @@ TEST_CASE(symbol_same_file_name1) {
 	unload_symtab(&load_mod[1]->symtab);
 	free(load_mod[1]);
 
-	system("rm -f name*.sym");
+	if (system("rm -f name*.sym"))
+		return TEST_NG;
 
 	return TEST_OK;
 }
@@ -1997,7 +1999,8 @@ TEST_CASE(symbol_same_file_name2) {
 	size_t i;
 
 	/* recover from earlier failures */
-	system("rm -f name*.sym");
+	if (system("rm -f name*.sym"))
+		return TEST_NG;
 
 	pr_dbg("allocating modules\n");
 	init_test_module_info(&save_mod[0], &save_mod[1], true, true);
@@ -2046,7 +2049,8 @@ TEST_CASE(symbol_same_file_name2) {
 	unload_symtab(&load_mod[1]->symtab);
 	free(load_mod[1]);
 
-	system("rm -f name*.sym");
+	if (system("rm -f name*.sym"))
+		return TEST_NG;
 
 	return TEST_OK;
 }


### PR DESCRIPTION
When 'make test' is executed, the following warning messages are displayed:

/home/ubuntu/uftrace/utils/dwarf.c: In function ‘func_dwarf_same_file_name1’:
/home/ubuntu/uftrace/utils/dwarf.c:2461:2: warning: ignoring return value of ‘system’, declared with attribute warn_unused_result [-Wunused-result]
  system("rm -f name*.dbg");
  ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/uftrace/utils/dwarf.c:2497:2: warning: ignoring return value of ‘system’, declared with attribute warn_unused_result [-Wunused-result]
  system("rm -f name*.dbg");
  ^~~~~~~~~~~~~~~~~~~~~~~~~

/home/ubuntu/uftrace/utils/dwarf.c: In function ‘func_dwarf_same_file_name2’:
/home/ubuntu/uftrace/utils/dwarf.c:2509:2: warning: ignoring return value of ‘system’, declared with attribute warn_unused_result [-Wunused-result]
  system("rm -f name*.dbg");
  ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/uftrace/utils/dwarf.c:2548:2: warning: ignoring return value of ‘system’, declared with attribute warn_unused_result [-Wunused-result]
  system("rm -f name*.dbg");
  ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/uftrace/utils/symbol.c: In function ‘func_symbol_same_file_name1’:
/home/ubuntu/uftrace/utils/symbol.c:1940:2: warning: ignoring return value of ‘system’, declared with attribute warn_unused_result [-Wunused-result]
  system("rm -f name*.sym");
  ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/uftrace/utils/symbol.c:1988:2: warning: ignoring return value of ‘system’, declared with attribute warn_unused_result [-Wunused-result]
  system("rm -f name*.sym");
  ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/uftrace/utils/symbol.c: In function ‘func_symbol_same_file_name2’:
/home/ubuntu/uftrace/utils/symbol.c:2000:2: warning: ignoring return value of ‘system’, declared with attribute warn_unused_result [-Wunused-result]
  system("rm -f name*.sym");
  ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/uftrace/utils/symbol.c:2049:2: warning: ignoring return value of ‘system’, declared with attribute warn_unused_result [-Wunused-result]
  system("rm -f name*.sym");
  ^~~~~~~~~~~~~~~~~~~~~~~~~

/home/ubuntu/uftrace/utils/extern.c: In function ‘func_fstack_extern_data’:
/home/ubuntu/uftrace/utils/extern.c:152:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
  write(fd, extern_data, sizeof(extern_data)-1);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Using unused return values makes these warning messages disappear.