### PR TITLE
tests: Sort import order of libraries using isort

### DIFF
--- a/misc/gen-autoargs.py
+++ b/misc/gen-autoargs.py
@@ -9,8 +9,9 @@
 #
 
 from __future__ import print_function
-import sys
+
 import re
+import sys
 
 # The syntax of C in Backus-Naur Form
 #  https://cs.wmich.edu/~gupta/teaching/cs4850/sumII06/The%20syntax%20of%20C%20in%20Backus-Naur%20form.htm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.isort]
+profile = "black"
+lines_between_types = 0
+lines_after_imports = 1
+combine_as_imports = true
+ignore_whitespace = true
+skip_gitignore = true
+

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import random
-import os, sys
-import tempfile
-import glob, re
-import subprocess as sp
+import glob
 import multiprocessing
+import os
+import random
+import re
+import subprocess as sp
+import sys
+import tempfile
 import time
 
 class TestBase:

--- a/tests/t022_filter_kernel.py
+++ b/tests/t022_filter_kernel.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import os
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t067_report_diff.py
+++ b/tests/t067_report_diff.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 XDIR='xxx'
 YDIR='yyy'

--- a/tests/t079_replay_kernel_D.py
+++ b/tests/t079_replay_kernel_D.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
-import subprocess as sp
 import os
+import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t080_replay_kernel_D2.py
+++ b/tests/t080_replay_kernel_D2.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
-import subprocess as sp
 import os
+import subprocess as sp
+
+from runtest import TestBase
 
 TDIR='xxx'
 

--- a/tests/t081_kernel_depth.py
+++ b/tests/t081_kernel_depth.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import os
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t091_replay_tid.py
+++ b/tests/t091_replay_tid.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import os.path
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t092_report_tid.py
+++ b/tests/t092_report_tid.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import os.path
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t095_graph_tid.py
+++ b/tests/t095_graph_tid.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import os.path
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t097_dump_basic.py
+++ b/tests/t097_dump_basic.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t098_dump_tid.py
+++ b/tests/t098_dump_tid.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
-import subprocess as sp
 import os.path
+import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t099_dump_filter.py
+++ b/tests/t099_dump_filter.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t100_dump_depth.py
+++ b/tests/t100_dump_depth.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t103_dump_kernel.py
+++ b/tests/t103_dump_kernel.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
-import subprocess as sp
 import os
+import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t104_graph_kernel.py
+++ b/tests/t104_graph_kernel.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
-import subprocess as sp
 import os
+import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t111_kernel_tid.py
+++ b/tests/t111_kernel_tid.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
-import subprocess as sp
 import os
+import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t117_time_range.py
+++ b/tests/t117_time_range.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 START=0
 

--- a/tests/t122_time_range2.py
+++ b/tests/t122_time_range2.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 START=0
 

--- a/tests/t125_report_range.py
+++ b/tests/t125_report_range.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 START=0
 

--- a/tests/t129_session_tid.py
+++ b/tests/t129_session_tid.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 # Test that task.txt files with a tid in the SESS line still work
 

--- a/tests/t132_trigger_kernel.py
+++ b/tests/t132_trigger_kernel.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import os
+
+from runtest import TestBase
 
 # there was a problem applying depth filter if it contains kernel functions
 class TestCase(TestBase):

--- a/tests/t135_trigger_time2.py
+++ b/tests/t135_trigger_time2.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 TDIR='xxx'
 TIME=0

--- a/tests/t137_kernel_tid_update.py
+++ b/tests/t137_kernel_tid_update.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import os
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t138_kernel_dynamic.py
+++ b/tests/t138_kernel_dynamic.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import os
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t139_kernel_dynamic2.py
+++ b/tests/t139_kernel_dynamic2.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import os
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t141_recv_basic.py
+++ b/tests/t141_recv_basic.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
-import subprocess as sp
 import os.path
+import subprocess as sp
+
+from runtest import TestBase
 
 TDIR  = 'xxx'
 

--- a/tests/t142_recv_multi.py
+++ b/tests/t142_recv_multi.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
-import subprocess as sp
 import os.path
 import random
+import subprocess as sp
+
+from runtest import TestBase
 
 TDIR  = 'xxx'
 

--- a/tests/t143_recv_kernel.py
+++ b/tests/t143_recv_kernel.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
-import subprocess as sp
-import random
 import os
+import random
+import subprocess as sp
+
+from runtest import TestBase
 
 TDIR  = 'xxx'
 

--- a/tests/t148_event_kernel.py
+++ b/tests/t148_event_kernel.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import os
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t149_event_kernel2.py
+++ b/tests/t149_event_kernel2.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import os
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t150_recv_event.py
+++ b/tests/t150_recv_event.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
-import subprocess as sp
 import os.path
+import subprocess as sp
+
+from runtest import TestBase
 
 TDIR  = 'xxx'
 

--- a/tests/t151_recv_runcmd.py
+++ b/tests/t151_recv_runcmd.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 TDIR = 'xxx'
 TMPF = 'out'

--- a/tests/t157_script_python.py
+++ b/tests/t157_script_python.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t158_report_diff_policy1.py
+++ b/tests/t158_report_diff_policy1.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 XDIR='xxx'
 YDIR='yyy'

--- a/tests/t159_report_diff_policy2.py
+++ b/tests/t159_report_diff_policy2.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 XDIR='xxx'
 YDIR='yyy'

--- a/tests/t160_report_diff_policy3.py
+++ b/tests/t160_report_diff_policy3.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 XDIR='xxx'
 YDIR='yyy'

--- a/tests/t164_report_sched.py
+++ b/tests/t164_report_sched.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t165_graph_sched.py
+++ b/tests/t165_graph_sched.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 FUNC='main'
 

--- a/tests/t166_dump_sched.py
+++ b/tests/t166_dump_sched.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t167_recv_sched.py
+++ b/tests/t167_recv_sched.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
-import subprocess as sp
 import os.path
+import subprocess as sp
+
+from runtest import TestBase
 
 TDIR  = 'xxx'
 

--- a/tests/t169_script_args.py
+++ b/tests/t169_script_args.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 FILE='script.py'
 

--- a/tests/t170_script_filter.py
+++ b/tests/t170_script_filter.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 FILE='script.py'
 

--- a/tests/t171_script_option.py
+++ b/tests/t171_script_option.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 FILE='script.py'
 

--- a/tests/t174_replay_filter_kernel.py
+++ b/tests/t174_replay_filter_kernel.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
-import subprocess as sp
 import os
+import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t177_report_diff_policy4.py
+++ b/tests/t177_report_diff_policy4.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 XDIR='xxx'
 YDIR='yyy'

--- a/tests/t179_arg_auto2.py
+++ b/tests/t179_arg_auto2.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import re
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t180_arg_auto3.py
+++ b/tests/t180_arg_auto3.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import re
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t183_info_quote.py
+++ b/tests/t183_info_quote.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t184_arg_enum.py
+++ b/tests/t184_arg_enum.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import re
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t189_replay_field2.py
+++ b/tests/t189_replay_field2.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t196_chrome_taskname.py
+++ b/tests/t196_chrome_taskname.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t199_script_info.py
+++ b/tests/t199_script_info.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t200_lib_dlopen2.py
+++ b/tests/t200_lib_dlopen2.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import os
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     """This tests when dlopen() loads multiple libraries (libbar and libbaz)

--- a/tests/t205_arg_auto4.py
+++ b/tests/t205_arg_auto4.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import re
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t206_arg_enum2.py
+++ b/tests/t206_arg_enum2.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import re
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t207_dump_graphviz.py
+++ b/tests/t207_dump_graphviz.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import os.path
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t208_watch_cpu.py
+++ b/tests/t208_watch_cpu.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import re
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t219_no_libcall_script.py
+++ b/tests/t219_no_libcall_script.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t220_trace_script.py
+++ b/tests/t220_trace_script.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
-import os, stat
+import os
+import stat
+
 from runtest import TestBase
 
 TEST_SCRIPT = "./test-script.sh"

--- a/tests/t222_external_data.py
+++ b/tests/t222_external_data.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
-import subprocess as sp
 import os.path
+import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t230_graph_task.py
+++ b/tests/t230_graph_task.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import re
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t234_script_luajit.py
+++ b/tests/t234_script_luajit.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t239_report_diff_field1.py
+++ b/tests/t239_report_diff_field1.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 XDIR='xxx'
 YDIR='yyy'

--- a/tests/t240_report_diff_field2.py
+++ b/tests/t240_report_diff_field2.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 XDIR='xxx'
 YDIR='yyy'

--- a/tests/t241_report_diff_field3.py
+++ b/tests/t241_report_diff_field3.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 XDIR='xxx'
 YDIR='yyy'

--- a/tests/t242_report_diff_field4.py
+++ b/tests/t242_report_diff_field4.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 XDIR='xxx'
 YDIR='yyy'

--- a/tests/t243_report_diff_field5.py
+++ b/tests/t243_report_diff_field5.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 XDIR='xxx'
 YDIR='yyy'

--- a/tests/t259_arg_struct_script.py
+++ b/tests/t259_arg_struct_script.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t260_arg_struct_luajit.py
+++ b/tests/t260_arg_struct_luajit.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t261_info_note.py
+++ b/tests/t261_info_note.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 class TestCase(TestBase):
     def __init__(self):

--- a/tests/t262_replay_with_syms.py
+++ b/tests/t262_replay_with_syms.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from runtest import TestBase
 import subprocess as sp
+
+from runtest import TestBase
 
 SYMDIR = "abc.syms"
 

--- a/uftrace-gdb.py
+++ b/uftrace-gdb.py
@@ -22,9 +22,9 @@ try:
 except:
     gdb.write("NOTE: gdb 7.2 or later required for helper scripts to work.\n")
 else:
-    import uftrace.utils
     import uftrace.lists
-    import uftrace.plthook
     import uftrace.mcount
+    import uftrace.plthook
     import uftrace.rbtree
     import uftrace.trigger
+    import uftrace.utils


### PR DESCRIPTION
I think it's better to stanzdarize import orders
of libraries in python scripts (in tests/ and scripts/, etc)
to prevent circular imports (although happens rarely),
or for faster import, or for better readabilities.

We can reformat import orders with isort tools,
and this commit contains the result of the tool.

reference: https://pypi.org/project/isort/

Signed-off-by: Kang Minchul <tegongkang@gmail.com>