### PR TITLE
scripts: Make lambda expression compatible for python3

### DIFF
--- a/scripts/report-libcall.py
+++ b/scripts/report-libcall.py
@@ -13,7 +13,7 @@ def uftrace_begin(ctx):
 
 def uftrace_entry(ctx):
     _name = ctx["name"]
-    if libcall_map.has_key(_name):
+    if _name in libcall_map:
         libcall_map[_name] += 1
     else:
         libcall_map[_name] = 1
@@ -23,7 +23,7 @@ def uftrace_exit(ctx):
 
 def uftrace_end():
     global libcall_map
-    sorted_dict = sorted(libcall_map.iteritems(), key=lambda (k, v): (v, k), reverse=True)
+    sorted_dict = sorted(libcall_map.items(), key=lambda k: k[1], reverse=True)
 
     pid = os.getpid()
     with open("/proc/%s/comm" % pid) as proc_comm:


### PR DESCRIPTION
Parenthesis for argument in lambda causes syntax error in python3 like below.
It's because ability to unpack tuple parameters was removed in python 3.

```
ubuntu@ubuntu:~/minchul/uftrace/scripts$ python2 report-libcall.py
ubuntu@ubuntu:~/minchul/uftrace/scripts$ python3 report-libcall.py
  File "report-libcall.py", line 26
    sorted_dict = sorted(libcall_map.iteritems(), key=lambda (k, v): (v, k), reverse=True)
                                                             ^
SyntaxError: invalid syntax
```

So this commit removed parenthesis for python3 compatibility.

reference: https://www.python.org/dev/peps/pep-3113/

Signed-off-by: Kang Minchul <tegongkang@gmail.com>