### PR TITLE
misc: Install python3-dev instead of libpython3-dev

### DIFF
--- a/misc/install-deps.sh
+++ b/misc/install-deps.sh
@@ -13,7 +13,7 @@ distro=$(grep "^ID=" /etc/os-release | cut -d\= -f2 | sed -e 's/"//g')
 
 case $distro in
     "ubuntu" | "debian" | "raspbian" | "kali" | "linuxmint")
-        apt-get $OPT install pandoc libdw-dev libpython3-dev libncursesw5-dev pkg-config
+        apt-get $OPT install pandoc libdw-dev python3-dev libncursesw5-dev pkg-config
         apt-get $OPT install libluajit-5.1-dev || true
         apt-get $OPT install libcapstone-dev || true ;;
     "fedora")


### PR DESCRIPTION
python3-config can be installed by python3-dev, which depends on
libpython3-dev.

We no longer require to use python3-config but it'd be better to install
python3-dev instead of libpython3-dev.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>