### PR TITLE
tui: Use -s option with --report option in TUI

### DIFF
--- a/cmds/report.c
+++ b/cmds/report.c
@@ -477,54 +477,6 @@ out:
 	__close_data_file(&dummy_opts, &data.handle, false);
 }
 
-char * convert_sort_keys(char *sort_keys)
-{
-	const char *default_sort_key[] = { OPT_SORT_KEYS,
-					   "total_avg", "self_avg" };
-	struct strv keys = STRV_INIT;
-	char *new_keys;
-	char *k;
-	int i;
-
-	if (sort_keys == NULL)
-		return xstrdup(default_sort_key[avg_mode]);
-
-	if (avg_mode == AVG_NONE) {
-		char *s;
-
-		s = new_keys = xstrdup(sort_keys);
-		while (*s) {
-			if (*s == '-')
-				*s = '_';
-			s++;
-		}
-
-		return new_keys;
-	}
-
-	strv_split(&keys, sort_keys, ",");
-
-	strv_for_each(&keys, k, i) {
-		if (!strcmp(k, "avg")) {
-			strv_replace(&keys, i, avg_mode == AVG_TOTAL ?
-				     "total_avg" : "self_avg");
-		}
-		else if (!strcmp(k, "min")) {
-			strv_replace(&keys, i, avg_mode == AVG_TOTAL ?
-				     "total_min" : "self_min");
-		}
-		else if (!strcmp(k, "max")) {
-			strv_replace(&keys, i, avg_mode == AVG_TOTAL ?
-				     "total_max" : "self_max");
-		}
-	}
-
-	new_keys = strv_join(&keys, ",");
-	strv_free(&keys);
-
-	return new_keys;
-}
-
 int command_report(int argc, char *argv[], struct opts *opts)
 {
 	int ret;
@@ -554,7 +506,7 @@ int command_report(int argc, char *argv[], struct opts *opts)
 	fstack_setup_filters(opts, &handle);
 
 	if (opts->diff) {
-		sort_keys = convert_sort_keys(opts->sort_keys);
+		sort_keys = convert_sort_keys(opts->sort_keys, avg_mode);
 		ret = report_setup_diff(sort_keys);
 	}
 	else if (opts->show_task) {
@@ -565,7 +517,7 @@ int command_report(int argc, char *argv[], struct opts *opts)
 		ret = report_setup_task(sort_keys);
 	}
 	else {
-		sort_keys = convert_sort_keys(opts->sort_keys);
+		sort_keys = convert_sort_keys(opts->sort_keys, avg_mode);
 		ret = report_setup_sort(sort_keys);
 	}
 	free(sort_keys);

--- a/doc/ko/uftrace-tui.md
+++ b/doc/ko/uftrace-tui.md
@@ -32,6 +32,11 @@ TUI 옵션
     'none' 과 같은 특수 필드를 사용하면 모든 필드를 숨길 수 있다.
     필드에 대한 설명은 `uftrace-graph`(1) 또는 `uftrace-report`(1)를 참고한다.
 
+-s *KEYS*[,*KEYS*,...], --sort=*KEYS*[,*KEYS*,...]
+:   주어진 키를 기반으로 함수들을 정렬한다.
+    여러 키들을 적용할 경우, 키들을 쉼표(,)로 나누어 표현한다.  total (time), total-avg,
+    total-min, total-max, self (time), self-avg, self-min, self-max, call, func를 키로
+    이용할 수 있다.  이 옵션은 반드시 --report 옵션과 함께 사용해야 한다.
 
 공통 옵션
 =========

--- a/doc/uftrace-tui.md
+++ b/doc/uftrace-tui.md
@@ -34,6 +34,11 @@ TUI OPTIONS
     The special field 'none' can be used (solely) to hide all fields.
     See `uftrace-graph`(1) or `uftrace-report`(1) for an explanation of fields.
 
+-s *KEYS*[,*KEYS*,...], \--sort=*KEYS*[,*KEYS*,...]
+:   Sort functions by given KEYS. Multiple KEYS can be given, separated by comma (,).
+    Possible keys are total (time), total-avg, total-min, total-max, self (time), self-avg,
+    self-min, self-max, call and func.
+    This option must be used with --report option.
 
 COMMON OPTIONS
 ==============

--- a/utils/report.h
+++ b/utils/report.h
@@ -60,6 +60,7 @@ void report_update_node(struct uftrace_report_node *node,
 void report_calc_avg(struct rb_root *root);
 void report_delete_node(struct rb_root *root, struct uftrace_report_node *node);
 
+char * convert_sort_keys(char *sort_keys, enum avg_mode avg_mode);
 int report_setup_sort(const char *sort_keys);
 void report_sort_nodes(struct rb_root *name_root, struct rb_root *sort_root);
 


### PR DESCRIPTION
The `tui` command couldn't use -s/--sort option with --report option.
This commit allows the command to use -s/--sort option when you use it with --report option.

Fixed: #1359.