### PR TITLE
Fix VERSION_GIT(version.h) in srcdir from tarball below other git repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ endif
 
 export UFTRACE_CFLAGS LIB_CFLAGS TEST_CFLAGS TEST_LDFLAGS
 
-VERSION_GIT := $(shell git describe --tags 2> /dev/null || echo v$(VERSION))
+VERSION_GIT := $(shell test -e .git && git describe --tags 2> /dev/null || echo v$(VERSION))
 
 all:
 
@@ -298,7 +298,7 @@ $(filter-out $(objdir)/uftrace.o, $(UFTRACE_OBJS)): $(objdir)/%.o: $(srcdir)/%.c
 	$(QUIET_CC)$(CC) $(UFTRACE_CFLAGS) -c -o $@ $<
 
 $(objdir)/version.h: PHONY
-	@$(srcdir)/misc/version.sh $@ $(VERSION_GIT) $(ARCH) $(objdir)
+	$(QUIET_GEN)$(srcdir)/misc/version.sh $@ $(VERSION_GIT) $(ARCH) $(objdir)
 
 $(srcdir)/utils/auto-args.h: $(srcdir)/misc/prototypes.h $(srcdir)/misc/gen-autoargs.py
 	$(QUIET_GEN)$(srcdir)/misc/gen-autoargs.py -i $< -o $@


### PR DESCRIPTION
@namhyung

To set the version string to be generate into `version.h`, `Makefile` uses:
```
VERSION_GIT := $(shell git describe --tags 2> /dev/null || echo v$(VERSION))
```
This usually works because ```git describe --tags``` would abort when
$(srcdir) is not located in or below a git repo, and v$(VERSION) is used.

When uftrace is built from a release tarball and the $(srcdir) is located
in a temporary directory below another git worktree or repo, `git describe`
describes the verison of the git repo in which the `$(srcdir)` is located,
which is a completely different version string from the other repo and not
the release version string of the git tarball.

Fix this by checking if $(srcdir)/.git is a directory (or a file):

In case uftrace is checked out externally, e.g. as a git submodule,
.git is a text file with a `git:`, followed by relative path to the
real .git directory, so it works also when .git/ is located externally.

This still does not work in other ways of including one git repo in another
like https://github.com/ingydotnet/git-subrepo, but they are not that common
and I see little reason to do that. I think these cases can only be fixed by
settings the VERSION variable outside of release tags differently as a flag.

Inserting 'test -e .git && ' into the shell command is enough as simple fix.