### PR TITLE
replay: Set module name as [event] for sched events

### DIFF
--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -113,6 +113,8 @@ static void print_module(struct field_data *fd)
 			modname = "[kernel]";
 		else if (map)
 			modname = basename(map->libname);
+		else if (is_sched_event(fstack->addr))
+			modname = "[event]";
 	}
 
 	pr_out("%*.*s", 16, 16, modname);


### PR DESCRIPTION
It used to show module name of schedule events as [unknown], but this
patch marks it as [event] as follows.
```
  $ uftrace --no-libcall -f +module t-fork
  # DURATION     TID        MODULE NAME   FUNCTION
              [ 55417]           t-fork | main() {
              [ 55417]                  |   /* linux:sched-out */
              [ 55432]           t-fork | a() {
              [ 55432]           t-fork |   b() {
     5.724 us [ 55432]           t-fork |     c();
     7.106 us [ 55432]           t-fork |   } /* b */
     7.724 us [ 55432]           t-fork | } /* a */
     7.724 us [ 55432]           t-fork | } /* main */
     1.246 ms [ 55417]          [event] |   /* linux:sched-in */
              [ 55417]           t-fork |   a() {
              [ 55417]           t-fork |     b() {
     1.213 us [ 55417]           t-fork |       c();
     2.588 us [ 55417]           t-fork |     } /* b */
     3.448 us [ 55417]           t-fork |   } /* a */
     1.677 ms [ 55417]           t-fork | } /* main */
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>