### PR TITLE
dynamic: Support -fpatchable-function-entry=N tracing

### DIFF
--- a/arch/aarch64/fentry.S
+++ b/arch/aarch64/fentry.S
@@ -1,0 +1,55 @@
+#include "utils/asm.h"
+
+.text
+
+/* universal stack constraint: (SP mod 16) == 0 */
+/* frame pointer was saved in the trampoline */
+GLOBAL(__fentry__)
+	/* save all caller-saved registers due to -fipa-ra */
+	stp	x14, x15, [sp, #-16]!
+	stp	x12, x13, [sp, #-16]!
+	stp	x10, x11, [sp, #-16]!
+
+	/* platform register and/or scratch registers */
+	stp	x8, x9, [sp, #-16]!
+
+	/* also save original child address */
+	stp	x29, x30, [sp, #-16]!
+
+	/* save arguments */
+	stp	x6, x7, [sp, #-16]!
+	stp	x4, x5, [sp, #-16]!
+	stp	x2, x3, [sp, #-16]!
+	stp	x0, x1, [sp, #-16]!
+
+	stp	d0, d1, [sp, #-16]!
+
+	add	x0, x29, #8
+	mov	x1, x30
+	add	x2, sp, #16
+	bl	mcount_entry
+
+	ldp	d0, d1, [sp], #16
+
+	/* restore arguments */
+	ldp	x0, x1, [sp], #16
+	ldp	x2, x3, [sp], #16
+	ldp	x4, x5, [sp], #16
+	ldp	x6, x7, [sp], #16
+
+	/* actual return address */
+	ldp	x16, x17, [sp], #16
+
+	ldp	x8, x9, [sp], #16
+
+	/* caller-saved registers */
+	ldp	x10, x11, [sp], #16
+	ldp	x12, x13, [sp], #16
+	ldp	x14, x15, [sp], #16
+
+	/* restore frame pointer */
+	ldp	x29, x30, [sp], #16
+
+	/* jump to the saved insn */
+	br	x17
+END(__fentry__)

--- a/arch/aarch64/mcount-dynamic.c
+++ b/arch/aarch64/mcount-dynamic.c
@@ -16,6 +16,8 @@
 
 #define CODE_SIZE  8
 
+static const unsigned int patchable_nop_patt[] = { 0xd503201f, 0xd503201f };
+
 static void save_orig_code(struct mcount_disasm_info *info)
 {
 	uint32_t jmp_insn[6] = {
@@ -175,7 +177,6 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct sym *sym)
 
 static int patch_patchable_func(struct mcount_dynamic_info *mdi, struct sym *sym)
 {
-	unsigned int patchable_nop_patt[] = { 0xd503201f, 0xd503201f };
 	void *insn = (void *)sym->addr + mdi->map->start;
 
 	/* only support calls to 2 NOPs at the beginning */

--- a/arch/aarch64/mcount-dynamic.c
+++ b/arch/aarch64/mcount-dynamic.c
@@ -38,6 +38,7 @@ static void save_orig_code(struct mcount_disasm_info *info)
 int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
 {
 	uintptr_t dentry_addr = (uintptr_t)(void *)&__dentry__;
+	uintptr_t fentry_addr = (uintptr_t)(void *)&__fentry__;
 	/*
 	 * trampoline assumes {x29,x30} was pushed but x29 was not updated.
 	 * make sure stack is 8-byte aligned.
@@ -49,6 +50,11 @@ int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
 		dentry_addr,
 		dentry_addr >> 32,
 	};
+
+	if (mdi->type == DYNAMIC_PATCHABLE) {
+		trampoline[3] = fentry_addr;
+		trampoline[4] = fentry_addr >> 32;
+	}
 
 	/* find unused 16-byte at the end of the code segment */
 	mdi->trampoline  = ALIGN(mdi->text_addr + mdi->text_size, PAGE_SIZE);
@@ -76,52 +82,162 @@ int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
 	return 0;
 }
 
+static void read_patchable_loc(struct mcount_dynamic_info *mdi,
+			    struct uftrace_elf_data *elf,
+			    struct uftrace_elf_iter *iter,
+			    unsigned long offset)
+{
+	typeof(iter->shdr) *shdr = &iter->shdr;
+
+	mdi->nr_patch_target = shdr->sh_size / sizeof(long);
+	mdi->patch_target = xmalloc(shdr->sh_size);
+
+	elf_get_secdata(elf, iter);
+	elf_read_secdata(elf, iter, 0, mdi->patch_target, shdr->sh_size);
+
+	/* symbol has relative address, fix it to match each other */
+	if (elf->ehdr.e_type == ET_EXEC) {
+		unsigned long *patchable_loc = mdi->patch_target;
+		unsigned i;
+
+		for (i = 0; i < mdi->nr_patch_target; i++) {
+			patchable_loc[i] -= offset;
+		}
+	}
+}
+
+void mcount_arch_find_module(struct mcount_dynamic_info *mdi,
+			     struct symtab *symtab)
+{
+	struct uftrace_elf_data elf;
+	struct uftrace_elf_iter iter;
+
+	mdi->type = DYNAMIC_NONE;
+
+	if (elf_init(mdi->map->libname, &elf) < 0)
+		goto out;
+
+	elf_for_each_shdr(&elf, &iter) {
+		char *shstr = elf_get_name(&elf, &iter, iter.shdr.sh_name);
+
+		if (!strcmp(shstr, PATCHABLE_SECT)) {
+			mdi->type = DYNAMIC_PATCHABLE;
+			read_patchable_loc(mdi, &elf, &iter, mdi->base_addr);
+			goto out;
+		}
+	}
+
+	switch (check_trace_functions(mdi->map->libname)) {
+	case TRACE_MCOUNT:
+		mdi->type = DYNAMIC_PG;
+		break;
+	default:
+		break;
+	}
+
+out:
+	pr_dbg("dynamic patch type: %s: %d (%s)\n", basename(mdi->map->libname),
+	       mdi->type, mdi_type_names[mdi->type]);
+
+	elf_finish(&elf);
+}
+
 static unsigned long get_target_addr(struct mcount_dynamic_info *mdi,
 				     unsigned long addr)
 {
+	/* encode the target address of the trampoline */
 	return (mdi->trampoline - addr - 4) >> 2;
 }
 
-int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym,
-		      struct mcount_disasm_engine *disasm, unsigned min_size)
+static int patch_code(struct mcount_dynamic_info *mdi, struct sym *sym)
 {
 	uint32_t push = 0xa9bf7bfd;  /* STP  x29, x30, [sp, #-0x10]! */
 	uint32_t call;
-	struct mcount_disasm_info info = {
-		.sym = sym,
-		.addr = sym->addr + mdi->map->start,
-	};
-	void *insn = (void *)info.addr;
+	void *insn = (void *)sym->addr + mdi->map->start;
 
-	if (min_size < CODE_SIZE)
-		min_size = CODE_SIZE;
-	if (sym->size <= min_size)
-		return INSTRUMENT_SKIPPED;
-
-	if (disasm_check_insns(disasm, mdi, &info) < 0)
-		return INSTRUMENT_FAILED;
-
-	save_orig_code(&info);
-
-	call = get_target_addr(mdi, info.addr);
+	call = get_target_addr(mdi, (unsigned long)insn);
 
 	if ((call & 0xfc000000) != 0)
 		return INSTRUMENT_FAILED;
-
-	pr_dbg2("patch normal func: %s (patch size: %d)\n",
-		sym->name, info.orig_size);
 
 	/* make a "BL" insn with 26-bit offset */
 	call |= 0x94000000;
 
 	/* hopefully we're not patching 'memcpy' itself */
 	memcpy(insn, &push, sizeof(push));
-	memcpy(insn+4, &call, sizeof(call));
+	memcpy(insn + 4, &call, sizeof(call));
 
 	/* flush icache so that cpu can execute the new code */
 	__builtin___clear_cache(insn, insn + CODE_SIZE);
 
 	return INSTRUMENT_SUCCESS;
+}
+
+static int patch_patchable_func(struct mcount_dynamic_info *mdi, struct sym *sym)
+{
+	unsigned int patchable_nop_patt[] = { 0xd503201f, 0xd503201f };
+	void *insn = (void *)sym->addr + mdi->map->start;
+
+	/* only support calls to 2 NOPs at the beginning */
+	if (memcmp(insn, patchable_nop_patt, sizeof(patchable_nop_patt))) {
+		pr_dbg("skip non-applicable functions: %s\n", sym->name);
+		return INSTRUMENT_FAILED;
+	}
+
+	if (patch_code(mdi, sym) < 0)
+		return INSTRUMENT_FAILED;
+
+	pr_dbg3("update %p for '%s' function dynamically to call __fentry__\n",
+		insn, sym->name);
+
+	return INSTRUMENT_SUCCESS;
+}
+
+static int patch_normal_func(struct mcount_dynamic_info *mdi, struct sym *sym,
+			     struct mcount_disasm_engine *disasm)
+{
+	struct mcount_disasm_info info = {
+		.sym = sym,
+		.addr = sym->addr + mdi->map->start,
+	};
+
+	if (disasm_check_insns(disasm, mdi, &info) < 0)
+		return INSTRUMENT_FAILED;
+
+	save_orig_code(&info);
+
+	if (patch_code(mdi, sym) < 0)
+		return INSTRUMENT_FAILED;
+
+	pr_dbg3("force patch normal func: %s (patch size: %d)\n",
+		sym->name, info.orig_size);
+
+	return INSTRUMENT_SUCCESS;
+}
+
+int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym,
+		      struct mcount_disasm_engine *disasm, unsigned min_size)
+{
+	int result = INSTRUMENT_SKIPPED;
+
+	if (min_size < CODE_SIZE)
+		min_size = CODE_SIZE;
+	if (sym->size <= min_size)
+		return INSTRUMENT_SKIPPED;
+
+	switch (mdi->type) {
+	case DYNAMIC_PATCHABLE:
+		result = patch_patchable_func(mdi, sym);
+		break;
+
+	case DYNAMIC_NONE:
+		result = patch_normal_func(mdi, sym, disasm);
+		break;
+
+	default:
+		break;
+	}
+	return result;
 }
 
 static void revert_normal_func(struct mcount_dynamic_info *mdi, struct sym *sym,

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -667,33 +667,27 @@ which disables the field display and shows function output only.
 
 DYNAMIC TRACING
 ===============
+FULL DYNAMIC TRACING
+--------------------
 The uftrace tool supports dynamic function tracing which can be enabled at
-runtime (load-time, to be precise) on x86_64.  Before recording functions,
-normally you need to build the target program with `-pg` (or
+runtime (load-time, to be precise) on x86_64 and AArch64.  Before recording
+functions, normally you need to build the target program with `-pg` (or
 `-finstrument-functions`), then it has some performance impact because all
-funtions call `mcount()`.
+functions call `mcount()`.
 
 With dynamic tracing, you can trace specific functions only given by the
 `-P`/`--patch` option and can also disable specific functions given by the
 `-U`/`--unpatch` option.  With capstone disassembly engine you even don't need
 to (re)compile the target with the option above.  Now uftrace can analyze the
 instructions and (if possible) it can copy them to a different place and rewrite
-it to call `mcount()` function) so that it can be traced by uftrace.  After that
+it to call `mcount()` function so that it can be traced by uftrace.  After that
 the control is passed to the copied instructions and then returned back to the
 remaining instructions.
-
-If the capstone is not available, you need to add some more compiler (gcc)
-options when building the target program.  The gcc 5.1 or more recent versions
-provide `-mfentry` and `-mnop-mcount` options which add instrumentation code
-(i.e.  calling `mcount()` function) at the very beginning of a function and
-convert the instruction to a NOP.  Then it has almost zero performance overhead
-when running in a normal condition.  The uftrace can selectively convert it 
-back to call `mcount()` using `-P` option.
 
 The following example shows an error message when normally running uftrace.
 Because the binary doesn't call any instrumentation code (i.e. 'mcount').
 
-    $ gcc -o abc -pg -mfentry -mnop-mcount tests/s-abc.c
+    $ gcc -o abc tests/s-abc.c
     $ uftrace abc
     uftrace: /home/namhyung/project/uftrace/cmd-record.c:1305:check_binary
       ERROR: Can't find 'mcount' symbol in the 'abc'.
@@ -735,10 +729,31 @@ For example if you want to trace all functions but 'a' in the above:
 The order of the options is important, if you change it like `-U a -P .` then
 it will trace all the functions since `-P .` will be effective for all.
 
-In addition, the `-U` option can be used to disable functions in binaries
-built with `-pg` (and `-mfentry` or `-mrecord-mcount`).  It might require
-capstone to parse the instructions.
 
+GCC FENTRY
+----------
+If the capstone is not available, you need to add some more compiler (gcc)
+options when building the target program.  The gcc 5.1 or more recent versions
+provide `-mfentry` and `-mnop-mcount` options which add instrumentation code
+(i.e.  calling `mcount()` function) at the very beginning of a function and
+convert the instruction to a NOP.  Then it has almost zero performance overhead
+when running in a normal condition.  The uftrace can selectively convert it
+back to call `mcount()` using `-P` option.
+
+    $ gcc -pg -mfentry -mnop-mcount -o abc-fentry tests/s-abc.c
+    $ uftrace -P . --no-libcall abc-fentry
+    # DURATION     TID     FUNCTION
+                [ 18973] | main() {
+                [ 18973] |   a() {
+                [ 18973] |     b() {
+       0.852 us [ 18973] |       c();
+       2.378 us [ 18973] |     } /* b */
+       2.909 us [ 18973] |   } /* a */
+       3.756 us [ 18973] | } /* main */
+
+
+CLANG XRAY
+----------
 Clang/LLVM 4.0 provides a dynamic instrumentation technique called
 [X-ray](http://llvm.org/docs/XRay.html).  It's similar to a combination of
 `gcc -mfentry -mnop-mcount` and `-finstrument-functions`.  The uftrace also

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -673,6 +673,83 @@ and equally use `-P` option for dynamic tracing like below:
        3.005 us [11098] | } /* main */
 
 
+PATCHABLE FUNCTION ENTRY
+------------------------
+Recent compilers in both gcc and clang support another useful option
+`-fpatchable-function-entry=N[,M]` that generates M NOPs before the function
+entry and N-M NOPs after the function entry.  We can simply use the case when M
+is 0 so `-fpatchable-function-entry=N` is enough.  The number of NOPs required
+for dynamic tracing depends on the architecture but x86_64 requires 5 NOPs and
+AArch64 requires 2 NOPs to dynamically patch a call instruction for uftrace
+recording.
+
+For example in x86_64, you can build the target program and trace as follows.
+
+    $ gcc -fpatchable-function-entry=5 -o abc-fpatchable tests/s-abc.c
+    $ uftrace record -P . abc-fpatchable
+    $ uftrace replay
+    # DURATION     TID     FUNCTION
+                [  6818] | main() {
+                [  6818] |   a() {
+                [  6818] |     b() {
+                [  6818] |       c() {
+       0.926 us [  6818] |         getpid();
+       4.158 us [  6818] |       } /* c */
+       4.590 us [  6818] |     } /* b */
+       4.957 us [  6818] |   } /* a */
+       5.593 us [  6818] | } /* main */
+
+This feature can also be used by explicitly adding compiler attribute to some
+specific functions with `__attribute__ ((patchable_function_entry (N,M)))`.
+For example, the 'tests/s-abc.c' program can be modified as follows.
+
+    static int c(void)
+    {
+            return 100000;
+    }
+
+    __attribute__((patchable_function_entry(5)))
+    static int b(void)
+    {
+            return c() + 1;
+    }
+
+    static int a(void)
+    {
+            return b() - 1;
+    }
+
+    __attribute__((patchable_function_entry(5)))
+    int main(void)
+    {
+            int ret = 0;
+
+            ret += a();
+            return ret ? 0 : 1;
+    }
+
+The attribute is added to function 'main' and 'b' only and this program can
+normally be compiled without any additional compiler options, but the compiler
+detects the attributes and adds 5 NOPs at the entry of 'main' and 'b'.
+
+    $ gcc -o abc tests/s-patchable-abc.c
+    $ uftrace record -P . abc
+    $ uftrace replay
+    # DURATION     TID     FUNCTION
+                [ 20803] | main() {
+       0.342 us [ 20803] |   b();
+       1.608 us [ 20803] | } /* main */
+
+With this way, uftrace can selectively trace only the functions user wants by
+explicitly adding the attribute.  This approach can collect trace records in a
+much less intrusive way compared to tracing the entire functions enabled by
+compiler flags.
+
+`-fpatchable-function-entry=N[,M]` option and its attribute are supported since
+gcc-8.1 and clang-10.
+This dynamic tracing feature can be used in both x86_64 and AArch64 as of now.
+
+
 SCRIPT EXECUTION
 ================
 The uftrace tool supports script execution for each function entry and exit.

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -591,6 +591,13 @@ static void patch_normal_func_matched(struct mcount_dynamic_info *mdi,
 static void patch_func_matched(struct mcount_dynamic_info *mdi,
 			       struct uftrace_mmap *map)
 {
+	/*
+	 * In some cases, the __patchable_function_entries section can be
+	 * removed.  For example, -Wl,--gc-sections strips this section.
+	 * In this case, we try patching in patch_normal_func_matched() by
+	 * looping over all the symbols available and check if the function
+	 * begins with NOP patterns for patchable function entry.
+	 */
 	if (mdi->type == DYNAMIC_PATCHABLE)
 		patch_patchable_func_matched(mdi, map);
 	else

--- a/libmcount/dynamic.h
+++ b/libmcount/dynamic.h
@@ -10,6 +10,7 @@
 #define PAGE_LEN(a, l)    (a + l - (unsigned long)PAGE_ADDR(a))
 #define XRAY_SECT  "xray_instr_map"
 #define MCOUNTLOC_SECT  "__mcount_loc"
+#define PATCHABLE_SECT  "__patchable_function_entries"
 
 /* target instrumentation function it needs to call */
 extern void __fentry__(void);
@@ -32,10 +33,11 @@ enum mcount_dynamic_type {
 	DYNAMIC_FENTRY,
 	DYNAMIC_FENTRY_NOP,
 	DYNAMIC_XRAY,
+	DYNAMIC_PATCHABLE,
 };
 
 __maybe_unused static const char *mdi_type_names[] = {
-	"none", "pg", "fentry", "fentry-nop", "xray",
+	"none", "pg", "fentry", "fentry-nop", "xray", "fpatchable",
 };
 
 struct mcount_dynamic_info {

--- a/tests/s-patchable-abc.c
+++ b/tests/s-patchable-abc.c
@@ -1,0 +1,45 @@
+/*
+ * This is a basic test to verify whether uftrace works on the system.
+ */
+#include <stdlib.h>
+#include <unistd.h>
+
+#if __x86_64__
+#define NR_NOPS 5
+#elif __aarch64__
+#define NR_NOPS 2
+#else
+#define NR_NOPS 0
+#endif
+
+#define __patchable __attribute__((patchable_function_entry(NR_NOPS)))
+
+static int a(void);
+static int b(void);
+static int c(void);
+
+__patchable static int a(void)
+{
+	return b() - 1;
+}
+
+static int b(void)
+{
+	return c() + 1;
+}
+
+__patchable static int c(void)
+{
+	return getpid() % 100000;
+}
+
+__patchable int main(int argc, char *argv[])
+{
+	int ret = 0;
+
+	if (argc > 1)
+		ret = atoi(argv[1]);
+
+	ret += a();
+	return ret ? 0 : 1;
+}

--- a/tests/t263_patchable_dynamic.py
+++ b/tests/t263_patchable_dynamic.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'abc', """
+# DURATION     TID     FUNCTION
+            [ 54963] | main() {
+            [ 54963] |   a() {
+            [ 54963] |     b() {
+   1.297 us [ 54963] |       c();
+   3.772 us [ 54963] |     } /* b */
+   4.376 us [ 54963] |   } /* a */
+   5.484 us [ 54963] | } /* main */
+""")
+
+    def prerun(self, timeout):
+        if not TestBase.check_arch_full_dynamic_support(self):
+            return TestBase.TEST_SKIP
+        return TestBase.TEST_SUCCESS
+
+    def build(self, name, cflags='', ldflags=''):
+        cflags = cflags.replace('-pg', '')
+        cflags = cflags.replace('-finstrument-functions', '')
+
+        # add patchable function entry option
+        machine = TestBase.get_machine(self)
+        if machine == 'x86_64':
+            cflags += ' -fpatchable-function-entry=5'
+        elif machine == 'aarch64':
+            cflags += ' -fpatchable-function-entry=2'
+
+        return TestBase.build(self, name, cflags, ldflags)
+
+    def setup(self):
+        self.option = '-P . --no-libcall'

--- a/tests/t264_patchable_dynamic2.py
+++ b/tests/t264_patchable_dynamic2.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'patchable-abc', """
+# DURATION     TID     FUNCTION
+            [  2331] | main() {
+            [  2331] |   a() {
+   0.897 us [  2331] |     c();
+   2.555 us [  2331] |   } /* a */
+   3.468 us [  2331] | } /* main */
+""")
+
+    def prerun(self, timeout):
+        if not TestBase.check_arch_full_dynamic_support(self):
+            return TestBase.TEST_SKIP
+        return TestBase.TEST_SUCCESS
+
+    def build(self, name, cflags='', ldflags=''):
+        cflags = cflags.replace('-pg', '')
+        cflags = cflags.replace('-finstrument-functions', '')
+        return TestBase.build(self, name, cflags, ldflags)
+
+    def setup(self):
+        self.option = '-P . --no-libcall'

--- a/tests/t265_patchable_dynamic3.py
+++ b/tests/t265_patchable_dynamic3.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'patchable-abc', """
+# DURATION     TID     FUNCTION
+            [  6907] | main() {
+   1.138 us [  6907] |   c();
+   4.345 us [  6907] | } /* main */
+""")
+
+    def prerun(self, timeout):
+        if not TestBase.check_arch_full_dynamic_support(self):
+            return TestBase.TEST_SKIP
+        return TestBase.TEST_SUCCESS
+
+    def build(self, name, cflags='', ldflags=''):
+        cflags = cflags.replace('-pg', '')
+        cflags = cflags.replace('-finstrument-functions', '')
+        return TestBase.build(self, name, cflags, ldflags)
+
+    def setup(self):
+        self.option = '-P . -U a --no-libcall'

--- a/tests/t266_patchable_dynamic4.py
+++ b/tests/t266_patchable_dynamic4.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'lib', """
+# DURATION     TID     FUNCTION
+            [  9519] | main() {
+            [  9519] |   foo() {
+            [  9519] |     lib_a() {
+   0.625 us [  9519] |       lib_c();
+   1.455 us [  9519] |     } /* lib_a */
+   2.125 us [  9519] |   } /* foo */
+   3.114 us [  9519] | } /* main */
+""", sort='simple')
+
+    def prerun(self, timeout):
+        if not TestBase.check_arch_full_dynamic_support(self):
+            return TestBase.TEST_SKIP
+        return TestBase.TEST_SUCCESS
+
+    def build(self, name, cflags='', ldflags=''):
+        cflags = cflags.replace('-pg', '')
+        cflags = cflags.replace('-finstrument-functions', '')
+
+        # add patchable function entry option
+        machine = TestBase.get_machine(self)
+        if machine == 'x86_64':
+            cflags += ' -fpatchable-function-entry=5'
+        elif machine == 'aarch64':
+            cflags += ' -fpatchable-function-entry=2'
+
+        if TestBase.build_libabc(self, cflags, ldflags) != 0:
+            return TestBase.TEST_BUILD_FAIL
+        return TestBase.build_libmain(self, name, 's-libmain.c',
+                                      ['libabc_test_lib.so'], cflags)
+
+    def setup(self):
+        self.option = '-P . -P .@libabc_test_lib.so -U lib_b@libabc_test_lib.so --no-libcall'

--- a/tests/t267_patchable_dynamic5.py
+++ b/tests/t267_patchable_dynamic5.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'patchable-abc', """
+# DURATION     TID     FUNCTION
+            [  2331] | main() {
+            [  2331] |   a() {
+   0.897 us [  2331] |     c();
+   2.555 us [  2331] |   } /* a */
+   3.468 us [  2331] | } /* main */
+""")
+
+    def prerun(self, timeout):
+        if not TestBase.check_arch_full_dynamic_support(self):
+            return TestBase.TEST_SKIP
+        return TestBase.TEST_SUCCESS
+
+    def build(self, name, cflags='', ldflags=''):
+        cflags = cflags.replace('-pg', '')
+        cflags = cflags.replace('-finstrument-functions', '')
+        cflags += ' -Wl,--gc-sections'
+        return TestBase.build(self, name, cflags, ldflags)
+
+    def setup(self):
+        self.option = '-P . --no-libcall'


### PR DESCRIPTION
Recnet gcc and clang provides a way to have NOP sleds at the beginning
of functions with new option '-fpatchable-function-entry=N[,M]'.

The explanation in gcc[1] is as follows.
```
  -fpatchable-function-entry=N[,M]
    Generate N NOPs right at the beginning of each function, with the
    function entry point before the Mth NOP. If M is omitted, it
    defaults to 0 so the function entry points to the address just at
    the first NOP. The NOP instructions reserve extra space which can be
    used to patch in any desired instrumentation at run time, provided
    that the code segment is writable. The amount of space is
    controllable indirectly via the number of NOPs; the NOP instruction
    used corresponds to the instruction emitted by the internal GCC
    back-end interface gen_nop. This behavior is target-specific and may
    also depend on the architecture variant and/or other compilation
    options.

    For run-time identification, the starting addresses of these areas,
    which correspond to their respective function entries minus M, are
    additionally collected in the __patchable_function_entries section
    of the resulting binary.

    Note that the value of __attribute__ ((patchable_function_entry (N,M)))
    takes precedence over command-line option -fpatchable-function-entry=N,M.
    This can be used to increase the area size or to remove it completely
    on a single function. If N=0, no pad location is recorded.

    The NOP instructions are inserted at—and maybe before, depending on
    M—the function entry address, even before the prologue.

    The maximum value of N and M is 65535.
```
This patch makes uftrace use -fpatchable-function-entry=N in x86_64.
The N should be 5(or greater) because The call instruction requires 5
bytes.  The example usage is as follows.
```
  $ gcc -fpatchable-function-entry=5 tests/s-abc.c

  $ uftrace -P. --debug-domain dynamic:3 a.out
  dynamic: dynamic patch type: a.out: 3 (fentry-nop)
  dynamic: update function 'a' dynamically to call __fentry__
  dynamic: update function 'b' dynamically to call __fentry__
  dynamic: update function 'c' dynamically to call __fentry__
  dynamic: update function 'main' dynamically to call __fentry__
  dynamic: patched all (4) functions in 'a.out'
  # DURATION     TID     FUNCTION
              [ 30535] | main() {
              [ 30535] |   a() {
              [ 30535] |     b() {
              [ 30535] |       c() {
     0.937 us [ 30535] |         getpid();
     4.143 us [ 30535] |       } /* c */
     4.618 us [ 30535] |     } /* b */
     5.078 us [ 30535] |   } /* a */
     5.769 us [ 30535] | } /* main */
```
Note that this feature reuses __fentry__ hook so it doesn't require
extra trampoline to handle original instructions as it does in full
dynamic tracing.

Closes: #1238

[1] https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fpatchable-function-entry
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>