### PR TITLE
doc: Update catapult repo to chromium.googlesource.com/catapult

### DIFF
--- a/doc/uftrace.html
+++ b/doc/uftrace.html
@@ -1696,18 +1696,18 @@ template: title-layout
 </a>
 ---
 ### [Chrome Trace Viewer](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool)
-.footnote[[Catapult Project](https://github.com/catapult-project/catapult)]
+.footnote[[Catapult Project](https://chromium.googlesource.com/catapult)]
 - uftrace dump --chrome generates trace in [JSON format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview).
-  - Catapult's [trace2html](https://github.com/catapult-project/catapult/blob/master/tracing/bin/trace2html) script can convert it to HTML.
+  - Catapult's [trace2html](https://chromium.googlesource.com/catapult/+/refs/heads/main/tracing/bin/trace2html) script can convert it to HTML.
 
 ```
         $ uftrace record a.out
 ```
 ---
 ### [Chrome Trace Viewer](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool)
-.footnote[[Catapult Project](https://github.com/catapult-project/catapult)]
+.footnote[[Catapult Project](https://chromium.googlesource.com/catapult)]
 - uftrace dump --chrome generates trace in [JSON format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview).
-  - Catapult's [trace2html](https://github.com/catapult-project/catapult/blob/master/tracing/bin/trace2html) script can convert it to HTML.
+  - Catapult's [trace2html](https://chromium.googlesource.com/catapult/+/refs/heads/main/tracing/bin/trace2html) script can convert it to HTML.
 
 ```
         $ uftrace record a.out
@@ -1716,9 +1716,9 @@ template: title-layout
 ```
 ---
 ### [Chrome Trace Viewer](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool)
-.footnote[[Catapult Project](https://github.com/catapult-project/catapult)]
+.footnote[[Catapult Project](https://chromium.googlesource.com/catapult)]
 - uftrace dump --chrome generates trace in [JSON format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview).
-  - Catapult's [trace2html](https://github.com/catapult-project/catapult/blob/master/tracing/bin/trace2html) script can convert it to HTML.
+  - Catapult's [trace2html](https://chromium.googlesource.com/catapult/+/refs/heads/main/tracing/bin/trace2html) script can convert it to HTML.
 
 ```
         $ uftrace record a.out
@@ -1729,9 +1729,9 @@ template: title-layout
 ```
 ---
 ### [Chrome Trace Viewer](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool)
-.footnote[[Catapult Project](https://github.com/catapult-project/catapult)]
+.footnote[[Catapult Project](https://chromium.googlesource.com/catapult)]
 - uftrace dump --chrome generates trace in [JSON format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview).
-  - Catapult's [trace2html](https://github.com/catapult-project/catapult/blob/master/tracing/bin/trace2html) script can convert it to HTML.
+  - Catapult's [trace2html](https://chromium.googlesource.com/catapult/+/refs/heads/main/tracing/bin/trace2html) script can convert it to HTML.
 
 ```
         $ uftrace record a.out
@@ -1743,9 +1743,9 @@ template: title-layout
 ```
 ---
 ### [Chrome Trace Viewer](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool)
-.footnote[[Catapult Project](https://github.com/catapult-project/catapult)]
+.footnote[[Catapult Project](https://chromium.googlesource.com/catapult)]
 - uftrace dump --chrome generates trace in [JSON format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview).
-  - Catapult's [trace2html](https://github.com/catapult-project/catapult/blob/master/tracing/bin/trace2html) script can convert it to HTML.
+  - Catapult's [trace2html](https://chromium.googlesource.com/catapult/+/refs/heads/main/tracing/bin/trace2html) script can convert it to HTML.
 
 ```
         $ uftrace record a.out


### PR DESCRIPTION
Since catapult repo in github is deprecated, the manual has to be
updated to https://chromium.googlesource.com/catapult.

Fixed: #1375

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>