### PR TITLE
aarch64: Filter out LDRB for full dynamic tracing

### DIFF
--- a/arch/aarch64/mcount-insn.c
+++ b/arch/aarch64/mcount-insn.c
@@ -281,8 +281,8 @@ out:
 
 static bool disasm_check_insn(uint8_t *insn)
 {
-	// LDR (literal)
-	if ((*insn & 0x3b) == 0x18)
+	// LDR (literal) or LDRB (Post-index, Pre-index variant, Unsigned offset)
+	if ((*insn & 0x3f) == 0x18 || (*insn & 0x3e) == 0x38)
 		return false;
 
 	// ADR or ADRP


### PR DESCRIPTION
The current logic couldn't filter out the following instruction
pattern.
```asm
  000000000299ed00 <llvm::Type::getPrimitiveSizeInBits() const>:
   299ed00:       52800021        mov     w1, #0x1
   299ed04:       39402002        ldrb    w2, [x0, #8]
     ...
```
This patch makes disasm_check_insn logic to handle LDRB instruction as
well when capstone is not used.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>