### PR TITLE
dynamic: Set dynamic min_size as patched code size + 1

### DIFF
--- a/arch/aarch64/mcount-dynamic.c
+++ b/arch/aarch64/mcount-dynamic.c
@@ -248,10 +248,11 @@ int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym,
 {
 	int result = INSTRUMENT_SKIPPED;
 
-	if (min_size < CODE_SIZE)
-		min_size = CODE_SIZE;
-	if (sym->size <= min_size)
-		return INSTRUMENT_SKIPPED;
+	if (min_size < CODE_SIZE + 1)
+		min_size = CODE_SIZE + 1;
+
+	if (sym->size < min_size)
+		return result;
 
 	switch (mdi->type) {
 	case DYNAMIC_PATCHABLE:

--- a/arch/i386/mcount-dynamic.c
+++ b/arch/i386/mcount-dynamic.c
@@ -142,8 +142,8 @@ int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym,
 {
 	int result = INSTRUMENT_SKIPPED;
 
-	if (min_size < CALL_INSN_SIZE)
-		min_size = CALL_INSN_SIZE;
+	if (min_size < CALL_INSN_SIZE + 1)
+		min_size = CALL_INSN_SIZE + 1;
 
 	if (sym->size < min_size)
 		return result;

--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -596,8 +596,8 @@ int mcount_patch_func(struct mcount_dynamic_info *mdi, struct sym *sym,
 {
 	int result = INSTRUMENT_SKIPPED;
 
-	if (min_size < CALL_INSN_SIZE)
-		min_size = CALL_INSN_SIZE;
+	if (min_size < CALL_INSN_SIZE + 1)
+		min_size = CALL_INSN_SIZE + 1;
 
 	if (sym->size < min_size)
 		return result;


### PR DESCRIPTION
uftrace has to skip the function target if the function size is same as
min_size given.  This is needed in the following case.
```
  00000000000005f5 <foo>:
   5f5:   e9 26 ff ff ff          jmpq   520 <AAA::bar(int)@plt>

  00000000000005fa <AAA::bar(int)>:
   5fa:   48 8b 05 ef 09 20 00    mov    0x2009ef(%rip),%rax        # 200ff0 <_DYNAMIC+0x198>
   601:   89 38                   mov    %edi,(%rax)
   603:   c3                      retq
```
In this case, the call instruction is overwritten at the entry of 'foo',
but the return address for the entry of foo is misinterpreted as the
address 0x5fa, which is the address of 'AAA::bar(int)>' so uftrace gets
confused about the function name and it fails as follows.

We should avoid patching when symbol size is less than or equal to
min_size.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>