### PR TITLE
tests: Fix a failure of 248 dynamic_dlopen with -Os

### DIFF
--- a/tests/s-libfoo.cpp
+++ b/tests/s-libfoo.cpp
@@ -12,6 +12,7 @@ public:
 extern "C" {
 	void foo(int n)
 	{
+		a = n;
 		AAA::bar(n);
 	}
 }


### PR DESCRIPTION
Since -Os optimizes for size, the code size of 'foo()' becomes too small
as follows.
```
  00000000000005f5 <foo>:
   5f5:   e9 26 ff ff ff          jmpq   520 <AAA::bar(int)@plt>

  00000000000005fa <AAA::bar(int)>:
   5fa:   48 8b 05 ef 09 20 00    mov    0x2009ef(%rip),%rax        # 200ff0 <_DYNAMIC+0x198>
   601:   89 38                   mov    %edi,(%rax)
   603:   c3                      retq
```
In this case, the call instruction is overwritten at the entry of 'foo',
but the return address for the entry of foo misinterpreted as the
address 0x5fa, which is the address of 'AAA::bar(int)>' so uftrace gets
confused about the function name and it fails as follows.
```diff
  t248_dynamic_dlopen: diff result of -pg -Os
  --- expect      2021-11-04 23:01:43.803874511 +0000
  +++ result      2021-11-04 23:01:43.803874511 +0000
  @@ -11,3 +11,3 @@
      dlsym();
  -   foo();
  +   AAA::bar();
      dlclose();

  248 dynamic_dlopen      : NG
```
This patch makes the size of 'foo' sligtly larger to avoid this problem.

Before:
```
  $ ./runtest.py 248
  Start 1 tests with 1 worker
  Test case                 pg             finstrument-fu
  ------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
  248 dynamic_dlopen      : OK OK OK OK NG OK OK OK OK NG
```
After:
```
  $ ./runtest.py 248
  Start 1 tests with 1 worker
  Test case                 pg             finstrument-fu
  ------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
  248 dynamic_dlopen      : OK OK OK OK OK OK OK OK OK OK
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>