### PR TITLE
misc: add libunwind-dev to install-deps.sh

### DIFF
--- a/misc/install-deps.sh
+++ b/misc/install-deps.sh
@@ -15,19 +15,23 @@ case $distro in
     "ubuntu" | "debian" | "raspbian" | "kali" | "linuxmint")
         apt-get $OPT install pandoc libdw-dev python3-dev libncursesw5-dev pkg-config
         apt-get $OPT install libluajit-5.1-dev || true
+        apt-get $OPT install libunwind-dev || true
         apt-get $OPT install libcapstone-dev || true ;;
     "fedora")
         dnf install $OPT pandoc elfutils-devel python3-devel ncurses-devel pkgconf-pkg-config
         dnf install $OPT luajit-devel || true
+        dnf install $OPT libunwind-devel || true
         dnf install $OPT capstone-devel || true ;;
     "rhel" | "centos")
         rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
         yum install $OPT pandoc elfutils-devel python3-devel ncurses-devel pkgconfig
         yum install $OPT luajit-devel || true
+        yum install $OPT libunwind-devel || true
         yum install $OPT capstone-devel || true ;;
     "arch" | "manjaro")
         pacman $OPT -S pandoc libelf python3 ncurses pkgconf
         pacman $OPT -S luajit || true
+        pacman $OPT -S libunwind || true
         pacman $OPT -S capstone || true ;;
     "alpine")
         apk $OPT add elfutils-dev python3-dev ncurses-dev pkgconf


### PR DESCRIPTION
Recently, uftrace started to make use of libunwind library.
commit df1f47075a3d ("Merge pull request #1301 from honggyukim/check/use-libunwind")

This commit adds libunwind-dev to install-deps.sh.
Since libunwind-dev ubuntu package only exists in upper than 18.04,
directive ' || true' has been added to suppress error.
(Same for Fedora, CentOS)

Signed-off-by: Daniel T. Lee <danieltimlee@gmail.com>

--- 

Ubuntu libunwind-dev search result
https://packages.ubuntu.com/search?keywords=libunwind-dev

Tested on vagrant 'generic/ubuntu1804', 'generic/ubuntu2110', 'generic/centos7', 'generic/fedora33', 'generic/arch'