### PR TITLE
dynamic: Do not skip weak symbol functions for dynamic tracing

### DIFF
--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -491,7 +491,9 @@ static bool skip_sym(struct sym *sym, struct mcount_dynamic_info *mdi,
 			return true;
 	}
 
-	if (sym->type != ST_LOCAL_FUNC && sym->type != ST_GLOBAL_FUNC)
+	if (sym->type != ST_LOCAL_FUNC &&
+	    sym->type != ST_GLOBAL_FUNC &&
+	    sym->type != ST_WEAK_FUNC)
 		return true;
 
 	if (!match_pattern_list(map, soname, sym->name)) {


### PR DESCRIPTION
If there is a simple example as follows.
```cpp
  $ cat shared_ptr.cc
  #include <memory>

  int main()
  {
          std::shared_ptr<int> p(new int);
  }
```
We can compile it with -pg and -fpatchable-function-entry=5 as follows.
```
  $ g++ -pg -o shared_ptr.pg shared_ptr.cc
  $ g++ -fpatchable-function-entry=5 -o shared_ptr.fpatchable shared_ptr.cc
```
Tracing result of shared_ptr.fpatchable shows much less functions than
shared_ptr.pg example.
```
  $ uftrace --no-libcall shared_ptr.pg | wc -l
  39

  $ uftrace -P. --no-libcall shared_ptr.fpatchable | wc -l
  11
```
It's because many functions are shown as weak symbols.
```
  $ nm -C shared_ptr.fpatchable | grep "std::shared"
  0000000000400b0e W std::shared_ptr<int>::shared_ptr<int, void>(int*)
  0000000000400b0e W std::shared_ptr<int>::shared_ptr<int, void>(int*)
  0000000000400aee W std::shared_ptr<int>::~shared_ptr()
  0000000000400aee W std::shared_ptr<int>::~shared_ptr()
```
But our logic in skip_sym() skips such weak symbols so this patch makes
dynamic tracing not to skip such weak symbols.

Fixed: #1384
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>