### PR TITLE
arch/arm/mcount-support.c: define EF_ARM_VFP_FLOAT when not available

### DIFF
--- a/arch/arm/mcount-support.c
+++ b/arch/arm/mcount-support.c
@@ -2,6 +2,10 @@
 #include <link.h>
 #include <elf.h>
 
+#ifndef EF_ARM_VFP_FLOAT
+# define EF_ARM_VFP_FLOAT 0x400
+#endif
+
 #ifndef EF_ARM_ABI_FLOAT_HARD
 # define EF_ARM_ABI_FLOAT_HARD  EF_ARM_VFP_FLOAT
 #endif


### PR DESCRIPTION
uClibc-ng `<elf.h>` doesn't define `EF_ARM_VFP_FLOAT`, so let's define it.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
[Retrieved from: https://git.buildroot.net/buildroot/tree/package/uftrace/0002-arch-arm-mcount-support.c-define-EF_ARM_VFP_FLOAT-wh.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>