### PR TITLE
cmds/records: replace ADDR_NO_RANDOMIZE by its value

### DIFF
--- a/cmds/record.c
+++ b/cmds/record.c
@@ -2105,7 +2105,7 @@ int do_child_exec(int ready, struct opts *opts,
 
 	if (opts->no_randomize_addr) {
 		/* disable ASLR (Address Space Layout Randomization) */
-		if (personality(ADDR_NO_RANDOMIZE) < 0)
+		if (personality(0x0040000 /* ADDR_NO_RANDOMIZE */) < 0)
 			pr_dbg("disabling ASLR failed\n");
 	}
 


### PR DESCRIPTION
uClibc-ng lacks the definition of ADDR_NO_RANDOMIZE, causing a build
failure. A patch was submitted to upstream uClibc-ng to address this
issue, but in the mean time, use an hardcoded value.

Using a #ifdef ... #endif test doesn't work as this value is defined
through an enum in glibc.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/uftrace/0001-cmds-records-replace-ADDR_NO_RANDOMIZE-by-its-value.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>