### PR TITLE
report: Add "all" field for -f option

### DIFF
--- a/doc/uftrace-report.md
+++ b/doc/uftrace-report.md
@@ -24,9 +24,10 @@ REPORT OPTIONS
 ==============
 -f *FIELD*, \--output-fields=*FIELD*
 :   Customize field in the output.  Possible values are: `total`, `total-avg`,
-    `total-min`, `total-max`, `self`, `self-avg`, `self-min`, `self-max` and
-    `call`.  Multiple fields can be set by using comma.  Special field of
-    'none' can be used (solely) to hide all fields.
+    `total-min`, `total-max`, `self`, `self-avg`, `self-min`, `self-max`,
+    `call` and `all`.  Multiple fields can be set by using comma.  Special field
+    of 'none' can be used (solely) to hide all fields and 'all' can be used to
+    show all fields.
     Default is 'total,self,call'.  See *FIELDS*.
 
 -s *KEYS*[,*KEYS*,...], \--sort=*KEYS*[,*KEYS*,...]

--- a/utils/field.c
+++ b/utils/field.c
@@ -120,6 +120,7 @@ void setup_field(struct list_head *output_fields, struct opts *opts,
 	unsigned i;
 	int j;
 	bool *field_flags;
+	bool all = false;
 
 	/* default fields */
 	if (opts->fields == NULL) {
@@ -147,6 +148,11 @@ void setup_field(struct list_head *output_fields, struct opts *opts,
 	strv_split(&strv, str, ",");
 
 	strv_for_each(&strv, p, j) {
+		if (!strcmp(p, "all")) {
+			all = true;
+			break;
+		}
+
 		for (i = 0; i < field_table_size; i++) {
 			field = field_table[i];
 
@@ -173,7 +179,7 @@ void setup_field(struct list_head *output_fields, struct opts *opts,
 		del_field(field);
 
 	for (i = 0; i < field_table_size; i++) {
-		if (field_flags[i])
+		if (field_flags[i] || all)
 			add_field(output_fields, field_table[i]);
 	}
 


### PR DESCRIPTION
Add "all" field to show all available fields.
It is applied to report, report --diff and report --task.

These are usage examples:
```
  $ uftrace report -f all
  Total time   Total avg   Total min   Total max   Self time    Self avg    Self min    Self max       Calls  Function
  ==========  ==========  ==========  ==========  ==========  ==========  ==========  ==========  ==========  ====================
   15.780 ms    1.753 ms   13.963 us   14.625 ms   15.780 ms    1.753 ms   13.963 us   14.625 ms           9  linux:schedule
   14.669 ms   14.669 ms   14.669 ms   14.669 ms   44.337 us   44.337 us   44.337 us   44.337 us           1  wait3
    1.744 ms    1.744 ms    1.744 ms    1.744 ms   22.354 us   22.354 us   22.354 us   22.354 us           1  main
```
```
  $ uftrace report --diff uftrace.data.old -f all
   Total time     Total avg     Total min     Total max     Self time      Self avg      Self min      Self max         Calls   Function
  ===========   ===========   ===========   ===========   ===========   ===========   ===========   ===========   ===========   ====================
    -1.728 ms     -1.728 ms     -1.728 ms     -1.728 ms    -20.332 us    -20.332 us    -20.332 us    -20.332 us            +0   main
  -919.681 us   -229.920 us     -0.981 us   -592.542 us    -51.027 us    -12.756 us     -0.981 us    -23.951 us            -4   pthread_join
  +898.949 us   +898.949 us   +898.949 us   +898.949 us    +45.330 us    +45.330 us    +45.330 us    +45.330 us            +0   wait3
```
```
  $ uftrace report --task -f all
  Total time   Self time     TID   Num funcs  Task name
  ==========  ==========  ======  ==========  ====================
   15.823 ms    1.198 ms   21346         893  sh
   13.837 ms   12.531 ms   21348          26  t-thread
    9.500 us    9.500 us   21349           4  t-thread
```
Signed-off-by: Eunseon Lee <esintospace@gmail.com>