### PR TITLE
replay: Remove source location information when returning a function

### DIFF
--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -983,11 +983,8 @@ static int print_graph_rstack(struct uftrace_data *handle,
 			print_field(task, fstack, NULL);
 			pr_out("%*s}%s", depth * 2, "", retval);
 			if (opts->comment) {
-				pr_gray(" /* %s%s%s ", symname,
+				pr_gray(" /* %s%s%s */", symname,
 					*libname ? "@" : "", libname);
-				if (str_loc)
-					pr_gray("at %s ", str_loc);
-				pr_gray("*/");
 			}
 			pr_out("\n");
 		}

--- a/tests/t236_replay_srcline.py
+++ b/tests/t236_replay_srcline.py
@@ -13,10 +13,10 @@ class TestCase(TestBase):
             [ 19939] |     b() { /* tests/s-abc.c:16 */
             [ 19939] |       c() { /* tests/s-abc.c:21 */
    1.120 us [ 19939] |         getpid();
-   1.697 us [ 19939] |       } /* c at tests/s-abc.c:21 */
-   2.044 us [ 19939] |     } /* b at tests/s-abc.c:16 */
-   2.329 us [ 19939] |   } /* a at tests/s-abc.c:11 */
-   2.644 us [ 19939] | } /* main at tests/s-abc.c:26 */
+   1.697 us [ 19939] |       } /* c */
+   2.044 us [ 19939] |     } /* b */
+   2.329 us [ 19939] |   } /* a */
+   2.644 us [ 19939] | } /* main */
 """, cflags='-g')
 
     def build(self, name, cflags='', ldflags=''):


### PR DESCRIPTION
At the request and guidance of @honggyukim, I removed nonvital source line information when returning functions for readability and simplicity.

```
Before:
  $ uftrace replay --srcline t-abc
     0.895 us [ 13079] | __monstartup();
     0.295 us [ 13079] | __cxa_atexit();
              [ 13079] | main() { /* tests/s-abc.c:26 */
              [ 13079] |   a() { /* tests/s-abc.c:11 */
              [ 13079] |     b() { /* tests/s-abc.c:16 */
              [ 13079] |       c() { /* tests/s-abc.c:21 */
     1.132 us [ 13079] |         getpid();
     2.930 us [ 13079] |       } /* c at tests/s-abc.c:21 */
     3.563 us [ 13079] |     } /* b at tests/s-abc.c:16 */
     4.028 us [ 13079] |   } /* a at tests/s-abc.c:11 */
     4.529 us [ 13079] | } /* main at tests/s-abc.c:26 */

After:
  $ uftrace replay --srcline t-abc
     0.895 us [ 13079] | __monstartup();
     0.295 us [ 13079] | __cxa_atexit();
              [ 13079] | main() { /* tests/s-abc.c:26 */
              [ 13079] |   a() { /* tests/s-abc.c:11 */
              [ 13079] |     b() { /* tests/s-abc.c:16 */
              [ 13079] |       c() { /* tests/s-abc.c:21 */
     1.132 us [ 13079] |         getpid();
     2.930 us [ 13079] |       } /* c */
     3.563 us [ 13079] |     } /* b */
     4.028 us [ 13079] |   } /* a */
     4.529 us [ 13079] | } /* main */
```
Any comments are welcome.
Thank you.