### PR TITLE
filter: Add -L/--loc-filter option to filter by source location 

### DIFF
--- a/cmds/record.c
+++ b/cmds/record.c
@@ -71,7 +71,7 @@ static bool can_use_fast_libmcount(struct uftrace_opts *opts)
 	if (getenv("UFTRACE_FILTER") || getenv("UFTRACE_TRIGGER") || getenv("UFTRACE_ARGUMENT") ||
 	    getenv("UFTRACE_RETVAL") || getenv("UFTRACE_PATCH") || getenv("UFTRACE_SCRIPT") ||
 	    getenv("UFTRACE_AUTO_ARGS") || getenv("UFTRACE_WATCH") || getenv("UFTRACE_CALLER") ||
-	    getenv("UFTRACE_SIGNAL") || getenv("UFTRACE_AGENT"))
+	    getenv("UFTRACE_SIGNAL") || getenv("UFTRACE_AGENT") || getenv("UFTRACE_LOCATION"))
 		return false;
 	return true;
 }
@@ -172,6 +172,16 @@ static void setup_child_environ(struct uftrace_opts *opts, int argc, char *argv[
 		if (filter_str) {
 			setenv("UFTRACE_FILTER", filter_str, 1);
 			free(filter_str);
+		}
+	}
+
+	if (opts->loc_filter) {
+		char *loc_str = uftrace_clear_kernel(opts->loc_filter);
+
+		if (loc_str) {
+			setenv("UFTRACE_LOCATION", loc_str, 1);
+			setenv("UFTRACE_SRCLINE", "1", 1);
+			free(loc_str);
 		}
 	}
 

--- a/doc/uftrace-dump.md
+++ b/doc/uftrace-dump.md
@@ -78,6 +78,10 @@ COMMON OPTIONS
     explicitly have the 'trace' trigger applied, those are always traced
     regardless of execution time.
 
+-L *LOCATION*, \--loc-filter=*LOCATION*
+:   Set filter to trace selected source locations.
+    This option can be used more than once.  See *FILTERS*.
+
 \--no-libcall
 :   Do not show library calls.
 

--- a/doc/uftrace-graph.md
+++ b/doc/uftrace-graph.md
@@ -68,6 +68,10 @@ COMMON OPTIONS
     explicitly have the 'trace' trigger applied, those are always traced
     regardless of execution time.
 
+-L *LOCATION*, \--loc-filter=*LOCATION*
+:   Set filter to trace selected source locations.
+    This option can be used more than once.  See *FILTERS*.
+
 \--no-libcall
 :   Do not show library calls.
 

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -46,6 +46,10 @@ COMMON OPTIONS
     explicitly have the 'trace' trigger applied, those are always traced
     regardless of execution time.  See *FILTERS*.
 
+-L *LOCATION*, \--loc-filter=*LOCATION*
+:   Set filter to trace selected source locations. This option can be used more
+    than once. Applies to replay command, not record. See *FILTERS*.
+
 \--no-libcall
 :   Do not record library function invocations.  Library calls are normally
     traced by hooking calls to the resolver function of dynamic linker in the PLT.

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -146,6 +146,10 @@ COMMON OPTIONS
     explicitly have the 'trace' trigger applied, those are always traced
     regardless of execution time.  See *FILTERS*.
 
+-L *LOCATION*, \--loc-filter=*LOCATION*
+:   Set filter to trace selected source locations.
+    This option can be used more than once. Implies --srcline. See *FILTERS*.
+
 \--no-libcall
 :   Do not record library function invocations.  Library calls are normally
     traced by hooking calls to the resolver function of dynamic linker in the PLT.
@@ -367,6 +371,25 @@ example will show all user functions and the (kernel) page fault handler.
       3.340 us [14721] |   } /* a */
      79.086 us [14721] | } /* main */
 
+In addition, you can set filter to record selected source locations with `-L` option.
+
+  $ uftrace record -L s-libmain.c t-lib
+  $ uftrace replay --srcline
+  # DURATION     TID     FUNCTION [SOURCE]
+              [  5043] | main() { /* /home/uftrace/tests/s-libmain.c:16 */
+     6.998 us [  5043] |   foo(); /* /home/uftrace/tests/s-libmain.c:11 */
+     9.393 us [  5043] | } /* main */
+
+You can set filter with the `@hide` suffix not to record selected source locations.
+
+  $ uftrace record -L s-libmain.c@hide t-lib
+  $ uftrace replay --srcline
+  # DURATION     TID     FUNCTION [SOURCE]
+              [ 14688] | lib_a() { /* /home/uftrace/tests/s-lib.c:10 */
+              [ 14688] |   lib_b() { /* /home/uftrace/tests/s-lib.c:15 */
+     1.505 us [ 14688] |     lib_c(); /* /home/uftrace/tests/s-lib.c:20 */
+     2.816 us [ 14688] |   } /* lib_b */
+     3.181 us [ 14688] | } /* lib_a */
 
 TRIGGERS
 ========

--- a/doc/uftrace-replay.md
+++ b/doc/uftrace-replay.md
@@ -48,6 +48,9 @@ REPLAY OPTIONS
 \--libname
 :   Show libname name along with function name.
 
+\--srcline
+:   Show source location of each function if available.
+
 \--format=*TYPE*
 :   Show format style output. Currently, normal and html styles are supported.
 
@@ -80,6 +83,10 @@ COMMON OPTIONS
 :   Do not show functions which run under the time threshold.  If some functions
     explicitly have the 'trace' trigger applied, those are always traced
     regardless of execution time.  See *FILTERS*.
+
+-L *LOCATION*, \--loc-filter=*LOCATION*
+:   Set filter to trace selected source locations.
+    This option can be used more than once.  See *FILTERS*.
 
 \--no-libcall
 :   Do not show library calls.
@@ -313,6 +320,26 @@ as well as DURATION and TID.
       42.124 us   0.220 us [ 6126] |   fgets();
       42.529 us            [ 6126] |   get_values_from() {
       42.645 us   0.236 us [ 6126] |     strdup();
+
+In addition, you can set filter to trace selected source locations with `-L` option.
+For this option, the `--srcline` option is required when using record command.
+
+    $ uftrace record --srcline t-lib
+    $ uftrace replay --srcline -L s-libmain.c
+    # DURATION     TID     FUNCTION [SOURCE]
+                [  5043] | main() { /* /home/uftrace/tests/s-libmain.c:16 */
+       6.998 us [  5043] |   foo(); /* /home/uftrace/tests/s-libmain.c:11 */
+       9.393 us [  5043] | } /* main */
+
+You can set filter with the `@hide` suffix not to trace selected source locations.
+
+    $ uftrace replay -L libmain*@hide
+    # DURATION     TID     FUNCTION
+                [   866] | lib_a() {
+                [   866] |   lib_b() {
+       1.576 us [   866] |     lib_c();
+       2.833 us [   866] |   } /* lib_b */
+       3.132 us [   866] | } /* lib_a */
 
 You can also set triggers on filtered functions.  See *TRIGGERS* section below
 for details.

--- a/doc/uftrace-report.md
+++ b/doc/uftrace-report.md
@@ -107,6 +107,10 @@ COMMON OPTIONS
     functions explicitly have the 'trace' trigger applied, those are always
     accounted regardless of execution time.
 
+-L *LOCATION*, \--loc-filter=*LOCATION*
+:   Set filter to trace selected source locations.
+    This option can be used more than once.  See *FILTERS*.
+
 \--no-libcall
 :   Do not show library calls.
 

--- a/doc/uftrace-script.md
+++ b/doc/uftrace-script.md
@@ -63,6 +63,10 @@ COMMON OPTIONS
     functions explicitly have the 'trace' trigger applied, those are always
     traced regardless of execution time.
 
+-L *LOCATION*, \--loc-filter=*LOCATION*
+:   Set filter to trace selected source locations.
+    This option can be used more than once.  See *FILTERS*.
+
 \--no-libcall
 :   Do not run script for library calls.
 

--- a/doc/uftrace-tui.md
+++ b/doc/uftrace-tui.md
@@ -69,6 +69,10 @@ COMMON OPTIONS
     explicitly have the 'trace' trigger applied, those are always traced
     regardless of execution time.
 
+-L *LOCATION*, \--loc-filter=*LOCATION*
+:   Set filter to trace selected source locations.
+    This option can be used more than once.  See *FILTERS*.
+
 \--no-libcall
 :   Do not show library calls.
 

--- a/misc/dbginfo.c
+++ b/misc/dbginfo.c
@@ -10,7 +10,7 @@
 
 void print_debug_info(struct uftrace_dbg_info *dinfo, bool auto_args)
 {
-	int i;
+	size_t i;
 	char *argspec = NULL;
 	char *retspec = NULL;
 

--- a/tests/t274_filter_loc1.py
+++ b/tests/t274_filter_loc1.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'lib', """
+# DURATION     TID     FUNCTION
+            [ 11746] | main() {
+            [ 11746] |   foo();
+            [ 11746] | } /* main */
+""", sort='simple', cflags='-g')
+
+    def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
+        if TestBase.build_libabc(self, cflags, ldflags) != 0:
+            return TestBase.TEST_BUILD_FAIL
+        return TestBase.build_libmain(self, name, 's-libmain.c',
+                                      ['libabc_test_lib.so'],
+                                      cflags, ldflags)
+
+    def prepare(self):
+        self.subcmd = 'record'
+        self.option = '--srcline --no-libcall'
+        return self.runcmd()
+
+    def setup(self):
+        self.subcmd = 'replay'
+        self.option = '-L s-libmain.c$'

--- a/tests/t275_filter_loc2.py
+++ b/tests/t275_filter_loc2.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'lib', """
+# DURATION     TID     FUNCTION
+            [  5295] | lib_a() {
+            [  5295] |   lib_b() {
+   1.457 us [  5295] |     lib_c();
+   2.401 us [  5295] |   } /* lib_b */
+   2.736 us [  5295] | } /* lib_a */
+""", sort='simple', cflags='-g')
+
+    def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
+        if TestBase.build_libabc(self, cflags, ldflags) != 0:
+            return TestBase.TEST_BUILD_FAIL
+        return TestBase.build_libmain(self, name, 's-libmain.c',
+                                      ['libabc_test_lib.so'],
+                                      cflags, ldflags)
+
+    def prepare(self):
+        self.subcmd = 'record'
+        self.option = '--srcline --no-libcall'
+        return self.runcmd()
+
+    def setup(self):
+        self.subcmd = 'replay'
+        self.option = '-L s-libmain.c@hide'

--- a/tests/t276_filter_loc3.py
+++ b/tests/t276_filter_loc3.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'lib', """
+# DURATION     TID     FUNCTION
+   2.664 us [ 14444] | lib_b();
+""", sort='simple', cflags='-g')
+
+    def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
+        if TestBase.build_libabc(self, cflags, ldflags) != 0:
+            return TestBase.TEST_BUILD_FAIL
+        return TestBase.build_libmain(self, name, 's-libmain.c',
+                                      ['libabc_test_lib.so'],
+                                      cflags, ldflags)
+
+    def prepare(self):
+        self.subcmd = 'record'
+        self.option = '--srcline --no-libcall'
+        return self.runcmd()
+
+    def setup(self):
+        self.subcmd = 'replay'
+        self.option = '-L s-lib.c -F lib_b -N lib_c'

--- a/uftrace.c
+++ b/uftrace.c
@@ -18,6 +18,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#include <dirent.h>
 #include <fcntl.h>
 #include <getopt.h>
 #include <stdio.h>
@@ -102,6 +103,8 @@ enum uftrace_short_options {
 	OPT_usage,
 	OPT_libmcount_path,
 	OPT_mermaid,
+	OPT_library_path,
+	OPT_loc_filter,
 };
 
 /* clang-format off */
@@ -238,7 +241,7 @@ __used static const char uftrace_footer[] =
 "\n";
 
 static const char uftrace_shopts[] =
-	"+aA:b:C:d:D:eE:f:F:ghH:kK:lN:p:P:r:R:s:S:t:T:U:vVW:Z:";
+	"+aA:b:C:d:D:eE:f:F:ghH:kK:lL:N:p:P:r:R:s:S:t:T:U:vVW:Z:";
 
 #define REQ_ARG(name, shopt) { #name, required_argument, 0, shopt }
 #define NO_ARG(name, shopt)  { #name, no_argument, 0, shopt }
@@ -328,6 +331,8 @@ static const struct option uftrace_options[] = {
 	REQ_ARG(signal, OPT_signal),
 	NO_ARG(srcline, OPT_srcline),
 	REQ_ARG(hide, 'H'),
+	REQ_ARG(loc-filter, OPT_loc_filter),
+	REQ_ARG(loc-filter-warning, 'L'), /* the long option is dummy, will change later */
 	REQ_ARG(clock, OPT_clock),
 	NO_ARG(help, 'h'),
 	NO_ARG(usage, OPT_usage),
@@ -547,8 +552,33 @@ static char *remove_trailing_slash(char *path)
 	return path;
 }
 
+static bool is_libmcount_directory(const char *path)
+{
+	DIR *dp = NULL;
+	struct dirent *ent;
+	int ret = false;
+
+	dp = opendir(path);
+	if (dp == NULL)
+		return false;
+
+	while ((ent = readdir(dp)) != NULL) {
+		if ((ent->d_type == DT_DIR && !strcmp(ent->d_name, "libmcount")) ||
+		    ((ent->d_type == DT_LNK || ent->d_type == DT_REG) &&
+		     !strcmp(ent->d_name, "libmcount.so"))) {
+			ret = true;
+			break;
+		}
+	}
+
+	closedir(dp);
+	return ret;
+}
+
 static int parse_option(struct uftrace_opts *opts, int key, char *arg)
 {
+	char *pos;
+
 	switch (key) {
 	case 'F':
 		opts->filter = opt_add_string(opts->filter, arg);
@@ -581,6 +611,25 @@ static int parse_option(struct uftrace_opts *opts, int key, char *arg)
 
 	case 'H':
 		opts->hide = opt_add_string(opts->hide, arg);
+		break;
+
+	case 'L':
+		if (is_libmcount_directory(arg))
+			pr_warn("--libmcount-path option should be used to set libmcount path.\n");
+		/* fall through */
+	case OPT_loc_filter:
+		pos = strstr(arg, "@hide");
+		if (!pos)
+			opts->loc_filter = opt_add_string(opts->loc_filter, arg);
+		else {
+			*pos = '\0';
+			opts->loc_filter = opt_add_prefix_string(opts->loc_filter, "!", arg);
+		}
+		/*
+		 * location filter focuses onto a given location,
+		 * displaying sched event with it is annoying.
+		 */
+		opts->no_sched = true;
 		break;
 
 	case 'v':
@@ -1246,6 +1295,7 @@ static void free_opts(struct uftrace_opts *opts)
 	free(opts->caller);
 	free(opts->watch);
 	free(opts->hide);
+	free(opts->loc_filter);
 	free_parsed_cmdline(opts->run_cmd);
 }
 

--- a/uftrace.h
+++ b/uftrace.h
@@ -244,6 +244,7 @@ struct uftrace_opts {
 	char *caller;
 	char *extern_data;
 	char *hide;
+	char *loc_filter;
 	char *with_syms;
 	char *clock;
 	int mode;

--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -463,7 +463,8 @@ int open_data_file(struct uftrace_opts *opts, struct uftrace_data *handle)
 		/* read old task file first and then try task.txt file */
 		if (read_task_file(sessions, opts->dirname, true, sym_rel, opts->srcline) < 0 &&
 		    read_task_txt_file(sessions, opts->dirname, opts->with_syms ?: opts->dirname,
-				       true, sym_rel, opts->srcline) < 0) {
+				       true, sym_rel,
+				       opts->srcline | (opts->loc_filter != NULL)) < 0) {
 			if (errno == ENOENT)
 				saved_errno = ENODATA;
 			else

--- a/utils/dwarf.c
+++ b/utils/dwarf.c
@@ -1965,7 +1965,7 @@ void save_debug_file(FILE *fp, char code, char *str, unsigned long val)
 static void save_debug_entries(struct uftrace_dbg_info *dinfo, const char *dirname,
 			       const char *filename, char *build_id)
 {
-	int i;
+	size_t i;
 	FILE *fp;
 	int idx;
 	int len;

--- a/utils/dwarf.h
+++ b/utils/dwarf.h
@@ -49,9 +49,9 @@ struct uftrace_dbg_info {
 	/* array of location - same order as symbol */
 	struct uftrace_dbg_loc *locs;
 	/* number of debug location info */
-	int nr_locs;
+	size_t nr_locs;
 	/* number of actually used debug location info */
-	int nr_locs_used;
+	size_t nr_locs_used;
 	/* ELF file type - EXEC, REL, DYN */
 	int file_type;
 	/* whether it needs to parse argument info */

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -36,6 +36,7 @@ enum trigger_flag {
 	TRIGGER_FL_CALLER = (1U << 15),
 	TRIGGER_FL_SIGNAL = (1U << 16),
 	TRIGGER_FL_HIDE = (1U << 17),
+	TRIGGER_FL_LOC = (1U << 18),
 };
 
 enum filter_mode {
@@ -59,6 +60,7 @@ struct uftrace_trigger {
 	char color;
 	uint64_t time;
 	enum filter_mode fmode;
+	enum filter_mode lmode;
 	enum trigger_read_type read;
 	struct list_head *pargs;
 };
@@ -112,6 +114,9 @@ void uftrace_setup_caller_filter(char *filter_str, struct uftrace_sym_info *sinf
 				 struct rb_root *root, struct uftrace_filter_setting *setting);
 void uftrace_setup_hide_filter(char *filter_str, struct uftrace_sym_info *sinfo,
 			       struct rb_root *root, struct uftrace_filter_setting *setting);
+void uftrace_setup_loc_filter(char *filter_str, struct uftrace_sym_info *sinfo,
+			      struct rb_root *root, enum filter_mode *mode,
+			      struct uftrace_filter_setting *setting);
 
 struct uftrace_filter *uftrace_match_filter(uint64_t ip, struct rb_root *root,
 					    struct uftrace_trigger *tr);

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -479,7 +479,7 @@ void setup_fstack_args(char *argspec, char *retspec, struct uftrace_data *handle
  */
 int fstack_setup_filters(struct uftrace_opts *opts, struct uftrace_data *handle)
 {
-	if (opts->filter || opts->trigger || opts->caller || opts->hide) {
+	if (opts->filter || opts->trigger || opts->caller || opts->hide || opts->loc_filter) {
 		struct uftrace_filter_setting setting = {
 			.ptype = opts->patt_type,
 			.allow_kernel = true,
@@ -488,7 +488,7 @@ int fstack_setup_filters(struct uftrace_opts *opts, struct uftrace_data *handle)
 		};
 
 		if (setup_fstack_filters(handle, opts->filter, opts->trigger, opts->caller,
-					 opts->hide, NULL, &setting) < 0) {
+					 opts->hide, opts->loc_filter, &setting) < 0) {
 			char * or = "";
 			pr_use("failed to set filter or trigger: ");
 			if (opts->filter) {
@@ -505,6 +505,10 @@ int fstack_setup_filters(struct uftrace_opts *opts, struct uftrace_data *handle)
 			}
 			if (opts->hide) {
 				pr_out("%s%s", or, opts->hide);
+				or = " or ";
+			}
+			if (opts->loc_filter) {
+				pr_out("%s%s", or, opts->loc_filter);
 				or = " or ";
 			}
 			pr_out("\n");

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -22,6 +22,7 @@ bool fstack_enabled = true;
 bool live_disabled = false;
 
 static enum filter_mode fstack_filter_mode = FILTER_MODE_NONE;
+static enum filter_mode fstack_loc_mode = FILTER_MODE_NONE;
 
 static int __read_task_ustack(struct uftrace_task_reader *task);
 
@@ -247,6 +248,15 @@ static int setup_hides(struct uftrace_session *s, void *arg)
 	return 0;
 }
 
+static int setup_locs(struct uftrace_session *s, void *arg)
+{
+	struct uftrace_filter_setting *setting = arg;
+
+	uftrace_setup_loc_filter(setting->info_str, &s->sym_info, &s->filters, &fstack_loc_mode,
+				 setting);
+	return 0;
+}
+
 static int count_filters(struct uftrace_session *s, void *arg)
 {
 	int *count = arg;
@@ -271,6 +281,12 @@ static int count_hides(struct uftrace_session *s, void *arg)
 	return 0;
 }
 
+static int count_locs(struct uftrace_session *s, void *arg)
+{
+	*(int *)arg += uftrace_count_filter(&s->filters, TRIGGER_FL_LOC);
+	return 0;
+}
+
 /**
  * setup_fstack_filters - setup symbol filters and triggers
  * @handle      - handle for uftrace data
@@ -278,6 +294,7 @@ static int count_hides(struct uftrace_session *s, void *arg)
  * @trigger_str - trigger definitions
  * @caller_str  - caller filter symbol names
  * @hide_str    - hide filter symbol names
+ * @loc_str     - source location filter symbol names
  * @setting     - filter setting
  *
  * This function sets up the symbol filters and triggers using following syntax:
@@ -287,7 +304,7 @@ static int count_hides(struct uftrace_session *s, void *arg)
  *   trigger_def = "depth=" NUM | "backtrace"
  */
 static int setup_fstack_filters(struct uftrace_data *handle, char *filter_str, char *trigger_str,
-				char *caller_str, char *hide_str,
+				char *caller_str, char *hide_str, char *loc_str,
 				struct uftrace_filter_setting *setting)
 {
 	int count = 0;
@@ -345,6 +362,19 @@ static int setup_fstack_filters(struct uftrace_data *handle, char *filter_str, c
 			return -1;
 
 		pr_dbg("setup hide filters for %d function(s)\n", count);
+	}
+
+	if (loc_str) {
+		int prev = count;
+
+		setting->info_str = loc_str;
+		walk_sessions(sessions, setup_locs, setting);
+		walk_sessions(sessions, count_locs, &count);
+
+		if (prev == count)
+			return -1;
+
+		pr_dbg("setup location filters for %d function(s)\n", count);
 	}
 
 	return 0;
@@ -458,7 +488,7 @@ int fstack_setup_filters(struct uftrace_opts *opts, struct uftrace_data *handle)
 		};
 
 		if (setup_fstack_filters(handle, opts->filter, opts->trigger, opts->caller,
-					 opts->hide, &setting) < 0) {
+					 opts->hide, NULL, &setting) < 0) {
 			char * or = "";
 			pr_use("failed to set filter or trigger: ");
 			if (opts->filter) {
@@ -608,6 +638,19 @@ int fstack_entry(struct uftrace_task_reader *task, struct uftrace_record *rstack
 	}
 	else {
 		if (fstack_filter_mode == FILTER_MODE_IN && task->filter.in_count == 0) {
+			fstack->flags |= FSTACK_FL_NORECORD;
+			return -1;
+		}
+	}
+
+	if (tr->flags & TRIGGER_FL_LOC) {
+		if (tr->lmode == FILTER_MODE_OUT) {
+			fstack->flags |= FSTACK_FL_NORECORD;
+			return -1;
+		}
+	}
+	else {
+		if (fstack_loc_mode == FILTER_MODE_IN) {
 			fstack->flags |= FSTACK_FL_NORECORD;
 			return -1;
 		}
@@ -786,7 +829,12 @@ static int fstack_check_skip(struct uftrace_task_reader *task, struct uftrace_re
 
 		depth = task->h->depth;
 	}
-	else if (fstack_filter_mode == FILTER_MODE_IN && task->filter.in_count == 0) {
+	else if (tr.flags & TRIGGER_FL_LOC) {
+		if (tr.fmode == FILTER_MODE_OUT)
+			return -1;
+	}
+	else if ((fstack_filter_mode == FILTER_MODE_IN || fstack_loc_mode == FILTER_MODE_IN) &&
+		 task->filter.in_count == 0) {
 		return -1;
 	}
 


### PR DESCRIPTION
The -O option supports a filter that traces or does not trace the selected
source location with the debug_info loaded.

These are usage example.

The '--srcline' option is required when using record command.
```
  $ uftrace record --srcline t-lib
```
The '-O' option is required when using replay command to set a filter to
trace selected source files.
```
  $ uftrace replay -O s-libmain.c --srcline
  # DURATION     TID     FUNCTION [SOURCE]
              [  4636] | main() { /* /home/uftrace/tests/s-libmain.c:16 */
     4.119 us [  4636] |   foo(); /* /home/uftrace/tests/s-libmain.c:11 */
     4.544 us [  4636] | } /* main at /home/uftrace/tests/s-libmain.c:16 */
```

You can set a filter to not trace selected source files with the '@hide' suffix.
```
  $ uftrace replay -O s-libmain.c@hide
  # DURATION     TID     FUNCTION
              [  5327] | lib_a() {
              [  5327] |   lib_b() {
     1.226 us [  5327] |     lib_c();
     2.419 us [  5327] |   } /* lib_b */
     2.789 us [  5327] | } /* lib_a */
```
Fixed: #1378

Signed-off-by: Eunseon Lee <esintospace@gmail.com>