### PR TITLE
python: Following python coding style in automated way with black

### DIFF
--- a/misc/gen-autoargs.py
+++ b/misc/gen-autoargs.py
@@ -22,27 +22,40 @@ argspec_file = "autoargs.h"
 storage_class_specifier = ["auto", "register", "static", "extern", "typedef"]
 type_qualifier = ["const", "volatile"]
 
-type_specifier = ["void", "char", "short", "int", "long", "float", "double", \
-                    "signed", "unsigned" ]
+type_specifier = ["void", "char", "short", "int", "long", "float", "double", "signed", "unsigned"]
 
 struct_or_union_specifier = ["struct", "union"]
 enum_specifier = ["enum"]
 
 typedef_name = [
-        "size_t", "ssize_t", "pid_t", "uid_t", "off_t", "off64_t",
-        "sigset_t", "socklen_t", "intptr_t", "nfds_t",
-        "pthread_t", "pthread_once_t", "pthread_attr_t",
-        "pthread_mutex_t", "pthread_mutexattr_t", "pthread_cond_t",
-        "Lmid_t", "FILE", "in_addr_t",
-    ]
+    "size_t",
+    "ssize_t",
+    "pid_t",
+    "uid_t",
+    "off_t",
+    "off64_t",
+    "sigset_t",
+    "socklen_t",
+    "intptr_t",
+    "nfds_t",
+    "pthread_t",
+    "pthread_once_t",
+    "pthread_attr_t",
+    "pthread_mutex_t",
+    "pthread_mutexattr_t",
+    "pthread_cond_t",
+    "Lmid_t",
+    "FILE",
+    "in_addr_t",
+]
 
-artifitial_type = [ "funcptr_t" ]
+artifitial_type = ["funcptr_t"]
 
 pointer = "*"
 reference = "&"
 
 type_specifier.extend(struct_or_union_specifier)
-#type_specifier.extend(enum_specifier)
+# type_specifier.extend(enum_specifier)
 type_specifier.extend(typedef_name)
 type_specifier.extend(["std::string"])
 type_specifier.extend(artifitial_type)
@@ -57,6 +70,7 @@ header = """\
 """
 
 verbose = False
+
 
 def parse_return_type(words):
     global storage_class_specifier
@@ -105,8 +119,8 @@ def parse_func_name(words):
 
 
 def parse_args(words):
-    if words[0] != '(' and words[-1] != ')':
-        return []   # fail
+    if words[0] != "(" and words[-1] != ")":
+        return []  # fail
 
     arg_type = []
     enum_flag = False
@@ -142,7 +156,7 @@ def parse_args(words):
 
 
 def parse_func_decl(func):
-    chunks = re.split('[\s,;]+|([*()])', func)
+    chunks = re.split("[\s,;]+|([*()])", func)
     words = [x for x in chunks if x]
     (return_type, words) = parse_return_type(words)
     (funcname, words) = parse_func_name(words)
@@ -154,15 +168,17 @@ DECL_TYPE_NONE = 0
 DECL_TYPE_FUNC = 1
 DECL_TYPE_ENUM = 2
 
+
 def get_decl_type(line):
     # function should have parenthesis
-    if line.find('(') >= 0:
+    if line.find("(") >= 0:
         return DECL_TYPE_FUNC
     # or it should be enum
-    if line.startswith('enum'):
+    if line.startswith("enum"):
         return DECL_TYPE_ENUM
     # error
     return DECL_TYPE_NONE
+
 
 def make_uftrace_retval_format(ctype, funcname):
     retval_format = funcname + "@"
@@ -194,7 +210,7 @@ def make_uftrace_retval_format(ctype, funcname):
         retval_format += "retval/p"
     elif ctype == "off64_t":
         retval_format += "retval/d64"
-    elif ctype.startswith('enum'):
+    elif ctype.startswith("enum"):
         retval_format += "retval/e:%s" % ctype[5:]
     else:
         retval_format += "retval"
@@ -209,7 +225,7 @@ def make_uftrace_args_format(args, funcname):
     f = 1
     for arg in args:
         i += 1
-        if (i > 1):
+        if i > 1:
             args_format += ","
         if arg == "void":
             args_format = ""
@@ -242,7 +258,7 @@ def make_uftrace_args_format(args, funcname):
             args_format += "arg%d/p" % i
         elif arg == "off64_t":
             args_format += "arg%d/d64" % i
-        elif arg.startswith('enum'):
+        elif arg.startswith("enum"):
             args_format += "arg%d/e:%s" % (i, arg[5:])
         else:
             args_format += "arg%d" % i
@@ -252,23 +268,38 @@ def make_uftrace_args_format(args, funcname):
 
 def parse_enum(line):
     # is this the final line (including semi-colon)
-    if line.find(';') >= 0:
-        return (DECL_TYPE_NONE, ' '.join(line.split()))
+    if line.find(";") >= 0:
+        return (DECL_TYPE_NONE, " ".join(line.split()))
 
     # continue to parse next line
-    return (DECL_TYPE_ENUM, ' '.join(line.split()))
+    return (DECL_TYPE_ENUM, " ".join(line.split()))
 
 
 def parse_argument():
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i", "--input-file", dest='infile', default="prototypes.h",
-                        help="input prototype header file (default: prototypes.h")
-    parser.add_argument("-o", "--output-file", dest='outfile', default="autoargs.h",
-                        help="output uftrace argspec file (default: autoargs.h)")
-    parser.add_argument("-v", "--verbose", dest='verbose', action='store_true',
-                        help="show internal command and result for debugging")
+    parser.add_argument(
+        "-i",
+        "--input-file",
+        dest="infile",
+        default="prototypes.h",
+        help="input prototype header file (default: prototypes.h",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        dest="outfile",
+        default="autoargs.h",
+        help="output uftrace argspec file (default: autoargs.h)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="verbose",
+        action="store_true",
+        help="show internal command and result for debugging",
+    )
 
     return parser.parse_args()
 
@@ -287,24 +318,24 @@ if __name__ == "__main__":
     retvals_list = ""
 
     # operator new and delete and their variations
-    args_list     = '\t\"_Znwm@arg1/u;\"\n'   \
-                  + '\t\"_Znam@arg1/u;\"\n'   \
-                  + '\t\"_ZdlPv@arg1/x;\"\n'  \
-                  + '\t\"_ZdaPv@arg1/x;\"\n'
+    args_list = (
+        '\t"_Znwm@arg1/u;"\n'
+        + '\t"_Znam@arg1/u;"\n'
+        + '\t"_ZdlPv@arg1/x;"\n'
+        + '\t"_ZdaPv@arg1/x;"\n'
+    )
 
     # operator new and its variations
-    retvals_list  = '\t\"_Znwm@retval/x;\"\n' \
-                  + '\t\"_Znam@retval/x;\"\n'
+    retvals_list = '\t"_Znwm@retval/x;"\n' + '\t"_Znam@retval/x;"\n'
 
     t = DECL_TYPE_NONE
     with open(prototype_file) as fin:
         for line in fin:
-            if len(line) <= 1 or line[0] == '#' or line[0:2] == "//" \
-                    or line[0:7] == "typedef":
+            if len(line) <= 1 or line[0] == "#" or line[0:2] == "//" or line[0:7] == "typedef":
                 continue
 
             if verbose:
-                print(line, end='')
+                print(line, end="")
 
             if t == DECL_TYPE_ENUM:
                 (t, curr) = parse_enum(line)
@@ -352,7 +383,7 @@ if __name__ == "__main__":
     fout.write(header)
 
     if len(enum_list) == 0:
-        enum_list="\"\""
+        enum_list = '""'
 
     fout.write("static char *auto_enum_list =\n")
     fout.write(enum_list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,5 @@ combine_as_imports = true
 ignore_whitespace = true
 skip_gitignore = true
 
+[tool.black]
+line-length = 100

--- a/scripts/count.py
+++ b/scripts/count.py
@@ -1,14 +1,18 @@
 count = 0
 
+
 def uftrace_begin(ctx):
     pass
+
 
 def uftrace_entry(ctx):
     global count
     count += 1
 
+
 def uftrace_exit(ctx):
     pass
+
 
 def uftrace_end():
     print(count)

--- a/scripts/dump.py
+++ b/scripts/dump.py
@@ -17,42 +17,49 @@ def uftrace_begin(ctx):
         print("  cmds    : %s" % " ".join(ctx["cmds"]))
     print("")
 
+
 # uftrace_entry is executed at the entry of each function.
 # if UFTRACE_FUNCS is defined, only the listed functions enter here.
 def uftrace_entry(ctx):
-    _tid        = ctx["tid"]
-    _depth      = ctx["depth"]
-    _time       = ctx["timestamp"]
+    _tid = ctx["tid"]
+    _depth = ctx["depth"]
+    _time = ctx["timestamp"]
     # _duration = ctx["duration"]        # exit only
-    _address    = ctx["address"]
-    _name       = ctx["name"]
+    _address = ctx["address"]
+    _name = ctx["name"]
 
     unit = 10 ** 9
-    print("%d.%d %6d: [entry] %s(%x) depth: %d" %
-            (_time / unit, _time % unit, _tid, _name, _address, _depth))
+    print(
+        "%d.%d %6d: [entry] %s(%x) depth: %d"
+        % (_time / unit, _time % unit, _tid, _name, _address, _depth)
+    )
 
     if "args" in ctx:
         for i in range(len(ctx["args"])):
             arg = ctx["args"][i]
             print("  args[%d] %s: %s" % (i, type(arg), arg))
 
+
 # uftrace_exit is executed at the exit of each function.
 # if UFTRACE_FUNCS is defined, only the listed functions enter here.
 def uftrace_exit(ctx):
-    _tid        = ctx["tid"]
-    _depth      = ctx["depth"]
-    _time       = ctx["timestamp"]
-    _duration   = ctx["duration"]        # not used here
-    _address    = ctx["address"]
-    _name       = ctx["name"]
+    _tid = ctx["tid"]
+    _depth = ctx["depth"]
+    _time = ctx["timestamp"]
+    _duration = ctx["duration"]  # not used here
+    _address = ctx["address"]
+    _name = ctx["name"]
 
     unit = 10 ** 9
-    print("%d.%d %6d: [exit ] %s(%x) depth: %d" %
-            (_time / unit, _time % unit, _tid, _name, _address, _depth))
+    print(
+        "%d.%d %6d: [exit ] %s(%x) depth: %d"
+        % (_time / unit, _time % unit, _tid, _name, _address, _depth)
+    )
 
     if "retval" in ctx:
         ret = ctx["retval"]
         print("  retval  %s: %s" % (type(ret), ret))
+
 
 # uftrace_end is optional, so can be omitted.
 def uftrace_end():

--- a/scripts/func-histogram.py
+++ b/scripts/func-histogram.py
@@ -22,17 +22,18 @@
 #   >= 1024us  :          0  (  0.0 %)
 #
 
-func = ''
-unit = 'us'
+func = ""
+unit = "us"
 histo = None
 
 divider = {
-    'ns': 1,
-    'us': 1000,
-    'ms': 1000000,
-    's':  1000000000,
-    'm':  60000000000,
+    "ns": 1,
+    "us": 1000,
+    "ms": 1000000,
+    "s": 1000000000,
+    "m": 60000000000,
 }
+
 
 def create_histogram():
     h = []
@@ -41,14 +42,16 @@ def create_histogram():
         h.append(0)
     return h
 
+
 def get_histogram_index(val):
     if val < 0:
         return 0
     val = int(val / divider[unit])
     for i in range(11):
         if val < (1 << i):
-            return i+1
+            return i + 1
     return 12
+
 
 def print_histogram():
     print("histogram of function latency of '%s'\n" % func)
@@ -60,17 +63,22 @@ def print_histogram():
 
     print(" <  %4d%-2s  : %10d  (%5.1f %%)" % (0, unit, histo[0], 100.0 * histo[0] / total))
     for i in range(11):
-        print(" <  %4d%-2s  : %10d  (%5.1f %%)" % (1 << i, unit, histo[i+1], 100.0 * histo[i+1] / total))
+        print(
+            " <  %4d%-2s  : %10d  (%5.1f %%)"
+            % (1 << i, unit, histo[i + 1], 100.0 * histo[i + 1] / total)
+        )
     print(" >= %4d%-2s  : %10d  (%5.1f %%)" % (1024, unit, histo[12], 100.0 * histo[12] / total))
+
 
 def parse_args(args):
     global func, unit
-    if args[0] == '-u' or args[0] == '--unit':
+    if args[0] == "-u" or args[0] == "--unit":
         unit = args[1]
         func = args[2]
     else:
-        unit = 'us'
+        unit = "us"
         func = args[0]
+
 
 #
 # uftrace interface functions
@@ -87,8 +95,10 @@ def uftrace_begin(ctx):
         return
     histo = create_histogram()
 
+
 def uftrace_entry(ctx):
     pass
+
 
 def uftrace_exit(ctx):
     global histo
@@ -101,6 +111,7 @@ def uftrace_exit(ctx):
     dur = int(ctx["duration"])
     idx = get_histogram_index(dur)
     histo[idx] += 1
+
 
 def uftrace_end():
     if histo is None:

--- a/scripts/info.py
+++ b/scripts/info.py
@@ -3,8 +3,10 @@ def uftrace_begin(ctx):
     print(ctx["version"])
     print(ctx["cmds"])
 
+
 def uftrace_entry(ctx):
     pass
+
 
 def uftrace_exit(ctx):
     pass

--- a/scripts/replay.py
+++ b/scripts/replay.py
@@ -1,6 +1,7 @@
 def uftrace_begin(ctx):
     print("# DURATION     TID     FUNCTION")
 
+
 def uftrace_entry(ctx):
     # read arguments
     _tid = ctx["tid"]
@@ -12,6 +13,7 @@ def uftrace_entry(ctx):
 
     buf = " %10s [%6d] | %s%s() {" % ("", _tid, space, _symname)
     print(buf)
+
 
 def uftrace_exit(ctx):
     # read arguments
@@ -28,8 +30,10 @@ def uftrace_exit(ctx):
     buf = "%s /* %s */" % (buf, _symname)
     print(buf)
 
+
 def uftrace_end():
     pass
+
 
 def get_time_and_unit(duration):
     duration = float(duration)

--- a/scripts/report-libcall.py
+++ b/scripts/report-libcall.py
@@ -8,8 +8,10 @@ import os
 
 libcall_map = {}
 
+
 def uftrace_begin(ctx):
     pass
+
 
 def uftrace_entry(ctx):
     _name = ctx["name"]
@@ -18,8 +20,10 @@ def uftrace_entry(ctx):
     else:
         libcall_map[_name] = 1
 
+
 def uftrace_exit(ctx):
     pass
+
 
 def uftrace_end():
     global libcall_map

--- a/scripts/retval-histogram.py
+++ b/scripts/retval-histogram.py
@@ -22,19 +22,20 @@
 #   >= 1024b  :          0  (  0.0 %)
 #
 
-func = ''
-unit = 'b'
+func = ""
+unit = "b"
 histo = None
 
 divider = {
-    'b': 1,
-    'k': 1000,
-    'K': 1000,
-    'm': 1000000,
-    'M': 1000000,
-    'g': 1000000000,
-    'G': 1000000000,
+    "b": 1,
+    "k": 1000,
+    "K": 1000,
+    "m": 1000000,
+    "M": 1000000,
+    "g": 1000000000,
+    "G": 1000000000,
 }
+
 
 def create_histogram():
     h = []
@@ -43,14 +44,16 @@ def create_histogram():
         h.append(0)
     return h
 
+
 def get_histogram_index(val):
     if val < 0:
         return 0
     val = int(val / divider[unit])
     for i in range(11):
         if val < (1 << i):
-            return i+1
+            return i + 1
     return 12
+
 
 def print_histogram():
     print("histogram of return value of '%s'\n" % func)
@@ -62,17 +65,22 @@ def print_histogram():
 
     print(" <  %4d%s  : %10d  (%5.1f %%)" % (0, unit, histo[0], 100.0 * histo[0] / total))
     for i in range(11):
-        print(" <  %4d%s  : %10d  (%5.1f %%)" % (1 << i, unit, histo[i+1], 100.0 * histo[i+1] / total))
+        print(
+            " <  %4d%s  : %10d  (%5.1f %%)"
+            % (1 << i, unit, histo[i + 1], 100.0 * histo[i + 1] / total)
+        )
     print(" >= %4d%s  : %10d  (%5.1f %%)" % (1024, unit, histo[12], 100.0 * histo[12] / total))
+
 
 def parse_args(args):
     global func, unit
-    if args[0] == '-u' or args[0] == '--unit':
+    if args[0] == "-u" or args[0] == "--unit":
         unit = args[1]
         func = args[2]
     else:
-        unit = 'b'
+        unit = "b"
         func = args[0]
+
 
 #
 # uftrace interface functions
@@ -89,8 +97,10 @@ def uftrace_begin(ctx):
         return
     histo = create_histogram()
 
+
 def uftrace_entry(ctx):
     pass
+
 
 def uftrace_exit(ctx):
     global histo
@@ -103,6 +113,7 @@ def uftrace_exit(ctx):
     retval = int(ctx["retval"])
     idx = get_histogram_index(retval)
     histo[idx] += 1
+
 
 def uftrace_end():
     if histo is None:

--- a/scripts/simple.py
+++ b/scripts/simple.py
@@ -1,13 +1,16 @@
 def uftrace_begin(ctx):
     print("program begins...")
 
+
 def uftrace_entry(ctx):
     func = ctx["name"]
     print("entry : " + func + "()")
 
+
 def uftrace_exit(ctx):
     func = ctx["name"]
     print("exit  : " + func + "()")
+
 
 def uftrace_end():
     print("program is finished")

--- a/scripts/strings.py
+++ b/scripts/strings.py
@@ -6,6 +6,7 @@
 
 strset = set()
 
+
 def uftrace_entry(ctx):
     global strset
     if "args" in ctx:
@@ -16,6 +17,7 @@ def uftrace_entry(ctx):
                 if arg != "" and arg[:8] != "struct: ":
                     strset.add(arg)
 
+
 def uftrace_exit(ctx):
     global strset
     if "retval" in ctx:
@@ -24,6 +26,7 @@ def uftrace_exit(ctx):
             ret = ret.strip()
             if ret != "" and ret[:8] != "struct: ":
                 strset.add(ret)
+
 
 def uftrace_end():
     global strset

--- a/scripts/trace-memcpy.py
+++ b/scripts/trace-memcpy.py
@@ -7,13 +7,15 @@
 #
 
 # Only "memcpy" calls this script and other functions never.
-UFTRACE_FUNCS = [ "memcpy" ]
+UFTRACE_FUNCS = ["memcpy"]
 
 count = 0
 total_bytes = 0
 
+
 def uftrace_begin(ctx):
     pass
+
 
 def uftrace_entry(ctx):
     global count
@@ -21,8 +23,10 @@ def uftrace_entry(ctx):
     count += 1
     total_bytes += ctx["args"][0]
 
+
 def uftrace_exit(ctx):
     pass
+
 
 def uftrace_end():
     global count

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -10,10 +10,11 @@ import sys
 import tempfile
 import time
 
+
 class TestBase:
     supported_lang = {
-        'C':   { 'cc': 'gcc', 'flags': 'CFLAGS',   'ext': '.c' },
-        'C++': { 'cc': 'g++', 'flags': 'CXXFLAGS', 'ext': '.cpp' },
+        "C": {"cc": "gcc", "flags": "CFLAGS", "ext": ".c"},
+        "C++": {"cc": "g++", "flags": "CXXFLAGS", "ext": ".cpp"},
     }
 
     TEST_SUCCESS = 0
@@ -27,16 +28,21 @@ class TestBase:
     TEST_SUCCESS_FIXED = -8
 
     basedir = os.path.dirname(os.getcwd())
-    objdir = 'objdir' in os.environ and os.environ['objdir'] or basedir
-    uftrace_cmd = objdir + '/uftrace'
-    default_opt = '--no-pager --no-event -L' + objdir
+    objdir = "objdir" in os.environ and os.environ["objdir"] or basedir
+    uftrace_cmd = objdir + "/uftrace"
+    default_opt = "--no-pager --no-event -L" + objdir
 
-    default_cflags = ['-fno-inline', '-fno-builtin', '-fno-ipa-cp',
-                      '-fno-omit-frame-pointer', '-D_FORTIFY_SOURCE=0']
+    default_cflags = [
+        "-fno-inline",
+        "-fno-builtin",
+        "-fno-ipa-cp",
+        "-fno-omit-frame-pointer",
+        "-D_FORTIFY_SOURCE=0",
+    ]
     feature = set()
 
-    def __init__(self, name, result, lang='C', cflags='', ldflags='', sort='task', serial=False):
-        _tmp = tempfile.mkdtemp(prefix='test_%s_' % name)
+    def __init__(self, name, result, lang="C", cflags="", ldflags="", sort="task", serial=False):
+        _tmp = tempfile.mkdtemp(prefix="test_%s_" % name)
         os.chdir(_tmp)
         self.test_dir = _tmp
         self.name = name
@@ -46,18 +52,18 @@ class TestBase:
         self.lang = lang
         self.sort_method = sort
         self.serial = serial
-        self.subcmd = 'live'
-        self.option = ''
-        self.exearg = 't-' + name
+        self.subcmd = "live"
+        self.option = ""
+        self.exearg = "t-" + name
         self.test_feature()
 
     def set_compiler(self, compiler):
-        if compiler == 'gcc':
-            self.supported_lang['C']['cc'] = 'gcc'
-            self.supported_lang['C++']['cc'] = 'g++'
-        elif compiler == 'clang':
-            self.supported_lang['C']['cc'] = 'clang'
-            self.supported_lang['C++']['cc'] = 'clang++'
+        if compiler == "gcc":
+            self.supported_lang["C"]["cc"] = "gcc"
+            self.supported_lang["C++"]["cc"] = "g++"
+        elif compiler == "clang":
+            self.supported_lang["C"]["cc"] = "clang"
+            self.supported_lang["C++"]["cc"] = "clang++"
         else:
             # ignore invalid compiler argument
             pass
@@ -74,8 +80,10 @@ class TestBase:
 
     def test_feature(self):
         try:
-            p = sp.Popen(self.uftrace_cmd + ' --version', shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
-            uftrace_version = p.communicate()[0].decode(errors='ignore')
+            p = sp.Popen(
+                self.uftrace_cmd + " --version", shell=True, stdout=sp.PIPE, stderr=sp.PIPE
+            )
+            uftrace_version = p.communicate()[0].decode(errors="ignore")
             s = uftrace_version.split()
             for i in range(3, len(s) - 1):
                 self.feature.add(s[i])
@@ -85,8 +93,8 @@ class TestBase:
 
     def convert_abs_path(self, build_cmd):
         cmd = build_cmd.split()
-        src_idx = [i for i, _cmd in enumerate(cmd) if _cmd.startswith('s-')][0]
-        abs_src = os.path.join(self.basedir, 'tests', cmd[src_idx])
+        src_idx = [i for i, _cmd in enumerate(cmd) if _cmd.startswith("s-")][0]
+        abs_src = os.path.join(self.basedir, "tests", cmd[src_idx])
         cmd[src_idx] = abs_src
         return " ".join(cmd)
 
@@ -96,7 +104,7 @@ class TestBase:
         try:
             p = sp.Popen(build_cmd.split(), stderr=sp.PIPE)
             if p.wait() != 0:
-                self.pr_debug(p.communicate()[1].decode(errors='ignore'))
+                self.pr_debug(p.communicate()[1].decode(errors="ignore"))
                 return TestBase.TEST_BUILD_FAIL
             return TestBase.TEST_SUCCESS
         except OSError as e:
@@ -105,235 +113,256 @@ class TestBase:
         except:
             return TestBase.TEST_BUILD_FAIL
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         if self.lang not in TestBase.supported_lang:
             pr_debug("%s: unsupported language: %s" % (name, self.lang))
             return TestBase.TEST_UNSUPP_LANG
 
         lang = TestBase.supported_lang[self.lang]
-        prog = 't-' + name
-        src  = 's-' + name + lang['ext']
+        prog = "t-" + name
+        src = "s-" + name + lang["ext"]
 
-        build_cflags  = ' '.join(TestBase.default_cflags + [self.cflags, cflags, \
-                                  os.getenv(lang['flags'], '')])
-        build_ldflags = ' '.join([self.ldflags, ldflags, \
-                                  os.getenv('LDFLAGS', '')])
+        build_cflags = " ".join(
+            TestBase.default_cflags + [self.cflags, cflags, os.getenv(lang["flags"], "")]
+        )
+        build_ldflags = " ".join([self.ldflags, ldflags, os.getenv("LDFLAGS", "")])
 
-        build_cmd = '%s -o %s %s %s %s' % \
-                    (lang['cc'], prog, build_cflags, src, build_ldflags)
+        build_cmd = "%s -o %s %s %s %s" % (lang["cc"], prog, build_cflags, src, build_ldflags)
 
         self.pr_debug("build command: %s" % build_cmd)
         return self.build_it(build_cmd)
 
-    def build_notrace_lib(self, dstname, srcname, cflags='', ldflags =''):
-        lang = TestBase.supported_lang['C']
+    def build_notrace_lib(self, dstname, srcname, cflags="", ldflags=""):
+        lang = TestBase.supported_lang["C"]
 
-        build_cflags  = ' '.join(TestBase.default_cflags + [self.cflags, cflags, \
-                                  os.getenv(lang['flags'], '')])
-        build_ldflags = ' '.join([self.ldflags, ldflags, \
-                                  os.getenv('LDFLAGS', '')])
+        build_cflags = " ".join(
+            TestBase.default_cflags + [self.cflags, cflags, os.getenv(lang["flags"], "")]
+        )
+        build_ldflags = " ".join([self.ldflags, ldflags, os.getenv("LDFLAGS", "")])
 
-        lib_cflags = build_cflags + ' -shared -fPIC'
+        lib_cflags = build_cflags + " -shared -fPIC"
 
-        build_cmd = '%s -o lib%s.so %s s-%s.c %s' % \
-                    (lang['cc'], dstname, lib_cflags, srcname, build_ldflags)
+        build_cmd = "%s -o lib%s.so %s s-%s.c %s" % (
+            lang["cc"],
+            dstname,
+            lib_cflags,
+            srcname,
+            build_ldflags,
+        )
 
-        build_cmd = build_cmd.replace('-pg', '').replace('-finstrument-functions', '')
+        build_cmd = build_cmd.replace("-pg", "").replace("-finstrument-functions", "")
         self.pr_debug("build command for library: %s" % build_cmd)
         return self.build_it(build_cmd)
 
-    def build_libabc(self, cflags='', ldflags=''):
-        lang = TestBase.supported_lang['C']
+    def build_libabc(self, cflags="", ldflags=""):
+        lang = TestBase.supported_lang["C"]
 
-        build_cflags  = ' '.join(TestBase.default_cflags + [self.cflags, cflags, \
-                                  os.getenv(lang['flags'], '')])
-        build_ldflags = ' '.join([self.ldflags, ldflags, \
-                                  os.getenv('LDFLAGS', '')])
+        build_cflags = " ".join(
+            TestBase.default_cflags + [self.cflags, cflags, os.getenv(lang["flags"], "")]
+        )
+        build_ldflags = " ".join([self.ldflags, ldflags, os.getenv("LDFLAGS", "")])
 
-        lib_cflags = build_cflags + ' -shared -fPIC'
+        lib_cflags = build_cflags + " -shared -fPIC"
 
         # build libabc_test_lib.so library
-        build_cmd = '%s -o libabc_test_lib.so %s s-lib.c %s' % \
-                    (lang['cc'], lib_cflags, build_ldflags)
+        build_cmd = "%s -o libabc_test_lib.so %s s-lib.c %s" % (
+            lang["cc"],
+            lib_cflags,
+            build_ldflags,
+        )
 
         self.pr_debug("build command for library: %s" % build_cmd)
         return self.build_it(build_cmd)
 
-    def build_libfoo(self, name, cflags='', ldflags=''):
-        lang = TestBase.supported_lang['C++']
+    def build_libfoo(self, name, cflags="", ldflags=""):
+        lang = TestBase.supported_lang["C++"]
 
-        build_cflags  = ' '.join(TestBase.default_cflags + [self.cflags, cflags, \
-                                  os.getenv(lang['flags'], '')])
-        build_ldflags = ' '.join([self.ldflags, ldflags, \
-                                  os.getenv('LDFLAGS', '')])
+        build_cflags = " ".join(
+            TestBase.default_cflags + [self.cflags, cflags, os.getenv(lang["flags"], "")]
+        )
+        build_ldflags = " ".join([self.ldflags, ldflags, os.getenv("LDFLAGS", "")])
 
-        lib_cflags = build_cflags + ' -shared -fPIC'
+        lib_cflags = build_cflags + " -shared -fPIC"
 
         # build lib{foo}.so library
-        build_cmd = '%s -o lib%s.so %s s-lib%s%s %s' % \
-                    (lang['cc'], name, lib_cflags, name, lang['ext'], build_ldflags)
+        build_cmd = "%s -o lib%s.so %s s-lib%s%s %s" % (
+            lang["cc"],
+            name,
+            lib_cflags,
+            name,
+            lang["ext"],
+            build_ldflags,
+        )
 
         self.pr_debug("build command for library: %s" % build_cmd)
         return self.build_it(build_cmd)
 
-    def build_libmain(self, exename, srcname, libs, cflags='', ldflags='', instrument=True):
+    def build_libmain(self, exename, srcname, libs, cflags="", ldflags="", instrument=True):
         if self.lang not in TestBase.supported_lang:
             self.pr_debug("%s: unsupported language: %s" % (self.name, self.lang))
             return TestBase.TEST_UNSUPP_LANG
 
         lang = TestBase.supported_lang[self.lang]
-        prog = 't-' + exename
-        build_cflags  = ' '.join(TestBase.default_cflags +
-                                 [self.cflags, cflags, os.getenv(lang['flags'], '')])
-        build_ldflags = ' '.join([self.ldflags, ldflags, os.getenv('LDFLAGS', '')])
-        exe_ldflags = build_ldflags + ' -Wl,-rpath,$ORIGIN -L. '
+        prog = "t-" + exename
+        build_cflags = " ".join(
+            TestBase.default_cflags + [self.cflags, cflags, os.getenv(lang["flags"], "")]
+        )
+        build_ldflags = " ".join([self.ldflags, ldflags, os.getenv("LDFLAGS", "")])
+        exe_ldflags = build_ldflags + " -Wl,-rpath,$ORIGIN -L. "
         for lib in libs:
-            exe_ldflags += ' -l' + lib[3:-3]
+            exe_ldflags += " -l" + lib[3:-3]
 
-        build_cmd = '%s -o %s %s %s %s' % (lang['cc'], prog, build_cflags, srcname, exe_ldflags)
+        build_cmd = "%s -o %s %s %s %s" % (lang["cc"], prog, build_cflags, srcname, exe_ldflags)
         if not instrument:
-            build_cmd = build_cmd.replace('-pg', '').replace('-finstrument-functions', '')
+            build_cmd = build_cmd.replace("-pg", "").replace("-finstrument-functions", "")
 
         self.pr_debug("build command for executable: %s" % build_cmd)
         return self.build_it(build_cmd)
 
     def prepare(self):
-        """ This function returns command line need to be run before"""
-        return ''
+        """This function returns command line need to be run before"""
+        return ""
 
     def setup(self):
-        """ This function sets up options to be passed to runcmd"""
+        """This function sets up options to be passed to runcmd"""
         pass
 
     def runcmd(self):
-        """ This function returns (shell) command that runs the test.
-            A test case can extend this to setup a complex configuration.  """
-        return '%s %s %s %s %s' % (TestBase.uftrace_cmd, self.subcmd, \
-                                   TestBase.default_opt, self.option, self.exearg)
+        """This function returns (shell) command that runs the test.
+        A test case can extend this to setup a complex configuration."""
+        return "%s %s %s %s %s" % (
+            TestBase.uftrace_cmd,
+            self.subcmd,
+            TestBase.default_opt,
+            self.option,
+            self.exearg,
+        )
 
     def task_sort(self, output, ignore_children=False):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         pids = {}
         order = 1
         before_main = True
-        for ln in output.split('\n'):
-            if ln.find(' | main()') > 0:
+        for ln in output.split("\n"):
+            if ln.find(" | main()") > 0:
                 before_main = False
             if before_main:
                 continue
             # ignore result of remaining functions which follows a blank line
-            if ln.strip() == '':
+            if ln.strip() == "":
                 break
-            pid_patt = re.compile('[^[]+\[ *(\d+)\] |')
+            pid_patt = re.compile("[^[]+\[ *(\d+)\] |")
             m = pid_patt.match(ln)
             try:
                 pid = int(m.group(1))
             except:
                 continue
 
-            func = ln.split('|', 1)[-1]
+            func = ln.split("|", 1)[-1]
             if pid not in pids:
-                pids[pid] = { 'order': order }
-                pids[pid]['result'] = []
+                pids[pid] = {"order": order}
+                pids[pid]["result"] = []
                 order += 1
-            pids[pid]['result'].append(func)
+            pids[pid]["result"].append(func)
 
-        result = ''
-        pid_list = sorted(list(pids), key=lambda p: pids[p]['order'])
+        result = ""
+        pid_list = sorted(list(pids), key=lambda p: pids[p]["order"])
 
         try:
             if ignore_children:
-                result += '\n'.join(pids[pid_list[0]]['result'])
+                result += "\n".join(pids[pid_list[0]]["result"])
             else:
                 for p in pid_list:
-                    result += '\n'.join(pids[p]['result']) + '\n'
+                    result += "\n".join(pids[p]["result"]) + "\n"
                 result = result.strip()
         except:
             pass  # this leads to a failure with 'NG'
         return result
 
     def simple_sort(self, output, ignored):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            func = ln.split('|', 1)[-1]
+            func = ln.split("|", 1)[-1]
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)
 
     def report_sort(self, output, ignored):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Total':
+            if line[0] == "Total":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]         [1]   [2]        [3]   [4]     [5]
             # total_time  unit  self_time  unit  called  function
             try:
-                if line[5].startswith('__'):
+                if line[5].startswith("__"):
                     continue
             except:
                 pass
-            result.append('%s %s' % (line[4], line[5]))
+            result.append("%s %s" % (line[4], line[5]))
 
-        return '\n'.join(result)
+        return "\n".join(result)
 
     def graph_sort(self, output, ignored):
-        """ This function post-processes output of the test to be compared.
-            It ignores blank and comment (#) lines and header lines.  """
+        """This function post-processes output of the test to be compared.
+        It ignores blank and comment (#) lines and header lines."""
         result = []
         mode = 0
-        for ln in output.split('\n'):
-            if ln.strip() == '' or ln.startswith('#'):
+        for ln in output.split("\n"):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
             # A graph result consists of backtrace and calling functions
-            if ln.startswith('=============== BACKTRACE ==============='):
+            if ln.startswith("=============== BACKTRACE ==============="):
                 mode = 1
                 continue
-            if ln.startswith('========== FUNCTION CALL GRAPH =========='):
+            if ln.startswith("========== FUNCTION CALL GRAPH =========="):
                 mode = 2
                 continue
             if mode == 1:
-                if ln.startswith(' backtrace #'):
-                    result.append(ln.split(',')[0])  # remove time part
-                if ln.startswith('   ['):
-                    result.append(ln.split('(')[0])  # remove '(addr)' part
+                if ln.startswith(" backtrace #"):
+                    result.append(ln.split(",")[0])  # remove time part
+                if ln.startswith("   ["):
+                    result.append(ln.split("(")[0])  # remove '(addr)' part
             if mode == 2:
                 if " : " in ln:
-                    result.append(ln.split(':')[1])  # remove time part
+                    result.append(ln.split(":")[1])  # remove time part
                 else:
                     result.append(ln)
 
-        return '\n'.join(result)
+        return "\n".join(result)
 
     def dump_sort(self, output, ignored):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         mode = 1
         result = []
 
         # A (raw) dump result consists of following data
         # <timestamp> <tid>: [<type>] <func>(<addr>) depth: <N>
-        patt = re.compile(r'[^[]*(?P<type>\[(entry|exit )\]) (?P<func>[_a-z0-9]*)\([0-9a-f]+\) (?P<depth>.*)')
+        patt = re.compile(
+            r"[^[]*(?P<type>\[(entry|exit )\]) (?P<func>[_a-z0-9]*)\([0-9a-f]+\) (?P<depth>.*)"
+        )
 
         # A (raw) dump argument patter
-        arg_patt = re.compile(r'^  args')
+        arg_patt = re.compile(r"^  args")
 
-        for ln in output.split('\n'):
-            if ln.startswith('uftrace'):
-                #result.append(ln)
+        for ln in output.split("\n"):
+            if ln.startswith("uftrace"):
+                # result.append(ln)
                 pass
             else:
                 m = arg_patt.match(ln)
@@ -345,15 +374,15 @@ class TestBase:
                 if m is None:
                     continue
                 # ignore __monstartup and __cxa_atexit
-                if m.group('func').startswith('__'):
+                if m.group("func").startswith("__"):
                     continue
-                result.append(patt.sub(r'\g<type> \g<depth> \g<func>', ln))
+                result.append(patt.sub(r"\g<type> \g<depth> \g<func>", ln))
 
-        return '\n'.join(result)
+        return "\n".join(result)
 
     def chrome_sort(self, output, ignored):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         import json
 
         # A chrome dump results consists of following JSON object:
@@ -362,31 +391,31 @@ class TestBase:
         try:
             o = json.loads(output)
         except:
-            return ''
-        for ln in o['traceEvents']:
-            if ln['name'].startswith('__'):
+            return ""
+        for ln in o["traceEvents"]:
+            if ln["name"].startswith("__"):
                 continue
-            if ln['ph'] == "M":
-                if ln['name'] == "process_name" or ln['name'] == "thread_name":
-                    args = ln['args']
-                    name = args['name']
-                    m = re.search(r'\[\d+\] (.*)', args['name'])
+            if ln["ph"] == "M":
+                if ln["name"] == "process_name" or ln["name"] == "thread_name":
+                    args = ln["args"]
+                    name = args["name"]
+                    m = re.search(r"\[\d+\] (.*)", args["name"])
                     if m:
                         name = m.group(1)
-                    result.append("%s %s %s" % (ln['ph'], ln['name'], name))
+                    result.append("%s %s %s" % (ln["ph"], ln["name"], name))
             else:
-                result.append("%s %s" % (ln['ph'], ln['name']))
-        return '\n'.join(result)
+                result.append("%s %s" % (ln["ph"], ln["name"]))
+        return "\n".join(result)
 
     def sort(self, output, ignore_children=False):
-        if not hasattr(TestBase, self.sort_method + '_sort'):
-            print('cannot find the sort function: %s' % self.sort_method)
-            return ''  # this leads to a failure with 'NG'
-        func = TestBase.__dict__[self.sort_method + '_sort']
+        if not hasattr(TestBase, self.sort_method + "_sort"):
+            print("cannot find the sort function: %s" % self.sort_method)
+            return ""  # this leads to a failure with 'NG'
+        func = TestBase.__dict__[self.sort_method + "_sort"]
         if callable(func):
             return func(self, output, ignore_children)
         else:
-            return ''  # this leads to a failure with 'NG'
+            return ""  # this leads to a failure with 'NG'
 
     def postrun(self, result):
         """This function is called after running a testcase"""
@@ -394,19 +423,20 @@ class TestBase:
 
     def fixup(self, cflags, result):
         """This function is called when result is different to expected.
-           But if we know some known difference on some optimization level,
-           apply it and re-test with the modified result."""
+        But if we know some known difference on some optimization level,
+        apply it and re-test with the modified result."""
         return result
 
     def check_dependency(self, item):
         import os.path
-        return os.path.exists('%s/check-deps/' % self.basedir + item)
+
+        return os.path.exists("%s/check-deps/" % self.basedir + item)
 
     def check_perf_paranoid(self):
-        if not 'perf' in TestBase.feature:
+        if not "perf" in TestBase.feature:
             return False
         try:
-            f = open('/proc/sys/kernel/perf_event_paranoid')
+            f = open("/proc/sys/kernel/perf_event_paranoid")
             v = int(f.readline())
             f.close()
 
@@ -421,17 +451,17 @@ class TestBase:
         EI_NIDENT = 16
 
         # e_ident[] indexes
-        EI_CLASS      = 4
+        EI_CLASS = 4
 
         # EI_CLASS
-        ELFCLASSNONE  = 0
-        ELFCLASS32    = 1
-        ELFCLASS64    = 2
-        ELFCLASSNUM   = 3
+        ELFCLASSNONE = 0
+        ELFCLASS32 = 1
+        ELFCLASS64 = 2
+        ELFCLASSNUM = 3
 
         try:
-            elfname = 't-' + self.name
-            f = open(elfname, 'rb')
+            elfname = "t-" + self.name
+            f = open(elfname, "rb")
             elf_ident = list(f.read(EI_NIDENT))
             ei_class = ord(elf_ident[EI_CLASS])
             f.close()
@@ -450,21 +480,16 @@ class TestBase:
         EI_NIDENT = 16
 
         # e_machine (architecture)
-        EM_386        = 3       # Intel 80386
-        EM_ARM        = 40      # ARM
-        EM_X86_64     = 62      # AMD x86-64 architecture
-        EM_AARCH64    = 183     # ARM AARCH64
+        EM_386 = 3  # Intel 80386
+        EM_ARM = 40  # ARM
+        EM_X86_64 = 62  # AMD x86-64 architecture
+        EM_AARCH64 = 183  # ARM AARCH64
 
-        machine = {
-            EM_386: 'i386',
-            EM_ARM: 'arm',
-            EM_X86_64: 'x86_64',
-            EM_AARCH64: 'aarch64'
-        }
+        machine = {EM_386: "i386", EM_ARM: "arm", EM_X86_64: "x86_64", EM_AARCH64: "aarch64"}
 
         try:
-            elfname = 't-' + self.name
-            f = open(elfname, 'rb')
+            elfname = "t-" + self.name
+            f = open(elfname, "rb")
 
             # consume elf_ident and e_type
             f.read(EI_NIDENT + 2)
@@ -483,29 +508,29 @@ class TestBase:
 
     def check_arch_full_dynamic_support(self):
         elf_machine = TestBase.get_elf_machine(self)
-        if elf_machine == 'x86_64' or elf_machine == 'aarch64':
+        if elf_machine == "x86_64" or elf_machine == "aarch64":
             return True
         return False
 
     def check_arch_mfentry_mnop_mcount_support(self):
         machine = TestBase.get_machine(self)
-        if machine == 'x86_64' or machine == 'i386':
+        if machine == "x86_64" or machine == "i386":
             return True
         return False
 
     def check_arch_sdt_support(self):
         machine = TestBase.get_machine(self)
-        if machine == 'x86_64':
+        if machine == "x86_64":
             return True
         return False
 
     def prerun(self, timeout):
-        self.subcmd = 'live'
-        self.option = ''
-        self.exearg = 't-' + self.name
+        self.subcmd = "live"
+        self.option = ""
+        self.exearg = "t-" + self.name
 
         cmd = self.prepare()
-        if cmd == '':
+        if cmd == "":
             return TestBase.TEST_SUCCESS
 
         self.pr_debug("prerun command: " + cmd)
@@ -518,6 +543,7 @@ class TestBase:
 
         ret = TestBase.TEST_SUCCESS
         import signal
+
         signal.signal(signal.SIGALRM, timeout_handler)
 
         try:
@@ -531,7 +557,7 @@ class TestBase:
 
     def run(self, name, cflags, diff, timeout):
         ret = TestBase.TEST_SUCCESS
-        dif = ''
+        dif = ""
 
         self.setup()
         test_cmd = self.runcmd()
@@ -549,14 +575,15 @@ class TestBase:
                 raise Timeout
 
         import signal
+
         signal.signal(signal.SIGALRM, timeout_handler)
 
         timed_out = False
         try:
             signal.alarm(timeout)
-            result_origin = p.communicate()[0].decode(errors='ignore')
+            result_origin = p.communicate()[0].decode(errors="ignore")
         except Timeout:
-            result_origin = ''
+            result_origin = ""
             timed_out = True
         signal.alarm(0)
 
@@ -566,12 +593,12 @@ class TestBase:
         ret = p.wait()
         if ret < 0:
             if timed_out:
-                return TestBase.TEST_TIME_OUT, ''
+                return TestBase.TEST_TIME_OUT, ""
             else:
-                return TestBase.TEST_ABNORMAL_EXIT, ''
+                return TestBase.TEST_ABNORMAL_EXIT, ""
         if ret > 0:
             if ret == 2:
-                return TestBase.TEST_ABNORMAL_EXIT, ''
+                return TestBase.TEST_ABNORMAL_EXIT, ""
             if diff:
                 dif = "%s: %s returns %d\n" % (name, cflags, ret)
             return TestBase.TEST_NONZERO_RETURN, dif
@@ -580,7 +607,7 @@ class TestBase:
         self.pr_debug("=========== %s ===========\n%s" % (" result ", result_tested))
         self.pr_debug("=========== %s ===========\n%s" % ("expected", result_expect))
 
-        if result_expect.strip() == '':
+        if result_expect.strip() == "":
             if diff:
                 dif = "%s: has no output for %s\n" % (name, cflags)
             return TestBase.TEST_DIFF_RESULT, dif
@@ -591,66 +618,67 @@ class TestBase:
 
         if result_expect != result_tested:
             if diff:
-                f = open('expect', 'w')
-                f.write(result_expect + '\n')
+                f = open("expect", "w")
+                f.write(result_expect + "\n")
                 f.close()
-                f = open('result', 'w')
-                f.write(result_tested + '\n')
+                f = open("result", "w")
+                f.write(result_tested + "\n")
                 f.close()
                 dif = "%s: diff result of %s\n" % (name, cflags)
                 try:
-                    p = sp.Popen(['colordiff', '-U1', 'expect', 'result'], stdout=sp.PIPE)
+                    p = sp.Popen(["colordiff", "-U1", "expect", "result"], stdout=sp.PIPE)
                 except:
-                    p = sp.Popen(['diff', '-U1', 'expect', 'result'], stdout=sp.PIPE)
-                dif += p.communicate()[0].decode(errors='ignore')
-                os.remove('expect')
-                os.remove('result')
+                    p = sp.Popen(["diff", "-U1", "expect", "result"], stdout=sp.PIPE)
+                dif += p.communicate()[0].decode(errors="ignore")
+                os.remove("expect")
+                os.remove("result")
             return TestBase.TEST_DIFF_RESULT, dif
 
-        return ret, ''
+        return ret, ""
 
     def __del__(self):
-        sp.call(['rm', '-rf', self.test_dir])
+        sp.call(["rm", "-rf", self.test_dir])
 
-RED     = '\033[1;31m'
-GREEN   = '\033[1;32m'
-YELLOW  = '\033[1;33m'
-NORMAL  = '\033[0m'
+
+RED = "\033[1;31m"
+GREEN = "\033[1;32m"
+YELLOW = "\033[1;33m"
+NORMAL = "\033[0m"
 
 colored_result = {
-    TestBase.TEST_SUCCESS:        GREEN  + 'OK' + NORMAL,
-    TestBase.TEST_UNSUPP_LANG:    YELLOW + 'LA' + NORMAL,
-    TestBase.TEST_BUILD_FAIL:     YELLOW + 'BI' + NORMAL,
-    TestBase.TEST_ABNORMAL_EXIT:  RED    + 'SG' + NORMAL,
-    TestBase.TEST_TIME_OUT:       RED    + 'TM' + NORMAL,
-    TestBase.TEST_DIFF_RESULT:    RED    + 'NG' + NORMAL,
-    TestBase.TEST_NONZERO_RETURN: RED    + 'NZ' + NORMAL,
-    TestBase.TEST_SKIP:           YELLOW + 'SK' + NORMAL,
-    TestBase.TEST_SUCCESS_FIXED:  YELLOW + 'OK' + NORMAL,
+    TestBase.TEST_SUCCESS: GREEN + "OK" + NORMAL,
+    TestBase.TEST_UNSUPP_LANG: YELLOW + "LA" + NORMAL,
+    TestBase.TEST_BUILD_FAIL: YELLOW + "BI" + NORMAL,
+    TestBase.TEST_ABNORMAL_EXIT: RED + "SG" + NORMAL,
+    TestBase.TEST_TIME_OUT: RED + "TM" + NORMAL,
+    TestBase.TEST_DIFF_RESULT: RED + "NG" + NORMAL,
+    TestBase.TEST_NONZERO_RETURN: RED + "NZ" + NORMAL,
+    TestBase.TEST_SKIP: YELLOW + "SK" + NORMAL,
+    TestBase.TEST_SUCCESS_FIXED: YELLOW + "OK" + NORMAL,
 }
 
 text_result = {
-    TestBase.TEST_SUCCESS:        'OK',
-    TestBase.TEST_UNSUPP_LANG:    'LA',
-    TestBase.TEST_BUILD_FAIL:     'BI',
-    TestBase.TEST_ABNORMAL_EXIT:  'SG',
-    TestBase.TEST_TIME_OUT:       'TM',
-    TestBase.TEST_DIFF_RESULT:    'NG',
-    TestBase.TEST_NONZERO_RETURN: 'NZ',
-    TestBase.TEST_SKIP:           'SK',
-    TestBase.TEST_SUCCESS_FIXED:  'OK',
+    TestBase.TEST_SUCCESS: "OK",
+    TestBase.TEST_UNSUPP_LANG: "LA",
+    TestBase.TEST_BUILD_FAIL: "BI",
+    TestBase.TEST_ABNORMAL_EXIT: "SG",
+    TestBase.TEST_TIME_OUT: "TM",
+    TestBase.TEST_DIFF_RESULT: "NG",
+    TestBase.TEST_NONZERO_RETURN: "NZ",
+    TestBase.TEST_SKIP: "SK",
+    TestBase.TEST_SUCCESS_FIXED: "OK",
 }
 
 result_string = {
-    TestBase.TEST_SUCCESS:        'Test succeeded',
-    TestBase.TEST_UNSUPP_LANG:    'Unsupported Language',
-    TestBase.TEST_BUILD_FAIL:     'Build failed',
-    TestBase.TEST_ABNORMAL_EXIT:  'Abnormal exit by signal',
-    TestBase.TEST_TIME_OUT:       'Test ran too long',
-    TestBase.TEST_DIFF_RESULT:    'Different test result',
-    TestBase.TEST_NONZERO_RETURN: 'Non-zero return value',
-    TestBase.TEST_SKIP:           'Skipped',
-    TestBase.TEST_SUCCESS_FIXED:  'Test succeeded (with some fixup)',
+    TestBase.TEST_SUCCESS: "Test succeeded",
+    TestBase.TEST_UNSUPP_LANG: "Unsupported Language",
+    TestBase.TEST_BUILD_FAIL: "Build failed",
+    TestBase.TEST_ABNORMAL_EXIT: "Abnormal exit by signal",
+    TestBase.TEST_TIME_OUT: "Test ran too long",
+    TestBase.TEST_DIFF_RESULT: "Different test result",
+    TestBase.TEST_NONZERO_RETURN: "Non-zero return value",
+    TestBase.TEST_SKIP: "Skipped",
+    TestBase.TEST_SUCCESS_FIXED: "Test succeeded (with some fixup)",
 }
 
 
@@ -658,7 +686,7 @@ def check_serial_case(case):
     # for python3
     _locals = {}
     exec("import %s; tc = %s.TestCase()" % (case, case), globals(), _locals)
-    tc = _locals['tc']
+    tc = _locals["tc"]
     return tc.serial
 
 
@@ -668,15 +696,15 @@ def run_single_case(case, flags, opts, arg):
     # for python3
     _locals = {}
     exec("import %s; tc = %s.TestCase()" % (case, case), globals(), _locals)
-    tc = _locals['tc']
+    tc = _locals["tc"]
     tc.set_debug(arg.debug)
     tc.set_compiler(arg.compiler)
     timeout = int(arg.timeout)
 
     for flag in flags:
         for opt in opts:
-            cflags = ' '.join(["-" + flag, "-" + opt])
-            dif = ''
+            cflags = " ".join(["-" + flag, "-" + opt])
+            dif = ""
             ret = tc.build(tc.name, cflags)
             if ret == TestBase.TEST_SUCCESS:
                 ret = tc.prerun(timeout)
@@ -690,7 +718,7 @@ def run_single_case(case, flags, opts, arg):
 
 def save_test_result(result, case, shared):
     # save diff before results for print_test_result() to see it
-    shared.diffs[case]   = [r[1] for r in result]
+    shared.diffs[case] = [r[1] for r in result]
     shared.results[case] = [r[0] for r in result]
     shared.progress += 1
     for r in result:
@@ -707,11 +735,11 @@ def print_test_result(case, result, diffs, color, ftests):
         result_list = plain_result
 
     for dif in diffs:
-        if dif != '':
-            sys.stdout.write(dif + '\n')
+        if dif != "":
+            sys.stdout.write(dif + "\n")
 
     output = case[1:4]
-    output += ' %-20s' % case[5:] + ': ' + ' '.join(result_list) + '\n'
+    output += " %-20s" % case[5:] + ": " + " ".join(result_list) + "\n"
 
     sys.stdout.write(output)
 
@@ -720,7 +748,7 @@ def print_test_result(case, result, diffs, color, ftests):
     for r in result:
         if r not in normal:
             output = case[1:4]
-            output += ' %-20s' % case[5:] + ': ' + ' '.join(plain_result) + '\n'
+            output += " %-20s" % case[5:] + ": " + " ".join(plain_result) + "\n"
             ftests.write(output)
             ftests.flush()
             break
@@ -729,19 +757,19 @@ def print_test_result(case, result, diffs, color, ftests):
 def print_test_header(opts, flags, ftests):
     optslen = len(opts)
 
-    header1 = '%-24s ' % 'Test case'
-    header2 = '-' * 24 + ':'
-    empty = '                      '
+    header1 = "%-24s " % "Test case"
+    header2 = "-" * 24 + ":"
+    empty = "                      "
 
     for flag in flags:
         # align with optimization flags
-        header1 += ' ' + flag[:optslen] + empty[len(flag):optslen]
-        header2 += ' ' + opts
+        header1 += " " + flag[:optslen] + empty[len(flag) : optslen]
+        header2 += " " + opts
 
     print(header1)
     print(header2)
-    ftests.write(header1 + '\n')
-    ftests.write(header2 + '\n')
+    ftests.write(header1 + "\n")
+    ftests.write(header2 + "\n")
     ftests.flush()
 
 
@@ -765,29 +793,64 @@ def parse_argument():
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-f", "--profile-flags", dest='flags',
-                        default="pg finstrument-functions",
-                        help="comma separated list of compiler profiling flags")
-    parser.add_argument("-O", "--optimize-levels", dest='opts', default="0123s",
-                        help="compiler optimization levels")
-    parser.add_argument("case", nargs='?', default="all",
-                        help="test case: 'all' or test number or (partial) name")
-    parser.add_argument("-p", "--profile-pg", dest='pg_flag', action='store_true',
-                        help="profiling with -pg option")
-    parser.add_argument("-i", "--instrument-functions", dest='if_flag', action='store_true',
-                        help="profiling with -finstrument-functions option")
-    parser.add_argument("-d", "--diff", dest='diff', action='store_true',
-                        help="show diff result if not matched")
-    parser.add_argument("-v", "--verbose", dest='debug', action='store_true',
-                        help="show internal command and result for debugging")
-    parser.add_argument("-n", "--no-color", dest='color', action='store_false',
-                        help="suppress color in the output")
-    parser.add_argument("-t", "--timeout", dest='timeout', default=5,
-                        help="fail test if it runs more than TIMEOUT seconds")
-    parser.add_argument("-j", "--worker", dest='worker', type=int, default=multiprocessing.cpu_count(),
-                        help="Parallel worker count; using all core for default")
-    parser.add_argument("-c", "--compiler", dest='compiler', default="gcc",
-                        help="Select compiler gcc or clang. (gcc by default)")
+    parser.add_argument(
+        "-f",
+        "--profile-flags",
+        dest="flags",
+        default="pg finstrument-functions",
+        help="comma separated list of compiler profiling flags",
+    )
+    parser.add_argument(
+        "-O", "--optimize-levels", dest="opts", default="0123s", help="compiler optimization levels"
+    )
+    parser.add_argument(
+        "case", nargs="?", default="all", help="test case: 'all' or test number or (partial) name"
+    )
+    parser.add_argument(
+        "-p", "--profile-pg", dest="pg_flag", action="store_true", help="profiling with -pg option"
+    )
+    parser.add_argument(
+        "-i",
+        "--instrument-functions",
+        dest="if_flag",
+        action="store_true",
+        help="profiling with -finstrument-functions option",
+    )
+    parser.add_argument(
+        "-d", "--diff", dest="diff", action="store_true", help="show diff result if not matched"
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="debug",
+        action="store_true",
+        help="show internal command and result for debugging",
+    )
+    parser.add_argument(
+        "-n", "--no-color", dest="color", action="store_false", help="suppress color in the output"
+    )
+    parser.add_argument(
+        "-t",
+        "--timeout",
+        dest="timeout",
+        default=5,
+        help="fail test if it runs more than TIMEOUT seconds",
+    )
+    parser.add_argument(
+        "-j",
+        "--worker",
+        dest="worker",
+        type=int,
+        default=multiprocessing.cpu_count(),
+        help="Parallel worker count; using all core for default",
+    )
+    parser.add_argument(
+        "-c",
+        "--compiler",
+        dest="compiler",
+        default="gcc",
+        help="Select compiler gcc or clang. (gcc by default)",
+    )
 
     return parser.parse_args()
 
@@ -798,23 +861,23 @@ if __name__ == "__main__":
 
     arg = parse_argument()
 
-    if arg.case == 'all':
-        testcases = glob.glob('t???_*.py')
+    if arg.case == "all":
+        testcases = glob.glob("t???_*.py")
     else:
         try:
-            testcases = glob.glob('t*' + arg.case + '*.py')
+            testcases = glob.glob("t*" + arg.case + "*.py")
             arg.worker = min(arg.worker, len(testcases))
         finally:
             if len(testcases) == 0:
                 print("cannot find testcase for : %s" % arg.case)
                 sys.exit(0)
 
-    opts = ' '.join(sorted(['O' + o for o in arg.opts]))
+    opts = " ".join(sorted(["O" + o for o in arg.opts]))
 
     if arg.pg_flag:
-        flags = ['pg']
+        flags = ["pg"]
     elif arg.if_flag:
-        flags = ['finstrument-functions']
+        flags = ["finstrument-functions"]
     else:
         flags = arg.flags.split()
 
@@ -847,13 +910,12 @@ if __name__ == "__main__":
 
     for tc in sorted(testcases):
         _pool = pool
-        name = tc.split('.')[0]  # remove '.py'
+        name = tc.split(".")[0]  # remove '.py'
         clbk = partial(save_test_result, case=name, shared=shared)
         if check_serial_case(name):
             _pool = serial_pool
 
-        _pool.apply_async(run_single_case, callback=clbk,
-                         args=[name, flags, opts.split(), arg])
+        _pool.apply_async(run_single_case, callback=clbk, args=[name, flags, opts.split(), arg])
 
     print("Start %s tests with %d worker" % (shared.tests_count, arg.worker))
     print_test_header(opts, flags, ftests)
@@ -861,11 +923,11 @@ if __name__ == "__main__":
     color = arg.color
     if not sys.stdout.isatty():
         color = False
-    if 'TERM' in os.environ and os.environ['TERM'] == 'dumb':
+    if "TERM" in os.environ and os.environ["TERM"] == "dumb":
         color = False
 
     for tc in sorted(testcases):
-        name = tc.split('.')[0]  # remove '.py'
+        name = tc.split(".")[0]  # remove '.py'
 
         while name not in shared.results:
             time.sleep(1)

--- a/tests/t001_basic.py
+++ b/tests/t001_basic.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
   62.202 us [28141] | __cxa_atexit();
             [28141] | main() {
@@ -16,4 +20,5 @@ class TestCase(TestBase):
    1.915 us [28141] |     } /* b */
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
-""")
+""",
+        )

--- a/tests/t002_argument.py
+++ b/tests/t002_argument.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'arg', """
+        TestBase.__init__(
+            self,
+            "arg",
+            """
 # DURATION    TID     FUNCTION
             [16325] | main() {
             [16325] |   foo() {
@@ -23,8 +27,9 @@ class TestCase(TestBase):
    0.130 us [16325] |     check();
    0.427 us [16325] |   } /* pass */
   42.161 us [16325] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
         # to avoid unexpected memcpy in aarch64
-        self.option = '-N memcpy '
+        self.option = "-N memcpy "

--- a/tests/t003_thread.py
+++ b/tests/t003_thread.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'thread', ldflags='-pthread', result="""
+        TestBase.__init__(
+            self,
+            "thread",
+            ldflags="-pthread",
+            result="""
 # DURATION    TID     FUNCTION
             [ 1429] | main() {
             [ 1429] |   pthread_create() {
@@ -56,7 +61,8 @@ class TestCase(TestBase):
  121.139 us [ 1433] | } /* foo */
    0.390 us [ 1429] |   } /* pthread_join */
  658.759 us [ 1429] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '--no-merge'
+        self.option = "--no-merge"

--- a/tests/t004_filter_F.py
+++ b/tests/t004_filter_F.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
             [28141] | a() {
             [28141] |   b() {
@@ -13,7 +17,9 @@ class TestCase(TestBase):
    1.430 us [28141] |     } /* c */
    1.915 us [28141] |   } /* b */
    2.405 us [28141] | } /* a */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def setup(self):
-        self.option = '-F a'
+        self.option = "-F a"

--- a/tests/t005_filter_N.py
+++ b/tests/t005_filter_N.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
   62.202 us [28141] | __cxa_atexit();
             [28141] | main() {
@@ -12,7 +16,8 @@ class TestCase(TestBase):
    1.915 us [28141] |     b();
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-N c'
+        self.option = "-N c"

--- a/tests/t006_filter_FN.py
+++ b/tests/t006_filter_FN.py
@@ -2,14 +2,20 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
             [28141] | a() {
    1.915 us [28141] |   b();
    2.405 us [28141] | } /* a */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def setup(self):
-        self.option = '-F a -N c'
+        self.option = "-F a -N c"

--- a/tests/t007_library.py
+++ b/tests/t007_library.py
@@ -2,22 +2,27 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'lib', """
+        TestBase.__init__(
+            self,
+            "lib",
+            """
 # DURATION    TID     FUNCTION
             [17455] | lib_a() {
             [17455] |   lib_b() {
   61.911 us [17455] |     lib_c();
  217.279 us [17455] |   } /* lib_b */
  566.261 us [17455] | } /* lib_a */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         if TestBase.build_libabc(self, cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
-        return TestBase.build_libmain(self, name, 's-libmain.c',
-                                      ['libabc_test_lib.so'])
+        return TestBase.build_libmain(self, name, "s-libmain.c", ["libabc_test_lib.so"])
 
     def setup(self):
-        self.option = '--force --no-libcall'
+        self.option = "--force --no-libcall"

--- a/tests/t008_daemon.py
+++ b/tests/t008_daemon.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'daemon', """
+        TestBase.__init__(
+            self,
+            "daemon",
+            """
 # DURATION    TID     FUNCTION
   71.636 us [28239] | __cxa_atexit();
             [28239] | main() {
@@ -25,4 +29,5 @@ task: 28239
 [1] daemon
 [0] main
 
-""")
+""",
+        )

--- a/tests/t009_fork.py
+++ b/tests/t009_fork.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', """
+        TestBase.__init__(
+            self,
+            "fork",
+            """
 # DURATION    TID     FUNCTION
             [26125] | __cxa_atexit() {
   68.297 us [26125] | } /* __cxa_atexit */
@@ -32,7 +36,8 @@ class TestCase(TestBase):
    6.520 us [26125] |     } /* b */
    7.140 us [26125] |   } /* a */
  420.059 us [26125] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '--no-merge'
+        self.option = "--no-merge"

--- a/tests/t010_forkexec.py
+++ b/tests/t010_forkexec.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'forkexec', """
+        TestBase.__init__(
+            self,
+            "forkexec",
+            """
 # DURATION    TID     FUNCTION
             [ 9874] | main() {
  142.145 us [ 9874] |   fork();
@@ -23,12 +27,13 @@ class TestCase(TestBase):
    2.515 ms [ 9874] |   } /* waitpid */
    2.708 ms [ 9874] | } /* main */
 
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        ret  = TestBase.build(self, 'abc', cflags, ldflags)
+    def build(self, name, cflags="", ldflags=""):
+        ret = TestBase.build(self, "abc", cflags, ldflags)
         ret += TestBase.build(self, self.name, cflags, ldflags)
         return ret
 
     def setup(self):
-        self.option = '-F main'
+        self.option = "-F main"

--- a/tests/t011_vforkexec.py
+++ b/tests/t011_vforkexec.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'vforkexec', """
+        TestBase.__init__(
+            self,
+            "vforkexec",
+            """
 # DURATION    TID     FUNCTION
             [ 3122] | main() {
             [ 3122] |   vfork() {
@@ -23,12 +27,13 @@ class TestCase(TestBase):
    7.511 us [ 3124] | } /* main */
    2.706 ms [ 3122] |   } /* wait */
    3.959 ms [ 3122] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        ret  = TestBase.build(self, 'abc', cflags, ldflags)
+    def build(self, name, cflags="", ldflags=""):
+        ret = TestBase.build(self, "abc", cflags, ldflags)
         ret += TestBase.build(self, self.name, cflags, ldflags)
         return ret
 
     def setup(self):
-        self.option = '-F main'
+        self.option = "-F main"

--- a/tests/t012_demangle.py
+++ b/tests/t012_demangle.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'demangle', lang='C++', result="""
+        TestBase.__init__(
+            self,
+            "demangle",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
             [31433] | ABC::foo() {
             [31433] |   __static_initialization_and_destruction_0() {
@@ -22,7 +27,8 @@ class TestCase(TestBase):
    1.323 us [31433] |   } /* ABC::foo */
    5.623 us [31433] | } /* main */
    9.223 us [31433] | std::ios_base::Init::~Init();
-""")
+""",
+        )
 
     def fixup(self, cflags, result):
-        return result.replace(" std::ios_base::Init::~Init();\n", '')
+        return result.replace(" std::ios_base::Init::~Init();\n", "")

--- a/tests/t013_signal.py
+++ b/tests/t013_signal.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'signal', """
+        TestBase.__init__(
+            self,
+            "signal",
+            """
 # DURATION    TID     FUNCTION
   78.933 us [28901] | __cxa_atexit();
             [28901] | main() {
@@ -17,4 +21,5 @@ class TestCase(TestBase):
   13.464 us [28901] |   } /* raise */
    0.102 us [28901] |   foo();
   17.113 us [28901] | } /* main */
-""")
+""",
+        )

--- a/tests/t014_ucontext.py
+++ b/tests/t014_ucontext.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'ucontext', """
+        TestBase.__init__(
+            self,
+            "ucontext",
+            """
 # DURATION    TID     FUNCTION
   79.593 us [28383] | __cxa_atexit();
             [28383] | main() {
@@ -19,4 +23,5 @@ class TestCase(TestBase):
    9.489 us [28383] |   } /* foo */
    0.130 us [28383] |   baz();
   15.586 us [28383] | } /* main */
-""")
+""",
+        )

--- a/tests/t015_longjmp.py
+++ b/tests/t015_longjmp.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'longjmp', """
+        TestBase.__init__(
+            self,
+            "longjmp",
+            """
 # DURATION    TID     FUNCTION
   63.615 us [29065] | __cxa_atexit();
             [29065] | main() {
@@ -14,4 +18,5 @@ class TestCase(TestBase):
    0.907 us [29065] |   } /* _setjmp */
    0.105 us [29065] |   bar();
   36.125 us [29065] | } /* main */
-""")
+""",
+        )

--- a/tests/t016_alloca.py
+++ b/tests/t016_alloca.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'alloca', """
+        TestBase.__init__(
+            self,
+            "alloca",
+            """
 # DURATION    TID     FUNCTION'
   75.736 us [ 6681] | __cxa_atexit();
             [ 6681] | main() {
@@ -20,4 +24,5 @@ class TestCase(TestBase):
    1.336 us [ 6681] |     } /* foo */
    3.723 us [ 6681] |   } /* bar */
    8.063 us [ 6681] | } /* main */
-""")
+""",
+        )

--- a/tests/t017_no_libcall.py
+++ b/tests/t017_no_libcall.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
             [28141] | main() {
             [28141] |   a() {
@@ -13,7 +17,8 @@ class TestCase(TestBase):
    1.915 us [28141] |     } /* b */
    2.405 us [28141] |   } /* a */
   72.252 us [28141] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '--no-libcall'
+        self.option = "--no-libcall"

--- a/tests/t018_filter_regex.py
+++ b/tests/t018_filter_regex.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'allocfree', """
+        TestBase.__init__(
+            self,
+            "allocfree",
+            """
 # DURATION    TID     FUNCTION
             [11583] | alloc1() {
             [11583] |   alloc2() {
@@ -17,7 +21,9 @@ class TestCase(TestBase):
    4.239 us [11583] |     } /* alloc3 */
    5.016 us [11583] |   } /* alloc2 */
  104.119 us [11583] | } /* alloc1 */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def setup(self):
         self.option = '-F "^alloc.*$"'

--- a/tests/t019_full_depth.py
+++ b/tests/t019_full_depth.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'allocfree', """
+        TestBase.__init__(
+            self,
+            "allocfree",
+            """
 # DURATION    TID     FUNCTION
             [30388] | main() {
             [30388] |   alloc1() {
@@ -14,7 +18,8 @@ class TestCase(TestBase):
    3.621 us [30388] |     free2();
    4.499 us [30388] |   } /* free1 */
  120.407 us [30388] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-D3'
+        self.option = "-D3"

--- a/tests/t020_filter_depth.py
+++ b/tests/t020_filter_depth.py
@@ -2,16 +2,22 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'allocfree', """
+        TestBase.__init__(
+            self,
+            "allocfree",
+            """
 # DURATION    TID     FUNCTION
             [20175] | alloc1() {
             [20175] |   alloc3() {
    5.792 us [20175] |     alloc5();
    7.914 us [20175] |   } /* alloc3 */
  114.958 us [20175] | } /* alloc1 */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def setup(self):
         self.option = '-D1 -F "alloc[135]"'

--- a/tests/t021_filter_plt.py
+++ b/tests/t021_filter_plt.py
@@ -2,15 +2,21 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'getids', """
+        TestBase.__init__(
+            self,
+            "getids",
+            """
 # DURATION    TID     FUNCTION
    1.811 us [18130] | getpid();
    1.776 us [18130] | getsid();
    1.289 us [18130] | getuid();
    1.043 us [18130] | getgid();
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def setup(self):
         self.option = '-F "get.?id@plt"'

--- a/tests/t022_filter_kernel.py
+++ b/tests/t022_filter_kernel.py
@@ -4,9 +4,14 @@ import os
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'getids', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "getids",
+            serial=True,
+            result="""
 # DURATION    TID     FUNCTION
             [20769] | main() {
    0.925 us [20769] |   getpid();
@@ -22,12 +27,13 @@ class TestCase(TestBase):
    0.054 us [20769] |     sys_getegid();
    0.912 us [20769] |   } /* getegid */
   81.933 us [20769] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
             return TestBase.TEST_SKIP
-        if os.path.exists('/.dockerenv'):
+        if os.path.exists("/.dockerenv"):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
@@ -37,9 +43,13 @@ class TestCase(TestBase):
     def fixup(self, cflags, result):
         uname = os.uname()
         # Linux v4.17 (x86_64) changed syscall routines
-        major, minor, release = uname[2].split('.')
-        if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
-            result = result.replace('sys_gete', '__x64_sys_gete')
+        major, minor, release = uname[2].split(".")
+        if (
+            uname[0] == "Linux"
+            and uname[4] == "x86_64"
+            and int(major) >= 5
+            or (int(major) == 4 and int(minor) >= 17)
+        ):
+            result = result.replace("sys_gete", "__x64_sys_gete")
 
         return result

--- a/tests/t023_replay_filter.py
+++ b/tests/t023_replay_filter.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'allocfree', """
+        TestBase.__init__(
+            self,
+            "allocfree",
+            """
 # DURATION    TID     FUNCTION
             [ 4629] | alloc3() {
    4.671 us [ 4629] |   alloc4();
@@ -16,12 +20,14 @@ class TestCase(TestBase):
    1.563 us [ 4629] |     } /* free5 */
    2.323 us [ 4629] |   } /* free2 */
    2.580 us [ 4629] | } /* free1 */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
+        self.subcmd = "replay"
         self.option = '-F alloc3 -D2 -F "free[15]"'

--- a/tests/t024_report_basic.py
+++ b/tests/t024_report_basic.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sort', """
+        TestBase.__init__(
+            self,
+            "sort",
+            """
   Total time   Self time       Calls  Function
   ==========  ==========  ==========  ====================================
     1.152 ms   71.683 us           1  main
@@ -14,11 +18,13 @@ class TestCase(TestBase):
    37.525 us    1.137 us           2  foo
    36.388 us   36.388 us           6  loop
     1.200 us    1.200 us           1  __cxa_atexit   # and this too
-""", sort='report')
+""",
+            sort="report",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
+        self.subcmd = "report"

--- a/tests/t025_report_s_call.py
+++ b/tests/t025_report_s_call.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sort', """
+        TestBase.__init__(
+            self,
+            "sort",
+            """
   Total time   Self time  Nr. called  Function
   ==========  ==========  ==========  ====================================
    36.388 us   36.388 us           6  loop
@@ -14,12 +18,14 @@ class TestCase(TestBase):
    70.176 us   70.176 us           1  __monstartup   # ignore this
     1.080 ms    1.813 us           1  bar
     1.200 us    1.200 us           1  __cxa_atexit   # and this too
-""", sort='report')
+""",
+            sort="report",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '-s call,self'
+        self.subcmd = "report"
+        self.option = "-s call,self"

--- a/tests/t026_filter_trigger.py
+++ b/tests/t026_filter_trigger.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'allocfree', """
+        TestBase.__init__(
+            self,
+            "allocfree",
+            """
 # DURATION    TID     FUNCTION
             [  767] | main() {
             [  767] |   alloc1() {
@@ -24,7 +28,8 @@ class TestCase(TestBase):
    2.857 us [  767] |     } /* free2 */
    3.188 us [  767] |   } /* free1 */
   66.699 us [  767] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
         self.option = '-F "main" -F "alloc3@depth=1"'

--- a/tests/t027_replay_filter_d.py
+++ b/tests/t027_replay_filter_d.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'allocfree', """
+        TestBase.__init__(
+            self,
+            "allocfree",
+            """
 # DURATION    TID     FUNCTION
             [ 4629] | main() {
             [ 4629] |   alloc1() {
@@ -24,12 +28,13 @@ class TestCase(TestBase):
    2.323 us [ 4629] |     } /* free2 */
    2.580 us [ 4629] |   } /* free1 */
   78.021 us [ 4629] | } /* main */
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
+        self.subcmd = "replay"
         self.option = '-F "main" -F "alloc3@depth=1"'

--- a/tests/t028_replay_backtrace.py
+++ b/tests/t028_replay_backtrace.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'allocfree', """
+        TestBase.__init__(
+            self,
+            "allocfree",
+            """
 # DURATION    TID     FUNCTION
   backtrace [ 4629] | /* [ 0] main */
   backtrace [ 4629] | /* [ 1] alloc1 */
@@ -15,12 +19,14 @@ class TestCase(TestBase):
    2.020 us [ 4629] |     malloc();
    4.334 us [ 4629] |   } /* alloc5 */
    4.671 us [ 4629] | } /* alloc4 */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
+        self.subcmd = "replay"
         self.option = '-T "alloc4@filter,backtrace"'

--- a/tests/t029_trigger_only.py
+++ b/tests/t029_trigger_only.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'allocfree', """
+        TestBase.__init__(
+            self,
+            "allocfree",
+            """
 # DURATION    TID     FUNCTION
  101.601 us [31924] | __monstartup();
    2.047 us [31924] | __cxa_atexit();
@@ -32,7 +36,8 @@ class TestCase(TestBase):
    4.588 us [31924] |     } /* free2 */
    5.177 us [31924] |   } /* free1 */
   11.175 us [31924] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
         self.option = '-T "alloc3@depth=1" -T "free@backtrace"'

--- a/tests/t030_replay_trigger.py
+++ b/tests/t030_replay_trigger.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'allocfree', """
+        TestBase.__init__(
+            self,
+            "allocfree",
+            """
 # DURATION    TID     FUNCTION
             [12561] | main() {
             [12561] |   alloc1() {
@@ -16,12 +20,13 @@ class TestCase(TestBase):
    3.905 us [12561] |     free2();
    4.392 us [12561] |   } /* free1 */
   10.380 us [12561] | } /* main */
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
+        self.subcmd = "replay"
         self.option = '-T "alloc1@depth=2" -T "free2@depth=1,backtrace"'

--- a/tests/t031_filter_demangle1.py
+++ b/tests/t031_filter_demangle1.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
             [14470] | ns::ns1::foo::bar() {
             [14470] |   ns::ns1::foo::bar1() {
@@ -16,7 +21,9 @@ class TestCase(TestBase):
    6.858 us [14470] |   } /* ns::ns1::foo::bar1 */
    2.207 us [14470] |   free();
  100.290 us [14470] | } /* ns::ns1::foo::bar */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def setup(self):
         self.option = '-F "ns::ns1::foo::bar"'

--- a/tests/t032_filter_demangle2.py
+++ b/tests/t032_filter_demangle2.py
@@ -2,15 +2,22 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
  128.411 us [30174] | operator new();
    4.580 us [30174] | operator delete();
   10.248 us [30174] | operator new();
    0.317 us [30174] | operator delete();
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def setup(self):
         self.option = '-F "^operator"'

--- a/tests/t033_filter_demangle3.py
+++ b/tests/t033_filter_demangle3.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
             [ 3357] | main() {
    2.874 us [ 3357] |   operator new();
@@ -23,7 +28,8 @@ class TestCase(TestBase):
    2.072 us [ 3357] |   } /* ns::ns2::foo::bar */
    0.311 us [ 3357] |   operator delete();
  105.160 us [ 3357] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
         self.option = '-N ".*ns1::.*"'

--- a/tests/t034_filter_demangle4.py
+++ b/tests/t034_filter_demangle4.py
@@ -2,16 +2,23 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
   61.419 us [ 1817] | ns::ns1::foo::foo();
             [ 1817] | ns::ns1::foo::bar() {
    2.585 us [ 1817] |   ns::ns1::foo::bar1();
    1.303 us [ 1817] |   free();
    4.863 us [ 1817] | } /* ns::ns1::foo::bar */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def setup(self):
         self.option = '-F "ns1::.*" -N "bar2$"'

--- a/tests/t035_filter_demangle5.py
+++ b/tests/t035_filter_demangle5.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
   66.323 us [ 1845] | ns::ns1::foo::foo();
             [ 1845] | ns::ns1::foo::bar() {
@@ -22,7 +27,9 @@ class TestCase(TestBase):
    0.450 us [ 1845] |     malloc();
    0.930 us [ 1845] |   } /* ns::ns2::foo::bar3 */
    1.393 us [ 1845] | } /* ns::ns2::foo::bar2 */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     # test whether filter option preserves the ordering
     def setup(self):

--- a/tests/t036_replay_filter_N.py
+++ b/tests/t036_replay_filter_N.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
             [ 7102] | main() {
    2.697 us [ 7102] |   operator new();
@@ -21,12 +26,13 @@ class TestCase(TestBase):
    1.566 us [ 7102] |   ns::ns2::foo::bar();
    0.168 us [ 7102] |   operator delete();
   78.921 us [ 7102] | } /* main */
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
+        self.subcmd = "replay"
         self.option = '-N "bar3$" -Tns::ns2::foo::bar@depth=1'

--- a/tests/t037_trace_onoff.py
+++ b/tests/t037_trace_onoff.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
             [30192] | main() {
    3.210 us [30192] |   operator new();
@@ -21,8 +26,9 @@ class TestCase(TestBase):
   15.807 us [30192] |   } /* ns::ns2::foo::bar */
    0.316 us [30192] |   operator delete();
  107.604 us [30192] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option  = '-T "ns::ns1::foo::bar2@trace_off" '
+        self.option = '-T "ns::ns1::foo::bar2@trace_off" '
         self.option += '-T "ns::ns2::foo::bar2@trace-on"'

--- a/tests/t038_trace_disable.py
+++ b/tests/t038_trace_disable.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
             [12683] |   ns::ns2::foo::bar() {
             [12683] |     ns::ns2::foo::bar1() {
@@ -18,7 +23,9 @@ class TestCase(TestBase):
  105.025 us [12683] |   } /* ns::ns2::foo::bar */
    0.602 us [12683] |   operator delete();
             [12683] | } /* main */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def setup(self):
         self.option = '--disable -T "ns::ns2::foo::bar@trace_on"'

--- a/tests/t039_trace_onoff_F.py
+++ b/tests/t039_trace_onoff_F.py
@@ -5,7 +5,11 @@ from runtest import TestBase
 # Unlike filters (-F), The trace-on/off trigger preserves the depth.
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
             [27770] |       ns::ns1::foo::bar3() {
    2.725 us [27770] |         malloc();
@@ -14,7 +18,9 @@ class TestCase(TestBase):
             [27770] |   } /* ns::ns1::foo::bar1 */
    1.791 us [27770] |   free();
             [27770] | } /* ns::ns1::foo::bar */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def setup(self):
         self.option = '--disable -F "ns::ns1::foo::bar" -T ".*foo::bar3@trace_on"'

--- a/tests/t040_replay_onoff.py
+++ b/tests/t040_replay_onoff.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
    4.843 us [29826] |   operator new();
    1.846 us [29826] |   ns::ns1::foo::foo();
@@ -18,10 +23,12 @@ class TestCase(TestBase):
             [29826] |     ns::ns2::foo::bar1() {
             [29826] |       ns::ns2::foo::bar2() {
             [29826] |         ns::ns2::foo::bar3() {
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):

--- a/tests/t041_replay_onoff_N.py
+++ b/tests/t041_replay_onoff_N.py
@@ -6,7 +6,11 @@ from runtest import TestBase
 # so 'trace-off' trigger cannot be fired and shows delete() and main exit.
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
    4.843 us [29826] |   operator new();
    1.846 us [29826] |   ns::ns1::foo::foo();
@@ -17,13 +21,15 @@ class TestCase(TestBase):
    0.597 us [29826] |   operator new();
    0.410 us [29826] |   operator delete();
  143.705 us [29826] | } /* main */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd  = 'replay'
-        self.option  = "--disable -N 'ns2.*' -T 'operator new@trace-on' "
+        self.subcmd = "replay"
+        self.option = "--disable -N 'ns2.*' -T 'operator new@trace-on' "
         self.option += "-T 'malloc@traceoff'"

--- a/tests/t042_live_disable.py
+++ b/tests/t042_live_disable.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
   53.511 us [ 6624] | ns::ns1::foo::foo();
             [ 6624] | ns::ns1::foo::bar2() {
@@ -18,7 +23,9 @@ class TestCase(TestBase):
    0.365 us [ 6624] |     malloc();
    0.834 us [ 6624] |   } /* ns::ns2::foo::bar3 */
    1.200 us [ 6624] | } /* ns::ns2::foo::bar2 */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def setup(self):
         self.option = '--disable -F ".*foo::foo" -T .foo::foo@trace_on -F .bar2'

--- a/tests/t043_full_demangle.py
+++ b/tests/t043_full_demangle.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
             [22757] | main() {
    2.554 us [22757] |   operator new(unsigned long);
@@ -23,14 +28,14 @@ class TestCase(TestBase):
    0.283 us [22757] |   operator new(unsigned long);
    0.223 us [22757] |   operator delete(void*);
   76.629 us [22757] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
         self.option = '--demangle=full -N "ns2.*"'
 
     def fixup(self, cflags, result):
         if TestBase.is_32bit(self):
-            return result.replace('unsigned long', 'unsigned int')
+            return result.replace("unsigned long", "unsigned int")
 
-        return result.replace('delete(void*);',
-                              'delete(void*, unsigned long);')
+        return result.replace("delete(void*);", "delete(void*, unsigned long);")

--- a/tests/t044_report_avg_total.py
+++ b/tests/t044_report_avg_total.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sort', """
+        TestBase.__init__(
+            self,
+            "sort",
+            """
    Total avg   Total min   Total max  Function
   ==========  ==========  ==========  ====================
    11.378 ms   11.378 ms   11.378 ms  main
@@ -14,33 +18,34 @@ class TestCase(TestBase):
    39.967 us   39.801 us   40.275 us  loop
     0.701 us    0.701 us    0.701 us  __monstartup   # ignore this
     0.270 us    0.270 us    0.270 us  __cxa_atexit   # and this too
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '--avg-total'
+        self.subcmd = "report"
+        self.option = "--avg-total"
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.strip() == "":
                 continue
             line = ln.split()
-            if line[1] == 'avg':
+            if line[1] == "avg":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]        [1]   [2]        [3]   [4]        [5]   [6]
             # avg_total  unit  min_total  unit  max_total  unit  function
-            if line[6].startswith('__'):
+            if line[6].startswith("__"):
                 continue
             result.append(line[6])
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t045_report_avg_self.py
+++ b/tests/t045_report_avg_self.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sort', """
+        TestBase.__init__(
+            self,
+            "sort",
+            """
     Self avg    Self min    Self max  Function
   ==========  ==========  ==========  ====================
    10.288 ms   10.288 ms   10.288 ms  usleep
@@ -14,33 +18,34 @@ class TestCase(TestBase):
     1.044 us    0.884 us    1.205 us  foo
     0.701 us    0.701 us    0.701 us  __monstartup   # ignore this
     0.270 us    0.270 us    0.270 us  __cxa_atexit   # and this too
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '--avg-self'
+        self.subcmd = "report"
+        self.option = "--avg-self"
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.strip() == "":
                 continue
             line = ln.split()
-            if line[1] == 'avg':
+            if line[1] == "avg":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]       [1]   [2]       [3]   [4]       [5]   [6]
             # avg_self  unit  min_self  unit  max_self  unit  function
-            if line[6].startswith('__'):
+            if line[6].startswith("__"):
                 continue
             result.append(line[6])
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t046_report_task.py
+++ b/tests/t046_report_task.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'thread-name', """
+        TestBase.__init__(
+            self,
+            "thread-name",
+            """
   Total time   Self time   Num funcs     TID  Task name
   ==========  ==========  ==========  ======  ================
   772.936 us  136.238 us           9   2569   t-thread-name
@@ -12,33 +16,35 @@ class TestCase(TestBase):
   174.537 us   83.934 us           3   2573   t-thread-name
   172.378 us   90.137 us           3   2574   t-thread-name
    63.568 us   63.568 us           3   2572   t-thread-name
-""", ldflags='-pthread')
+""",
+            ldflags="-pthread",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '--task'
+        self.subcmd = "report"
+        self.option = "--task"
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Total':
+            if line[0] == "Total":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]         [1]   [2]        [3]   [4]        [5]  [6]
             # total_time  unit  self_time  unit  num_funcs  tid  task_name
-            if line[4].startswith('__'):
+            if line[4].startswith("__"):
                 continue
             result.append(line[6])
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t047_signal2.py
+++ b/tests/t047_signal2.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'signal2', """
+        TestBase.__init__(
+            self,
+            "signal2",
+            """
 # DURATION    TID     FUNCTION
    3.966 us [24050] | __monstartup();
    0.342 us [24050] | __cxa_atexit();
@@ -23,4 +27,5 @@ class TestCase(TestBase):
    3.331 ms [24050] |     } /* bar */
   10.736 ms [24050] |   } /* foo */
   10.738 ms [24050] | } /* main */
-""")
+""",
+        )

--- a/tests/t048_malloc_impl.py
+++ b/tests/t048_malloc_impl.py
@@ -2,15 +2,20 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'malloc', """
+        TestBase.__init__(
+            self,
+            "malloc",
+            """
 # DURATION    TID     FUNCTION
             [16726] | main() {
    0.426 us [16726] |   malloc();
    0.397 us [16726] |   free();
    3.074 us [16726] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-F main'
+        self.option = "-F main"

--- a/tests/t049_column_view.py
+++ b/tests/t049_column_view.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'thread', ldflags='-pthread', result="""
+        TestBase.__init__(
+            self,
+            "thread",
+            ldflags="-pthread",
+            result="""
 # DURATION    TID     FUNCTION
             [15156] | main() {
             [15156] |   pthread_create() {
@@ -56,7 +61,8 @@ class TestCase(TestBase):
    1.796 us [15161] |                                 } /* foo */
    1.358 ms [15156] |   } /* pthread_join */
    1.995 ms [15156] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '--column-view --column-offset=4 --no-merge'
+        self.option = "--column-view --column-offset=4 --no-merge"

--- a/tests/t050_no_pltbind.py
+++ b/tests/t050_no_pltbind.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'racycount', ldflags='-pthread', result="""
+        TestBase.__init__(
+            self,
+            "racycount",
+            ldflags="-pthread",
+            result="""
 # DURATION    TID     FUNCTION
             [22829] | __monstartup() {
   17.753 us [22829] | } /* __monstartup */
@@ -38,7 +43,8 @@ class TestCase(TestBase):
             [22829] |   pthread_join() {
    5.735 us [22829] |   } /* pthread_join */
    1.122 ms [22829] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '--no-pltbind --column-view --no-merge'
+        self.option = "--no-pltbind --column-view --no-merge"

--- a/tests/t051_return.py
+++ b/tests/t051_return.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'return', result="""
+        TestBase.__init__(
+            self,
+            "return",
+            result="""
 # DURATION    TID     FUNCTION
             [12703] | main() {
             [12703] |   return_large() {
@@ -13,8 +17,9 @@ class TestCase(TestBase):
    0.153 us [12703] |   return_small();
    0.157 us [12703] |   return_long_double();
    4.097 us [12703] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
         # to avoid unexpected memcpy in aarch64
-        self.option = '-N memcpy '
+        self.option = "-N memcpy "

--- a/tests/t052_nested_func.py
+++ b/tests/t052_nested_func.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'nested', result="""
+        TestBase.__init__(
+            self,
+            "nested",
+            result="""
 # DURATION    TID     FUNCTION
             [13348] | main() {
             [13348] |   foo() {
@@ -18,34 +22,35 @@ class TestCase(TestBase):
    2.479 us [13348] |     } /* qsort */
    3.462 us [13348] |   } /* bar */
    3.623 us [13348] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if self.supported_lang['C']['cc'] == 'clang':
+    def build(self, name, cflags="", ldflags=""):
+        if self.supported_lang["C"]["cc"] == "clang":
             # clang doesn't allow nested function.
             return TestBase.TEST_SKIP
         return TestBase.build(self, name, cflags, ldflags)
 
     def sort(self, output, ignore_children=False):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         before_main = True
         funcs = []
-        for ln in output.split('\n'):
-            if ln.find(' | main()') > 0:
+        for ln in output.split("\n"):
+            if ln.find(" | main()") > 0:
                 before_main = False
             if before_main:
                 continue
             # ignore result of remaining functions which follows a blank line
-            if ln.strip() == '':
-                break;
+            if ln.strip() == "":
+                break
 
             try:
-                func = ln.split('|', 1)[-1]
+                func = ln.split("|", 1)[-1]
                 # ignore function suffix after '.'
-                funcs.append(func.split('.',1)[0])
+                funcs.append(func.split(".", 1)[0])
             except:
                 pass
 
-        result = '\n'.join(funcs)
+        result = "\n".join(funcs)
         return result

--- a/tests/t053_filter_time.py
+++ b/tests/t053_filter_time.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            result="""
 # DURATION    TID     FUNCTION
             [18219] | main() {
             [18219] |   foo() {
@@ -13,7 +17,8 @@ class TestCase(TestBase):
    2.095 ms [18219] |     } /* bar */
    2.106 ms [18219] |   } /* foo */
    2.107 ms [18219] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-t 1ms'
+        self.option = "-t 1ms"

--- a/tests/t054_filter_time_F.py
+++ b/tests/t054_filter_time_F.py
@@ -2,14 +2,20 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            result="""
 # DURATION    TID     FUNCTION
             [18229] | bar() {
    2.078 ms [18229] |   usleep();
    2.080 ms [18229] | } /* bar */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def setup(self):
-        self.option = '-t 1ms -F bar'
+        self.option = "-t 1ms -F bar"

--- a/tests/t055_filter_time_N.py
+++ b/tests/t055_filter_time_N.py
@@ -2,14 +2,19 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            result="""
 # DURATION    TID     FUNCTION
             [18224] | main() {
    2.083 ms [18224] |   foo();
    2.085 ms [18224] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-t 1ms -N bar'
+        self.option = "-t 1ms -N bar"

--- a/tests/t056_filter_time_T.py
+++ b/tests/t056_filter_time_T.py
@@ -2,14 +2,19 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            result="""
 # DURATION    TID     FUNCTION
             [18260] | main() {
    2.088 ms [18260] |   foo();
    2.090 ms [18260] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
         self.option = '-t 1ms -T "mem_alloc@trace-off" -T "mem_free@trace-on"'

--- a/tests/t057_filter_time_D.py
+++ b/tests/t057_filter_time_D.py
@@ -2,16 +2,21 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            result="""
 # DURATION    TID     FUNCTION
             [18270] | main() {
             [18270] |   foo() {
    2.071 ms [18270] |     bar();
    2.082 ms [18270] |   } /* foo */
    2.083 ms [18270] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-t 1ms -D3'
+        self.option = "-t 1ms -D3"

--- a/tests/t058_arg_int.py
+++ b/tests/t058_arg_int.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'exp-int', result="""
+        TestBase.__init__(
+            self,
+            "exp-int",
+            result="""
 # DURATION    TID     FUNCTION
             [18270] | main() {
    0.371 ms [18270] |   int_add(-1, 2);
@@ -12,11 +16,12 @@ class TestCase(TestBase):
    0.711 ms [18270] |   int_mul(3, 4);
    0.923 ms [18270] |   int_div(4, -2);
    3.281 ms [18270] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)

--- a/tests/t059_arg_str.py
+++ b/tests/t059_arg_str.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'exp-str', result="""
+        TestBase.__init__(
+            self,
+            "exp-str",
+            result="""
 # DURATION    TID     FUNCTION
             [18141] | main() {
    0.271 ms [18141] |   str_cpy("", "hello");
@@ -13,11 +17,12 @@ class TestCase(TestBase):
    0.216 ms [18141] |   str_cpy("hello world", "goodbye");
    0.303 ms [18141] |   str_cat("goodbye", " world");
    3.134 ms [18141] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)

--- a/tests/t060_arg_fmt.py
+++ b/tests/t060_arg_fmt.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'exp-int', result="""
+        TestBase.__init__(
+            self,
+            "exp-int",
+            result="""
 # DURATION    TID     FUNCTION
             [18278] | main() {
    0.371 ms [18278] |   int_add(-1, 2);
@@ -12,11 +16,12 @@ class TestCase(TestBase):
    0.711 ms [18278] |   int_mul();
    0.923 ms [18278] |   int_div(4, 0xfe);
    3.281 ms [18278] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)

--- a/tests/t061_arg_plt.py
+++ b/tests/t061_arg_plt.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'pltarg', result="""
+        TestBase.__init__(
+            self,
+            "pltarg",
+            result="""
 # DURATION    TID     FUNCTION
    1.237 us [ 3479] | __monstartup();
    0.897 us [ 3479] | __cxa_atexit();
@@ -14,12 +18,13 @@ class TestCase(TestBase):
    2.139 us [ 3479] |   malloc(100);
    1.017 us [ 3479] |   free();
   12.233 us [ 3479] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
         self.option = '-A "getenv|atoi@arg1/s" -A malloc@arg1'
-        self.exearg = 't-' + self.name + ' 100'
+        self.exearg = "t-" + self.name + " 100"
 
     def fixup(self, cflags, result):
         # for some reason, ARM eats up atoi()
-        return result.replace('   2.079 us [ 3479] |   atoi("100");\n', '')
+        return result.replace('   2.079 us [ 3479] |   atoi("100");\n', "")

--- a/tests/t062_arg_char.py
+++ b/tests/t062_arg_char.py
@@ -2,23 +2,28 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'exp-char', result="""
+        TestBase.__init__(
+            self,
+            "exp-char",
+            result="""
 # DURATION    TID     FUNCTION
             [18279] | main() {
    0.371 ms [18279] |   foo('f', 'o', 'o');
    0.923 ms [18279] |   bar('\\0', 'B', 97, 0x72);
    3.281 ms [18279] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option  = '-A "foo@arg1/c,arg2/c,arg3/c" '
+        self.option = '-A "foo@arg1/c,arg2/c,arg3/c" '
         self.option += '-A "bar@arg1/c,arg2/c,arg3/i,arg4/x8"'

--- a/tests/t063_retval.py
+++ b/tests/t063_retval.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'exp-int', result="""
+        TestBase.__init__(
+            self,
+            "exp-int",
+            result="""
 # DURATION    TID     FUNCTION
    1.498 us [ 3338] | __monstartup();
    1.079 us [ 3338] | __cxa_atexit();
@@ -14,11 +18,12 @@ class TestCase(TestBase):
    0.446 us [ 3338] |   int_mul(3, 4) = 12;
    0.429 us [ 3338] |   int_div(4, -2) = -2;
    8.568 us [ 3338] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support return value now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
@@ -28,6 +33,6 @@ class TestCase(TestBase):
 
         if TestBase.is_32bit(self):
             # int_mul@arg1 is a 'long long', so we should skip arg2
-            self.option  = '-A "int_(add|sub|div)@arg1,arg2" '
+            self.option = '-A "int_(add|sub|div)@arg1,arg2" '
             self.option += '-A "int_mul@arg1/i64,arg3" '
             self.option += '-R "^int_@retval/i32"'

--- a/tests/t064_trigger_trace.py
+++ b/tests/t064_trigger_trace.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            result="""
 # DURATION    TID     FUNCTION
             [18219] | main() {
             [18219] |   foo() {
@@ -14,7 +18,8 @@ class TestCase(TestBase):
    2.095 ms [18219] |     } /* bar */
    2.106 ms [18219] |   } /* foo */
    2.107 ms [18219] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
         self.option = '-t 1ms -T "mem_alloc@trace"'

--- a/tests/t065_arg_order.py
+++ b/tests/t065_arg_order.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'exp-int', result="""
+        TestBase.__init__(
+            self,
+            "exp-int",
+            result="""
 # DURATION    TID     FUNCTION
             [18279] | main() {
    0.371 ms [18279] |   int_add(-1, 2);
@@ -12,11 +16,12 @@ class TestCase(TestBase):
    0.711 ms [18279] |   int_mul(0x4, 3);
    0.923 ms [18279] |   int_div(4, -2);
    3.281 ms [18279] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support return value now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
@@ -26,5 +31,5 @@ class TestCase(TestBase):
 
         if TestBase.is_32bit(self):
             # int_mul@arg1 is a 'long long', so we should skip arg2
-            self.option  = '-A "int_mul@arg3/x" -A "^int_@arg1" '
+            self.option = '-A "int_mul@arg3/x" -A "^int_@arg1" '
             self.option += '-A "int_(add|sub|div)@arg2" -A "int_mul@arg1/i64" '

--- a/tests/t066_no_demangle.py
+++ b/tests/t066_no_demangle.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
             [17005] | _ZN2ns3ns13foo3barEv() {
             [17005] |   _ZN2ns3ns13foo4bar1Ev() {
@@ -16,7 +21,9 @@ class TestCase(TestBase):
    4.128 us [17005] |   } /* _ZN2ns3ns13foo4bar1Ev */
    1.463 us [17005] |   free();
    6.702 us [17005] | } /* _ZN2ns3ns13foo3barEv */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def setup(self):
         self.option = '--demangle=no -F "_ZN2ns3ns13foo3barEv"'

--- a/tests/t067_report_diff.py
+++ b/tests/t067_report_diff.py
@@ -4,12 +4,16 @@ import subprocess as sp
 
 from runtest import TestBase
 
-XDIR='xxx'
-YDIR='yyy'
+XDIR = "xxx"
+YDIR = "yyy"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 #
 # uftrace diff
 #  [0] base: xxx   (from uftrace record -d xxx tests/t-abc )
@@ -22,42 +26,43 @@ class TestCase(TestBase):
     5.925 us    5.385 us    -9.11%     0.786 us    0.554 us   -29.52%            1          1         +0   b
     5.139 us    4.831 us    -5.99%     3.517 us    3.137 us   -10.80%            1          1         +0   c
     1.622 us    1.694 us    +4.44%     1.622 us    1.694 us    +4.44%            1          1         +0   getpid
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        self.subcmd = 'record'
-        self.option = '-d ' + XDIR
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.option = "-d " + XDIR
+        self.exearg = "t-" + self.name
         record_cmd = self.runcmd()
         sp.call(record_cmd.split())
 
-        self.option = '-d ' + YDIR
+        self.option = "-d " + YDIR
         record_cmd = self.runcmd()
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '--sort-column 0 --diff-policy full,percent'  # old behavior
-        self.exearg = '-d %s --diff %s' % (XDIR, YDIR)
+        self.subcmd = "report"
+        self.option = "--sort-column 0 --diff-policy full,percent"  # old behavior
+        self.exearg = "-d %s --diff %s" % (XDIR, YDIR)
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.startswith('#') or ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.startswith("#") or ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Total':
+            if line[0] == "Total":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]  [1]  [2]  [3]  [4]      [5]  [6]  [7]  [8]  [9]      [10]   [11]   [12]       [13]
             # tT/0 unit tT/1 unit percent  tS/0 unit tS/1 unit percent  call/0 call/1 call/diff  function
-            if line[-1].startswith('__'):
+            if line[-1].startswith("__"):
                 continue
-            result.append('%s %s %s %s' % (line[-4], line[-3], line[-2], line[-1]))
+            result.append("%s %s %s %s" % (line[-4], line[-3], line[-2], line[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t068_filter_time_A.py
+++ b/tests/t068_filter_time_A.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            result="""
 # DURATION    TID     FUNCTION
             [23157] | main() {
             [23157] |   foo() {
@@ -13,8 +17,9 @@ class TestCase(TestBase):
    2.095 ms [23157] |     } /* bar */
    2.106 ms [23157] |   } /* foo */
    2.107 ms [23157] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option  = '-t 1ms -R mem_alloc@retval '
-        self.option += '-A mem_free@arg1 -A usleep@plt,arg1'
+        self.option = "-t 1ms -R mem_alloc@retval "
+        self.option += "-A mem_free@arg1 -A usleep@plt,arg1"

--- a/tests/t069_graph.py
+++ b/tests/t069_graph.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sort', result="""
+        TestBase.__init__(
+            self,
+            "sort",
+            result="""
 # Function Call Graph for 'main' (session: baa921f86e22e0c9)
 =============== BACKTRACE ===============
  backtrace #0: hit 1, time  11.460 ms
@@ -17,13 +21,15 @@ class TestCase(TestBase):
             :  | 
   10.362 ms :  +-(1) bar
   10.091 ms :    (1) usleep
-""", sort='graph')
+""",
+            sort="graph",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.exearg = "t-" + self.name
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'graph'
-        self.exearg = 'main'
+        self.subcmd = "graph"
+        self.exearg = "main"

--- a/tests/t070_graph_backtrace.py
+++ b/tests/t070_graph_backtrace.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', result="""
+        TestBase.__init__(
+            self,
+            "abc",
+            result="""
 # Function Call Graph for 'getpid' (session: adff9f265b25c0d8)
 =============== BACKTRACE ===============
  backtrace #0: hit 1, time   2.010 us
@@ -16,13 +20,15 @@ class TestCase(TestBase):
 
 ========== FUNCTION CALL GRAPH ==========
    2.010 us : (1) getpid
-""", sort='graph')
+""",
+            sort="graph",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.exearg = "t-" + self.name
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'graph'
-        self.exearg = 'getpid'
+        self.subcmd = "graph"
+        self.exearg = "getpid"

--- a/tests/t071_graph_depth.py
+++ b/tests/t071_graph_depth.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # Function Call Graph for 'main' (session: b508f628ffe7287f)
 =============== BACKTRACE ===============
  backtrace #0: hit 1, time  17.931 us
@@ -33,15 +38,17 @@ class TestCase(TestBase):
    0.740 us :     | (1) ns::ns2::foo::bar3
             :     | 
    0.187 us :     +-(1) free
-""", sort='graph')
+""",
+            sort="graph",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
-        self.option = ''
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.option = ""
+        self.exearg = "t-" + self.name
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'graph'
-        self.option = '-D5'
-        self.exearg = 'main'
+        self.subcmd = "graph"
+        self.option = "-D5"
+        self.exearg = "main"

--- a/tests/t072_no_comment.py
+++ b/tests/t072_no_comment.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
    0.508 us [  772] | __monstartup();
    0.425 us [  772] | __cxa_atexit();
@@ -17,7 +21,8 @@ class TestCase(TestBase):
    1.037 us [  772] |     }
    1.188 us [  772] |   }
    1.378 us [  772] | }
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '--no-comment'
+        self.option = "--no-comment"

--- a/tests/t073_lib_filter.py
+++ b/tests/t073_lib_filter.py
@@ -2,20 +2,25 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'lib', """
+        TestBase.__init__(
+            self,
+            "lib",
+            """
 # DURATION    TID     FUNCTION
             [17456] | lib_b() {
    6.911 us [17456] |   lib_c();
    8.279 us [17456] | } /* lib_b */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         if TestBase.build_libabc(self, cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
-        return TestBase.build_libmain(self, name, 's-libmain.c',
-                                      ['libabc_test_lib.so'])
+        return TestBase.build_libmain(self, name, "s-libmain.c", ["libabc_test_lib.so"])
 
     def setup(self):
-        self.option = '--force -F lib_b@libabc_test'
+        self.option = "--force -F lib_b@libabc_test"

--- a/tests/t074_lib_trigger.py
+++ b/tests/t074_lib_trigger.py
@@ -2,20 +2,25 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'lib', """
+        TestBase.__init__(
+            self,
+            "lib",
+            """
 # DURATION    TID     FUNCTION
             [17457] | lib_a() {
    6.911 us [17457] |   lib_b();
    8.279 us [17457] | } /* lib_a */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         if TestBase.build_libabc(self, cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
-        return TestBase.build_libmain(self, name, 's-libmain.c',
-                                      ['libabc_test_lib.so'])
+        return TestBase.build_libmain(self, name, "s-libmain.c", ["libabc_test_lib.so"])
 
     def setup(self):
-        self.option = '--force --no-libcall -T lib_b@libabc_test,depth=1'
+        self.option = "--force --no-libcall -T lib_b@libabc_test,depth=1"

--- a/tests/t075_lib_arg.py
+++ b/tests/t075_lib_arg.py
@@ -2,26 +2,31 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'lib', """
+        TestBase.__init__(
+            self,
+            "lib",
+            """
 # DURATION    TID     FUNCTION
             [17458] | lib_a(4095) {
             [17458] |   lib_b(4096) {
    5.193 us [17458] |     lib_c(4095);
    6.911 us [17458] |   } /* lib_b */
    8.279 us [17458] | } /* lib_a */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         if TestBase.build_libabc(self, cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
-        return TestBase.build_libmain(self, name, 's-libmain.c',
-                                      ['libabc_test_lib.so'])
+        return TestBase.build_libmain(self, name, "s-libmain.c", ["libabc_test_lib.so"])
 
     def setup(self):
-        self.option = '--force --no-libcall -A ^lib@libabc_test,arg1'
+        self.option = "--force --no-libcall -A ^lib@libabc_test,arg1"

--- a/tests/t076_lib_replay_F.py
+++ b/tests/t076_lib_replay_F.py
@@ -2,26 +2,31 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'lib', """
+        TestBase.__init__(
+            self,
+            "lib",
+            """
 # DURATION    TID     FUNCTION
             [17459] | lib_b() {
    6.911 us [17459] |   lib_c();
    8.279 us [17459] | } /* lib_b */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         if TestBase.build_libabc(self, cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
-        return TestBase.build_libmain(self, name, 's-libmain.c',
-                                      ['libabc_test_lib.so'])
+        return TestBase.build_libmain(self, name, "s-libmain.c", ["libabc_test_lib.so"])
 
     def prepare(self):
-        self.subcmd = 'record'
-        self.option = '--force'
+        self.subcmd = "record"
+        self.option = "--force"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-F lib_b@libabc_test'
+        self.subcmd = "replay"
+        self.option = "-F lib_b@libabc_test"

--- a/tests/t077_lib_replay_T.py
+++ b/tests/t077_lib_replay_T.py
@@ -2,26 +2,31 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'lib', """
+        TestBase.__init__(
+            self,
+            "lib",
+            """
 # DURATION    TID     FUNCTION
             [17460] | lib_a() {
    6.911 us [17460] |   lib_b();
    8.279 us [17460] | } /* lib_a */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         if TestBase.build_libabc(self, cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
-        return TestBase.build_libmain(self, name, 's-libmain.c',
-                                      ['libabc_test_lib.so'])
+        return TestBase.build_libmain(self, name, "s-libmain.c", ["libabc_test_lib.so"])
 
     def prepare(self):
-        self.subcmd = 'record'
-        self.option = '--force --no-libcall'
+        self.subcmd = "record"
+        self.option = "--force --no-libcall"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-T lib_a@libabc_test,depth=2'
+        self.subcmd = "replay"
+        self.option = "-T lib_a@libabc_test,depth=2"

--- a/tests/t078_max_stack.py
+++ b/tests/t078_max_stack.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
    1.138 us [28141] | __monstartup();
    2.202 us [28141] | __cxa_atexit();
@@ -13,7 +17,8 @@ class TestCase(TestBase):
    1.915 us [28141] |     b();
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '--max-stack=3'
+        self.option = "--max-stack=3"

--- a/tests/t079_replay_kernel_D.py
+++ b/tests/t079_replay_kernel_D.py
@@ -5,9 +5,14 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "openclose",
+            serial=True,
+            result="""
 # DURATION    TID     FUNCTION
    1.088 us [18343] | __monstartup();
    0.640 us [18343] | __cxa_atexit();
@@ -19,18 +24,19 @@ class TestCase(TestBase):
   10.781 us [18343] |     sys_close();
   37.325 us [18343] |   } /* fclose */
  128.387 us [18343] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
             return TestBase.TEST_SKIP
-        if os.path.exists('/.dockerenv'):
+        if os.path.exists("/.dockerenv"):
             return TestBase.TEST_SKIP
 
-        self.subcmd  = 'record'
-        self.option  = '-K3 '
-        self.option += '-N %s@kernel ' % 'exit_to_usermode_loop'
-        self.option += '-N %s@kernel' % '_*do_page_fault'
+        self.subcmd = "record"
+        self.option = "-K3 "
+        self.option += "-N %s@kernel " % "exit_to_usermode_loop"
+        self.option += "-N %s@kernel" % "_*do_page_fault"
 
         record_cmd = self.runcmd()
         sp.call(record_cmd.split())
@@ -38,16 +44,20 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-k -D3'
+        self.subcmd = "replay"
+        self.option = "-k -D3"
 
     def fixup(self, cflags, result):
         uname = os.uname()
 
         # Linux v4.17 (x86_64) changed syscall routines
-        major, minor, release = uname[2].split('.')
-        if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
-            result = result.replace('sys_', '__x64_sys_')
+        major, minor, release = uname[2].split(".")
+        if (
+            uname[0] == "Linux"
+            and uname[4] == "x86_64"
+            and int(major) >= 5
+            or (int(major) == 4 and int(minor) >= 17)
+        ):
+            result = result.replace("sys_", "__x64_sys_")
 
-        return result.replace(' sys_open', ' sys_openat')
+        return result.replace(" sys_open", " sys_openat")

--- a/tests/t080_replay_kernel_D2.py
+++ b/tests/t080_replay_kernel_D2.py
@@ -5,12 +5,16 @@ import subprocess as sp
 
 from runtest import TestBase
 
-TDIR='xxx'
+TDIR = "xxx"
 
 # there was a problem applying depth filter if it contains kernel functions
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "openclose",
+            serial=True,
+            result="""
 # DURATION    TID     FUNCTION
    1.088 us [18343] | __monstartup();
    0.640 us [18343] | __cxa_atexit();
@@ -18,20 +22,21 @@ class TestCase(TestBase):
   89.018 us [18343] |   fopen();
   37.325 us [18343] |   fclose();
  128.387 us [18343] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
             return TestBase.TEST_SKIP
-        if os.path.exists('/.dockerenv'):
+        if os.path.exists("/.dockerenv"):
             return TestBase.TEST_SKIP
 
-        self.subcmd = 'record'
-        self.option = '-K3 -N %s@kernel' % 'smp_irq_work_interrupt'
+        self.subcmd = "record"
+        self.option = "-K3 -N %s@kernel" % "smp_irq_work_interrupt"
         record_cmd = self.runcmd()
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-k -D2'
+        self.subcmd = "replay"
+        self.option = "-k -D2"

--- a/tests/t081_kernel_depth.py
+++ b/tests/t081_kernel_depth.py
@@ -4,9 +4,14 @@ import os
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "openclose",
+            serial=True,
+            result="""
 # DURATION    TID     FUNCTION
    1.540 us [27711] | __monstartup();
    1.089 us [27711] | __cxa_atexit();
@@ -22,27 +27,32 @@ class TestCase(TestBase):
    1.429 us [27711] |     } /* sys_close */
    8.028 us [27711] |   } /* fclose */
   26.938 us [27711] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
             return TestBase.TEST_SKIP
-        if os.path.exists('/.dockerenv'):
+        if os.path.exists("/.dockerenv"):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.option  = '-k --kernel-depth=2 --match glob '
-        self.option += '-N exit_to_usermode_loop@kernel '
-        self.option += '-N *do_page_fault@kernel'
+        self.option = "-k --kernel-depth=2 --match glob "
+        self.option += "-N exit_to_usermode_loop@kernel "
+        self.option += "-N *do_page_fault@kernel"
 
     def fixup(self, cflags, result):
         uname = os.uname()
 
         # Linux v4.17 (x86_64) changed syscall routines
-        major, minor, release = uname[2].split('.')
-        if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
-            result = result.replace(' sys_', ' __x64_sys_')
+        major, minor, release = uname[2].split(".")
+        if (
+            uname[0] == "Linux"
+            and uname[4] == "x86_64"
+            and int(major) >= 5
+            or (int(major) == 4 and int(minor) >= 17)
+        ):
+            result = result.replace(" sys_", " __x64_sys_")
 
-        return result.replace(' sys_open', ' sys_openat')
+        return result.replace(" sys_open", " sys_openat")

--- a/tests/t082_arg_many.py
+++ b/tests/t082_arg_many.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'arg', """
+        TestBase.__init__(
+            self,
+            "arg",
+            """
 # DURATION    TID     FUNCTION
             [13476] | main() {
             [13476] |   foo() {
@@ -23,16 +27,17 @@ class TestCase(TestBase):
    0.130 us [13476] |     check();
    0.427 us [13476] |   } /* pass */
   18.161 us [13476] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option  = '-A "many@arg1/i32,arg2/i32,arg3/i32,arg4/i32,'
-        self.option += 'arg5/i32,arg6/i32,arg7/i32,arg8/i32,arg9/i32,'
+        self.option = '-A "many@arg1/i32,arg2/i32,arg3/i32,arg4/i32,'
+        self.option += "arg5/i32,arg6/i32,arg7/i32,arg8/i32,arg9/i32,"
         self.option += 'arg10/i32,arg11/i32,arg12/i32,arg13/i32"'

--- a/tests/t083_arg_float.py
+++ b/tests/t083_arg_float.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'exp-float', result="""
+        TestBase.__init__(
+            self,
+            "exp-float",
+            result="""
 # DURATION    TID     FUNCTION
             [18276] | main() {
    0.371 ms [18276] |   float_add(-0.100000, 0.200000) = 0.100000;
@@ -12,24 +16,27 @@ class TestCase(TestBase):
    0.711 ms [18276] |   float_mul(300.000000, 400.000000) = 120000.000000;
    0.923 ms [18276] |   float_div(40000000000.000000, -0.020000) = -2000000000000.000000;
    3.281 ms [18276] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option  = '-A "float_add@fparg1/32,fparg2/32" -R "float_add@retval/f32" '
+        self.option = '-A "float_add@fparg1/32,fparg2/32" -R "float_add@retval/f32" '
         self.option += '-A "float_sub@fparg1/32,fparg2"    -R "float_sub@retval/f32" '
         self.option += '-A "float_mul@fparg1/64,fparg2/32" -R "float_mul@retval/f64" '
         self.option += '-A "float_div@fparg1,fparg2"       -R "float_div@retval/f"'
 
         if TestBase.is_32bit(self):
             # argument count follows the size of type
-            self.option = self.option.replace('float_mul@fparg1/64,fparg2/32',
-                                              'float_mul@fparg1/64,fparg3/32')
-            self.option = self.option.replace('float_div@fparg1,fparg2',
-                                              'float_div@fparg1/64,fparg3/64')
+            self.option = self.option.replace(
+                "float_mul@fparg1/64,fparg2/32", "float_mul@fparg1/64,fparg3/32"
+            )
+            self.option = self.option.replace(
+                "float_div@fparg1,fparg2", "float_div@fparg1/64,fparg3/64"
+            )

--- a/tests/t084_arg_mixed.py
+++ b/tests/t084_arg_mixed.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'exp-mixed', result="""
+        TestBase.__init__(
+            self,
+            "exp-mixed",
+            result="""
 # DURATION    TID     FUNCTION
             [18276] | main() {
    0.371 ms [18276] |   mixed_add(-1, 0.200000) = -0.800000;
@@ -13,17 +17,18 @@ class TestCase(TestBase):
    0.923 ms [18276] |   mixed_div(4, -0.000002) = -2000000.000000;
    1.257 ms [18276] |   mixed_str("argument", 0.000000) = "return";
    4.891 ms [18276] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option  = '-A "mixed_add@arg1/i32,fparg1/32" '
+        self.option = '-A "mixed_add@arg1/i32,fparg1/32" '
         self.option += '-R "mixed_add@retval/f64" '
         self.option += '-A "mixed_sub@arg1/x,arg2" '
         self.option += '-R "mixed_sub@retval" '
@@ -34,10 +39,10 @@ class TestCase(TestBase):
         self.option += '-A "mixed_str@arg1/s,fparg1" '
         self.option += '-R "mixed_str@retval/s"'
 
-        if TestBase.get_elf_machine(self) == 'arm':
-            self.option = self.option.replace('fparg1/80%stack+1', 'fparg1/80')
+        if TestBase.get_elf_machine(self) == "arm":
+            self.option = self.option.replace("fparg1/80%stack+1", "fparg1/80")
         elif TestBase.is_32bit(self):
-            self.option  = '-A "mixed_add@arg1/i32,fparg2/32" '
+            self.option = '-A "mixed_add@arg1/i32,fparg2/32" '
             self.option += '-R "mixed_add@retval/f64" '
             self.option += '-A "mixed_sub@arg1/x,arg2" '
             self.option += '-R "mixed_sub@retval" '

--- a/tests/t085_arg_reg.py
+++ b/tests/t085_arg_reg.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'exp-mixed', result="""
+        TestBase.__init__(
+            self,
+            "exp-mixed",
+            result="""
 # DURATION    TID     FUNCTION
             [18277] | main() {
    0.371 ms [18277] |   mixed_add(-1, 0.200000);
@@ -13,30 +17,31 @@ class TestCase(TestBase):
    0.923 ms [18277] |   mixed_div(4, -0.000002);
    1.257 ms [18277] |   mixed_str("argument", 0.000000);
    4.891 ms [18277] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        if TestBase.get_elf_machine(self) == 'i386':
+        if TestBase.get_elf_machine(self) == "i386":
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option  = '-A "mixed_add@arg1/i32%rdi,fparg1/32%xmm0" '
+        self.option = '-A "mixed_add@arg1/i32%rdi,fparg1/32%xmm0" '
         self.option += '-A "mixed_sub@arg1/x%rdi,arg2%rsi" '
         self.option += '-A "mixed_mul@fparg1%xmm0,arg1/i64" '
         self.option += '-A "mixed_div@arg1/i64,fparg1/80%stack+1" '
         self.option += '-A "mixed_str@arg1/s%rdi,fparg1%xmm0"'
 
-        if TestBase.get_elf_machine(self) == 'arm':
-            self.option = self.option.replace('%rdi', '%r0')
-            self.option = self.option.replace('%rsi', '%r1')
-            self.option = self.option.replace('32%xmm0', '32%s0')
-            self.option = self.option.replace('%xmm0', '%d0')
-            self.option = self.option.replace('fparg1/80%stack+1', 'fparg1/80')
+        if TestBase.get_elf_machine(self) == "arm":
+            self.option = self.option.replace("%rdi", "%r0")
+            self.option = self.option.replace("%rsi", "%r1")
+            self.option = self.option.replace("32%xmm0", "32%s0")
+            self.option = self.option.replace("%xmm0", "%d0")
+            self.option = self.option.replace("fparg1/80%stack+1", "fparg1/80")

--- a/tests/t086_arg_stack.py
+++ b/tests/t086_arg_stack.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'arg', """
+        TestBase.__init__(
+            self,
+            "arg",
+            """
 # DURATION    TID     FUNCTION
             [13476] | main() {
             [13476] |   foo() {
@@ -23,23 +27,24 @@ class TestCase(TestBase):
    0.130 us [13476] |     check();
    0.427 us [13476] |   } /* pass */
   18.161 us [13476] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option  = '-A "many@arg1/i32%stack+1,arg2/i32%stack+2" '
+        self.option = '-A "many@arg1/i32%stack+1,arg2/i32%stack+2" '
         self.option += '-A "many@arg3/i32%stack+3,arg4/i32%stack+4" '
         self.option += '-A "many@arg5/i32%stack5,arg6/i32%stack6,arg7/i32%stack7"'
 
         if TestBase.is_32bit(self):
             # i386 use stack for passing argument. so, change order.
-            self.option  = '-A "many@arg1/i32%stack+7,arg2/i32%stack+8" '
+            self.option = '-A "many@arg1/i32%stack+7,arg2/i32%stack+8" '
             self.option += '-A "many@arg3/i32%stack+9,arg4/i32%stack+10" '
             self.option += '-A "many@arg5/i32%stack11,arg6/i32%stack12,arg7/i32%stack13"'
             # FIXME: arm has to be handled differently

--- a/tests/t087_arg_variadic.py
+++ b/tests/t087_arg_variadic.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'variadic', result="""
+        TestBase.__init__(
+            self,
+            "variadic",
+            result="""
 # DURATION    TID     FUNCTION
    1.334 us [ 9624] | __monstartup();
    0.869 us [ 9624] | __cxa_atexit();
@@ -13,19 +17,20 @@ class TestCase(TestBase):
    8.979 us [ 9624] |     vsnprintf(256, "print %c %s %d %ld %lu %lld %f");
   12.642 us [ 9624] |   } /* variadic */
   13.250 us [ 9624] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option  = '-A "variadic@arg1/s,arg2/c,arg3/s,arg4,arg5,arg6,arg7/i64,fparg1" '
+        self.option = '-A "variadic@arg1/s,arg2/c,arg3/s,arg4,arg5,arg6,arg7/i64,fparg1" '
         self.option += '-A "vsnprintf@arg2,arg3/s" '
 
         if TestBase.is_32bit(self):
-            self.option  = '-A "variadic@arg1/s,arg2/c,arg3/s,arg4,arg5,arg6,arg7/i64,fparg9" '
+            self.option = '-A "variadic@arg1/s,arg2/c,arg3/s,arg4,arg5,arg6,arg7/i64,fparg9" '
             self.option += '-A "vsnprintf@arg2,arg3/s" '

--- a/tests/t088_graph_session.py
+++ b/tests/t088_graph_session.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'forkexec', result="""
+        TestBase.__init__(
+            self,
+            "forkexec",
+            result="""
 # Function Call Graph for 'main' (session: 327202376e209585)
 =============== BACKTRACE ===============
  backtrace #0: hit 1, time   5.824 us
@@ -27,44 +31,48 @@ class TestCase(TestBase):
  127.172 us :  +-(1) fork
             :  | 
    3.527 ms :  +-(1) waitpid
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        ret  = TestBase.build(self, 'abc', cflags, ldflags)
+    def build(self, name, cflags="", ldflags=""):
+        ret = TestBase.build(self, "abc", cflags, ldflags)
         ret += TestBase.build(self, self.name, cflags, ldflags)
         return ret
 
     def prepare(self):
-        self.subcmd = 'record'
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.exearg = "t-" + self.name
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'graph'
-        self.exearg = 'main'
+        self.subcmd = "graph"
+        self.exearg = "main"
 
     def fixup(self, cflags, result):
-        return result.replace("readlink", """memset
+        return result.replace(
+            "readlink",
+            """memset
             :  | 
-   9.814 us :  +-(1) readlink""")
+   9.814 us :  +-(1) readlink""",
+        )
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared.
-            It ignores blank and comment (#) lines and header lines.  """
+        """This function post-processes output of the test to be compared.
+        It ignores blank and comment (#) lines and header lines."""
         result = []
         mode = 0
-        for ln in output.split('\n'):
-            if ln.strip() == '' or ln.startswith('#'):
+        for ln in output.split("\n"):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            if ln.startswith('=============== BACKTRACE ==============='):
+            if ln.startswith("=============== BACKTRACE ==============="):
                 mode = 1  # it seems to be broken in this case
                 continue
-            if ln.startswith('========== FUNCTION CALL GRAPH =========='):
+            if ln.startswith("========== FUNCTION CALL GRAPH =========="):
                 mode = 2
                 continue
             if mode == 1:
-                pass      # compare function graph part only
+                pass  # compare function graph part only
             if mode == 2:
-                result.append(ln.split(':')[1])      # remove time part
+                result.append(ln.split(":")[1])  # remove time part
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t089_graph_exit.py
+++ b/tests/t089_graph_exit.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'exit', result="""
+        TestBase.__init__(
+            self,
+            "exit",
+            result="""
 # Function Call Graph for 'main' (session: 095c3a95937bdbae)
 =============== BACKTRACE ===============
  backtrace #0: hit 1, time   0.527 us
@@ -14,12 +18,14 @@ class TestCase(TestBase):
    0.527 us : (1) main
    0.387 us : (1) foo
             : (1) exit
-""", sort='graph')
+""",
+            sort="graph",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'graph'
-        self.exearg = 'main'
+        self.subcmd = "graph"
+        self.exearg = "main"

--- a/tests/t090_report_recursive.py
+++ b/tests/t090_report_recursive.py
@@ -7,7 +7,10 @@ from runtest import TestBase
 # So just use 'same' symbol to indicate it handles recursive calls properly.
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fibonacci', """
+        TestBase.__init__(
+            self,
+            "fibonacci",
+            """
   Total time   Self time       Calls  Function
   ==========  ==========  ==========  ====================================
    25.024 us    2.718 us           1  main
@@ -15,33 +18,34 @@ class TestCase(TestBase):
     2.853 us    2.853 us           1  __monstartup
     2.706 us    2.706 us           1  atoi
     2.194 us    2.194 us           1  __cxa_atexit
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
+        self.subcmd = "report"
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared.
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared.
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
-            if line[5] != 'fib':
+            if line[5] != "fib":
                 continue
             # A report line consists of following data
             # [0]         [1]   [2]        [3]   [4]    [5]
             # total_time  unit  self_time  unit  calls  function
             if line[0] == line[2]:
-                result.append('same same')
+                result.append("same same")
             else:
-                result.append('%s %s' % (line[0], line[2]))
+                result.append("%s %s" % (line[0], line[2]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t091_replay_tid.py
+++ b/tests/t091_replay_tid.py
@@ -4,9 +4,13 @@ import os.path
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', """
+        TestBase.__init__(
+            self,
+            "fork",
+            """
 # DURATION    TID     FUNCTION
             [ 1661] | main() {
  130.930 us [ 1661] |   fork();
@@ -19,24 +23,25 @@ class TestCase(TestBase):
    6.094 us [ 1661] |     } /* b */
    6.602 us [ 1661] |   } /* a */
  849.948 us [ 1661] | } /* main */
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
         t = 0
-        for ln in open(os.path.join('uftrace.data', 'task.txt')):
-            if not ln.startswith('TASK'):
+        for ln in open(os.path.join("uftrace.data", "task.txt")):
+            if not ln.startswith("TASK"):
                 continue
             try:
-                t = int(ln.split()[2].split('=')[1])
+                t = int(ln.split()[2].split("=")[1])
             except:
                 pass
         if t == 0:
-            self.subcmd = 'FAILED TO FIND TID'
+            self.subcmd = "FAILED TO FIND TID"
             return
 
-        self.subcmd = 'replay'
-        self.option = '-F main --tid %d' % t
+        self.subcmd = "replay"
+        self.option = "-F main --tid %d" % t

--- a/tests/t092_report_tid.py
+++ b/tests/t092_report_tid.py
@@ -4,9 +4,13 @@ import os.path
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', """
+        TestBase.__init__(
+            self,
+            "fork",
+            """
   Total time   Self time       Calls  Function
   ==========  ==========  ==========  ====================================
   849.948 us   20.543 us           1  main
@@ -18,24 +22,26 @@ class TestCase(TestBase):
     4.234 us    4.234 us           1  getpid
     1.568 us    1.568 us           1  __monstartup
     1.140 us    1.140 us           1  __cxa_atexit
-""", sort='report')
+""",
+            sort="report",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
         t = 0
-        for ln in open(os.path.join('uftrace.data', 'task.txt')):
-            if not ln.startswith('TASK'):
+        for ln in open(os.path.join("uftrace.data", "task.txt")):
+            if not ln.startswith("TASK"):
                 continue
             try:
-                t = int(ln.split()[2].split('=')[1])
+                t = int(ln.split()[2].split("=")[1])
             except:
                 pass
         if t == 0:
-            self.subcmd = 'FAILED TO FIND TID'
+            self.subcmd = "FAILED TO FIND TID"
             return
 
-        self.subcmd = 'report'
-        self.option = '--tid %d' % t
+        self.subcmd = "report"
+        self.option = "--tid %d" % t

--- a/tests/t093_report_filter.py
+++ b/tests/t093_report_filter.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', """
+        TestBase.__init__(
+            self,
+            "fork",
+            """
   Total time   Self time       Calls  Function
   ==========  ==========  ==========  ====================================
   849.948 us   20.543 us           2  main
@@ -12,12 +16,14 @@ class TestCase(TestBase):
   130.930 us  130.930 us           2  fork
     6.602 us    0.508 us           1  a
     6.094 us    0.414 us           1  b
-""", sort='report')
+""",
+            sort="report",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '-F main -N c'
+        self.subcmd = "report"
+        self.option = "-F main -N c"

--- a/tests/t094_report_depth.py
+++ b/tests/t094_report_depth.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', """
+        TestBase.__init__(
+            self,
+            "fork",
+            """
   Total time   Self time       Calls  Function
   ==========  ==========  ==========  ====================================
   849.948 us   20.543 us           2  main
@@ -15,12 +19,14 @@ class TestCase(TestBase):
     3.626 us    1.612 us           1  c
     1.568 us    1.568 us           1  __monstartup
     1.140 us    1.140 us           1  __cxa_atexit
-""", sort='report')
+""",
+            sort="report",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '-D 3'
+        self.subcmd = "report"
+        self.option = "-D 3"

--- a/tests/t095_graph_tid.py
+++ b/tests/t095_graph_tid.py
@@ -4,9 +4,13 @@ import os.path
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', result="""
+        TestBase.__init__(
+            self,
+            "fork",
+            result="""
 # Function Call Graph for 'a' (session: 5eec64959f2b2e87)
 =============== BACKTRACE ===============
  backtrace #0: hit 1, time   4.290 us
@@ -18,25 +22,27 @@ class TestCase(TestBase):
    3.970 us : (1) b
    3.580 us : (1) c
    2.616 us : (1) getpid
-""", sort='graph')
+""",
+            sort="graph",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
         t = 0
-        for ln in open(os.path.join('uftrace.data', 'task.txt')):
-            if not ln.startswith('TASK'):
+        for ln in open(os.path.join("uftrace.data", "task.txt")):
+            if not ln.startswith("TASK"):
                 continue
             try:
-                t = int(ln.split()[2].split('=')[1])
+                t = int(ln.split()[2].split("=")[1])
             except:
                 pass
         if t == 0:
-            self.subcmd = 'FAILED TO FIND TID'
+            self.subcmd = "FAILED TO FIND TID"
             return
 
-        self.subcmd = 'graph'
-        self.option = '--tid %d' % t
-        self.exearg = 'a'
+        self.subcmd = "graph"
+        self.option = "--tid %d" % t
+        self.exearg = "a"

--- a/tests/t096_graph_filter.py
+++ b/tests/t096_graph_filter.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', result="""
+        TestBase.__init__(
+            self,
+            "fork",
+            result="""
 # Function Call Graph for 'a' (session: 93175b4bdd9d0ddf)
 =============== BACKTRACE ===============
  backtrace #0: hit 1, time   4.217 us
@@ -14,13 +18,15 @@ class TestCase(TestBase):
 ========== FUNCTION CALL GRAPH ==========
    4.217 us : (1) a
    3.876 us : (1) b
-""", sort='graph')
+""",
+            sort="graph",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'graph'
-        self.option = '-F main -N c'
-        self.exearg = 'a'
+        self.subcmd = "graph"
+        self.option = "-F main -N c"
+        self.exearg = "a"

--- a/tests/t097_dump_basic.py
+++ b/tests/t097_dump_basic.py
@@ -4,9 +4,13 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 uftrace file header: magic         = 4674726163652100
 uftrace file header: version       = 4
 uftrace file header: header size   = 40
@@ -30,19 +34,21 @@ reading 5231.dat
 58348.873448707   5231: [exit ] b(4006a0) depth: 2
 58348.873448996   5231: [exit ] a(4006b2) depth: 1
 58348.873449309   5231: [exit ] main(400512) depth: 0
-""", sort='dump')
+""",
+            sort="dump",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'dump'
+        self.subcmd = "dump"
 
     def fixup(self, cflags, result):
         if TestBase.is_32bit(self):
             result = result.replace("2 (64 bit)", "1 (32 bit)")
-        p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
-        if 'BuildID' not in p.communicate()[0].decode(errors='ignore'):
+        p = sp.Popen(["file", "t-" + self.name], stdout=sp.PIPE)
+        if "BuildID" not in p.communicate()[0].decode(errors="ignore"):
             result = result.replace("0xbff", "0xbfd")
         return result

--- a/tests/t098_dump_tid.py
+++ b/tests/t098_dump_tid.py
@@ -5,9 +5,13 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', """
+        TestBase.__init__(
+            self,
+            "fork",
+            """
 uftrace file header: magic         = 4674726163652100
 uftrace file header: version       = 4
 uftrace file header: header size   = 40
@@ -32,32 +36,34 @@ reading 5186.dat
 58071.918048760   5186: [exit ] a(400774) depth: 1
 58071.918049117   5186: [exit ] main(400590) depth: 0
 reading 5188.dat
-""", sort='dump')
+""",
+            sort="dump",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
         t = 0
-        for ln in open(os.path.join('uftrace.data', 'task.txt')):
-            if not ln.startswith('TASK'):
+        for ln in open(os.path.join("uftrace.data", "task.txt")):
+            if not ln.startswith("TASK"):
                 continue
             try:
-                t = int(ln.split()[2].split('=')[1])
+                t = int(ln.split()[2].split("=")[1])
             except:
                 pass
         if t == 0:
-            self.subcmd = 'FAILED TO FIND TID'
+            self.subcmd = "FAILED TO FIND TID"
             return
 
-        self.subcmd = 'dump'
-        self.option = '--tid %d' % t
+        self.subcmd = "dump"
+        self.option = "--tid %d" % t
 
     def fixup(self, cflags, result):
         if TestBase.is_32bit(self):
             result = result.replace("2 (64 bit)", "1 (32 bit)")
-        p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
-        if 'BuildID' not in p.communicate()[0].decode(errors='ignore'):
+        p = sp.Popen(["file", "t-" + self.name], stdout=sp.PIPE)
+        if "BuildID" not in p.communicate()[0].decode(errors="ignore"):
             result = result.replace("0xbff", "0xbfd")
         return result

--- a/tests/t099_dump_filter.py
+++ b/tests/t099_dump_filter.py
@@ -4,9 +4,13 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 uftrace file header: magic         = 4674726163652100
 uftrace file header: version       = 4
 uftrace file header: header size   = 40
@@ -22,20 +26,22 @@ reading 5231.dat
 58348.873448707   5231: [exit ] b(4006a0) depth: 2
 58348.873448996   5231: [exit ] a(4006b2) depth: 1
 58348.873449309   5231: [exit ] main(400512) depth: 0
-""", sort='dump')
+""",
+            sort="dump",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'dump'
-        self.option = '-F main -N c'
+        self.subcmd = "dump"
+        self.option = "-F main -N c"
 
     def fixup(self, cflags, result):
         if TestBase.is_32bit(self):
             result = result.replace("2 (64 bit)", "1 (32 bit)")
-        p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
-        if 'BuildID' not in p.communicate()[0].decode(errors='ignore'):
+        p = sp.Popen(["file", "t-" + self.name], stdout=sp.PIPE)
+        if "BuildID" not in p.communicate()[0].decode(errors="ignore"):
             result = result.replace("0xbff", "0xbfd")
         return result

--- a/tests/t100_dump_depth.py
+++ b/tests/t100_dump_depth.py
@@ -4,9 +4,13 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 uftrace file header: magic         = 4674726163652100
 uftrace file header: version       = 4
 uftrace file header: header size   = 40
@@ -22,20 +26,22 @@ reading 5231.dat
 58348.873448707   5231: [exit ] b(4006a0) depth: 2
 58348.873448996   5231: [exit ] a(4006b2) depth: 1
 58348.873449309   5231: [exit ] main(400512) depth: 0
-""", sort='dump')
+""",
+            sort="dump",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'dump'
-        self.option = '-F main -D 3'
+        self.subcmd = "dump"
+        self.option = "-F main -D 3"
 
     def fixup(self, cflags, result):
         if TestBase.is_32bit(self):
             result = result.replace("2 (64 bit)", "1 (32 bit)")
-        p = sp.Popen(['file', 't-' + self.name], stdout=sp.PIPE)
-        if 'BuildID' not in p.communicate()[0].decode(errors='ignore'):
+        p = sp.Popen(["file", "t-" + self.name], stdout=sp.PIPE)
+        if "BuildID" not in p.communicate()[0].decode(errors="ignore"):
             result = result.replace("0xbff", "0xbfd")
         return result

--- a/tests/t101_dump_chrome.py
+++ b/tests/t101_dump_chrome.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 {"traceEvents":[
 {"ts":0,"ph":"M","pid":5231,"name":"process_name","args":{"name":"[5231] t-abc"}},
 {"ts":0,"ph":"M","pid":5231,"name":"thread_name","args":{"name":"[5231] t-abc"}},
@@ -20,12 +24,14 @@ class TestCase(TestBase):
 "command_line":"uftrace record -d abc.data t-abc ",
 "recorded_time":"Sat Oct  1 18:19:06 2016"
 } }
-""", sort='chrome')
+""",
+            sort="chrome",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'dump'
-        self.option = '-F main -D 4 --chrome'
+        self.subcmd = "dump"
+        self.option = "-F main -D 4 --chrome"

--- a/tests/t102_dump_flamegraph.py
+++ b/tests/t102_dump_flamegraph.py
@@ -2,29 +2,34 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 main 1
 main;a 1
 main;a;b 1
 main;a;b;c 1
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'dump'
-        self.option = '-F main -D 4 --flame-graph'
+        self.subcmd = "dump"
+        self.option = "-F main -D 4 --flame-graph"
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.strip() == "":
                 continue
             result.append(ln)
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t103_dump_kernel.py
+++ b/tests/t103_dump_kernel.py
@@ -5,9 +5,14 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'getids', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "getids",
+            serial=True,
+            result="""
 {"traceEvents":[
 {"ts":14510734170,"ph":"M","pid":32687,"name":"process_name","args":{'name': 't-getids'}},
 {"ts":14510734170,"ph":"M","pid":32687,"name":"thread_name","args":{'name': 't-getids'}},
@@ -47,41 +52,49 @@ class TestCase(TestBase):
 "command_line":"uftrace record -k -d xxx t-getids ",
 "recorded_time":"Sun Oct  2 20:52:31 2016"
 } }
-""", sort='chrome')
+""",
+            sort="chrome",
+        )
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
             return TestBase.TEST_SKIP
-        if os.path.exists('/.dockerenv'):
+        if os.path.exists("/.dockerenv"):
             return TestBase.TEST_SKIP
 
-        self.subcmd = 'record'
-        self.option = '-k'
+        self.subcmd = "record"
+        self.option = "-k"
         record_cmd = self.runcmd()
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'dump'
-        self.option = '-k --chrome'
+        self.subcmd = "dump"
+        self.option = "-k --chrome"
 
     def fixup(self, cflags, result):
-        result = result.replace("""\
+        result = result.replace(
+            """\
 {"ts":14510734172,"ph":"B","pid":32687,"name":"getpid"},
 {"ts":14510734173,"ph":"E","pid":32687,"name":"getpid"},\
 """,
-"""\
+            """\
 {"ts":14510734172,"ph":"B","pid":32687,"name":"getpid"},
 {"ts":14510734172,"ph":"B","pid":32687,"name":"sys_getpid"},
 {"ts":14510734172,"ph":"E","pid":32687,"name":"sys_getpid"},
 {"ts":14510734173,"ph":"E","pid":32687,"name":"getpid"},\
-""")
+""",
+        )
         uname = os.uname()
 
         # Linux v4.17 (x86_64) changed syscall routines
-        major, minor, release = uname[2].split('.')
-        if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
-            result = result.replace('sys_get', '__x64_sys_get')
+        major, minor, release = uname[2].split(".")
+        if (
+            uname[0] == "Linux"
+            and uname[4] == "x86_64"
+            and int(major) >= 5
+            or (int(major) == 4 and int(minor) >= 17)
+        ):
+            result = result.replace("sys_get", "__x64_sys_get")
 
         return result

--- a/tests/t104_graph_kernel.py
+++ b/tests/t104_graph_kernel.py
@@ -5,9 +5,14 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'getids', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "getids",
+            serial=True,
+            result="""
 # Function Call Graph for 'main' (session: 59268c360e3c1bd6)
 =============== BACKTRACE ===============
  backtrace #0: hit 1, time  24.837 us
@@ -37,38 +42,46 @@ class TestCase(TestBase):
             :  | 
    4.223 us :  +-(1) getegid
    1.710 us :    (1) sys_getegid
-""", sort='graph')
+""",
+            sort="graph",
+        )
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
             return TestBase.TEST_SKIP
-        if os.path.exists('/.dockerenv'):
+        if os.path.exists("/.dockerenv"):
             return TestBase.TEST_SKIP
 
-        self.subcmd = 'record'
-        self.option = '-k'
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.option = "-k"
+        self.exearg = "t-" + self.name
 
         record_cmd = self.runcmd()
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'graph'
-        self.option = '-k'
-        self.exearg = 'main'
+        self.subcmd = "graph"
+        self.option = "-k"
+        self.exearg = "main"
 
     def fixup(self, cflags, result):
         uname = os.uname()
 
-        result = result.replace("(1) getpid",
-"""(1) getpid
-   0.738 us :  | (1) sys_getpid""")
+        result = result.replace(
+            "(1) getpid",
+            """(1) getpid
+   0.738 us :  | (1) sys_getpid""",
+        )
 
         # Linux v4.17 (x86_64) changed syscall routines
-        major, minor, release = uname[2].split('.')
-        if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
-            result = result.replace('sys_get', '__x64_sys_get')
+        major, minor, release = uname[2].split(".")
+        if (
+            uname[0] == "Linux"
+            and uname[4] == "x86_64"
+            and int(major) >= 5
+            or (int(major) == 4 and int(minor) >= 17)
+        ):
+            result = result.replace("sys_get", "__x64_sys_get")
 
         return result

--- a/tests/t105_replay_time.py
+++ b/tests/t105_replay_time.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            result="""
 # DURATION    TID     FUNCTION
             [32537] | main() {
             [32537] |   foo() {
@@ -13,12 +17,13 @@ class TestCase(TestBase):
    2.084 ms [32537] |     } /* bar */
    2.102 ms [32537] |   } /* foo */
    2.103 ms [32537] | } /* main */
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-t 1ms'
+        self.subcmd = "replay"
+        self.option = "-t 1ms"

--- a/tests/t106_report_time.py
+++ b/tests/t106_report_time.py
@@ -2,21 +2,27 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', """
+        TestBase.__init__(
+            self,
+            "sleep",
+            """
   Total time   Self time       Calls  Function
   ==========  ==========  ==========  ====================================
     2.103 ms    0.910 us           1  main
     2.102 ms   18.787 us           1  foo
     2.084 ms    4.107 us           1  bar
     2.080 ms    2.080 ms           1  usleep
-""", sort='report')
+""",
+            sort="report",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '-t 1ms'
+        self.subcmd = "report"
+        self.option = "-t 1ms"

--- a/tests/t107_dump_time.py
+++ b/tests/t107_dump_time.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', """
+        TestBase.__init__(
+            self,
+            "sleep",
+            """
 {"traceEvents":[
 {"ts":0,"ph":"M","pid":32537,"name":"process_name","args":{"name":"[32537] t-sleep"}},
 {"ts":0,"ph":"M","pid":32537,"name":"thread_name","args":{"name":"[32537] t-sleep"}},
@@ -20,12 +24,14 @@ class TestCase(TestBase):
 "command_line":"uftrace record -d xxx t-sleep ",
 "recorded_time":"Mon Oct  3 22:45:57 2016"
 } }
-""", sort='chrome')
+""",
+            sort="chrome",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'dump'
-        self.option = '-t 1ms --chrome'
+        self.subcmd = "dump"
+        self.option = "-t 1ms --chrome"

--- a/tests/t108_graph_time.py
+++ b/tests/t108_graph_time.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            result="""
 # Function Call Graph for 'main' (session: b78e9c27042adaa7)
 =============== BACKTRACE ===============
  backtrace #0: hit 1, time   2.109 ms
@@ -15,13 +19,15 @@ class TestCase(TestBase):
    2.109 ms : (1) foo
    2.098 ms : (1) bar
    2.096 ms : (1) usleep
-""", sort='graph')
+""",
+            sort="graph",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'graph'
-        self.option = '-t 1ms'
-        self.exearg = 'main'
+        self.subcmd = "graph"
+        self.option = "-t 1ms"
+        self.exearg = "main"

--- a/tests/t109_replay_time_A.py
+++ b/tests/t109_replay_time_A.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            result="""
 # DURATION    TID     FUNCTION
             [32537] | main(1) {
             [32537] |   foo() {
@@ -13,20 +17,22 @@ class TestCase(TestBase):
    2.084 ms [32537] |     } /* bar */
    2.102 ms [32537] |   } /* foo */
    2.103 ms [32537] | } /* main */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if cflags.find('-finstrument-functions') >= 0:
+    def build(self, name, cflags="", ldflags=""):
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
         return TestBase.build(self, name, cflags, ldflags)
 
     def prepare(self):
-        self.subcmd  = "record"
-        self.option  = "-A main@arg1 "
+        self.subcmd = "record"
+        self.option = "-A main@arg1 "
         self.option += "-A (malloc|free|usleep)@plt,arg1 "
         self.option += "-R malloc@retval"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-t 1ms'
+        self.subcmd = "replay"
+        self.option = "-t 1ms"

--- a/tests/t110_replay_time_T.py
+++ b/tests/t110_replay_time_T.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            result="""
 # DURATION    TID     FUNCTION
             [13256] | main() {
             [13256] |   foo() {
@@ -16,12 +20,13 @@ class TestCase(TestBase):
    2.075 ms [13256] |     } /* bar */
    2.084 ms [13256] |   } /* foo */
    2.085 ms [13256] | } /* main */
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-t 1ms -T malloc@trace'
+        self.subcmd = "replay"
+        self.option = "-t 1ms -T malloc@trace"

--- a/tests/t111_kernel_tid.py
+++ b/tests/t111_kernel_tid.py
@@ -5,9 +5,14 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "fork",
+            serial=True,
+            result="""
 # DURATION    TID     FUNCTION
             [ 1661] | main() {
             [ 1661] |   fork() {
@@ -25,17 +30,18 @@ class TestCase(TestBase):
    6.094 us [ 1661] |     } /* b */
    6.602 us [ 1661] |   } /* a */
  849.948 us [ 1661] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
             return TestBase.TEST_SKIP
-        if os.path.exists('/.dockerenv'):
+        if os.path.exists("/.dockerenv"):
             return TestBase.TEST_SKIP
 
-        self.subcmd  = 'record'
-        self.option  = '-k --match glob '
-        self.option += '-N *page_fault@kernel'
+        self.subcmd = "record"
+        self.option = "-k --match glob "
+        self.option += "-N *page_fault@kernel"
 
         record_cmd = self.runcmd()
         sp.call(record_cmd.split())
@@ -43,38 +49,46 @@ class TestCase(TestBase):
 
     def setup(self):
         t = 0
-        for ln in open(os.path.join('uftrace.data', 'task.txt')):
-            if not ln.startswith('TASK'):
+        for ln in open(os.path.join("uftrace.data", "task.txt")):
+            if not ln.startswith("TASK"):
                 continue
             try:
-                t = int(ln.split()[2].split('=')[1])
+                t = int(ln.split()[2].split("=")[1])
             except:
                 pass
         if t == 0:
-            self.subcmd = 'FAILED TO FIND TID'
+            self.subcmd = "FAILED TO FIND TID"
             return
 
-        self.subcmd = 'replay'
-        self.option = '-k --tid %d' % t
+        self.subcmd = "replay"
+        self.option = "-k --tid %d" % t
 
     def fixup(self, cflags, result):
-        result = result.replace("            [ 1661] |   fork() {",
-"""\
+        result = result.replace(
+            "            [ 1661] |   fork() {",
+            """\
             [ 1661] |   fork() {
-   5.135 us [ 1661] |     sys_getpid();""")
+   5.135 us [ 1661] |     sys_getpid();""",
+        )
 
-        result = result.replace("   4.234 us [ 1661] |         getpid();",
-"""\
+        result = result.replace(
+            "   4.234 us [ 1661] |         getpid();",
+            """\
             [ 1661] |         getpid() {
    3.328 us [ 1661] |           sys_getpid();
-   4.234 us [ 1661] |         } /* getpid */""")
+   4.234 us [ 1661] |         } /* getpid */""",
+        )
 
         uname = os.uname()
 
         # Linux v4.17 (x86_64) changed syscall routines
-        major, minor, release = uname[2].split('.')
-        if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
-            result = result.replace('sys_', '__x64_sys_')
+        major, minor, release = uname[2].split(".")
+        if (
+            uname[0] == "Linux"
+            and uname[4] == "x86_64"
+            and int(major) >= 5
+            or (int(major) == 4 and int(minor) >= 17)
+        ):
+            result = result.replace("sys_", "__x64_sys_")
 
         return result

--- a/tests/t112_replay_skip.py
+++ b/tests/t112_replay_skip.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'thread', ldflags='-pthread', result="""
+        TestBase.__init__(
+            self,
+            "thread",
+            ldflags="-pthread",
+            result="""
 # DURATION    TID     FUNCTION
             [20053] | main() {
   81.953 us [20053] |   pthread_create();
@@ -16,12 +21,13 @@ class TestCase(TestBase):
    0.702 us [20053] |   pthread_join();
    0.650 us [20053] |   pthread_join();
    1.309 ms [20053] | } /* main */
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-F main'
+        self.subcmd = "replay"
+        self.option = "-F main"

--- a/tests/t113_trigger_time.py
+++ b/tests/t113_trigger_time.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            result="""
 # DURATION    TID     FUNCTION
             [16873] | main() {
             [16873] |   foo() {
@@ -16,7 +20,8 @@ class TestCase(TestBase):
    2.071 ms [16873] |     } /* bar */
    2.085 ms [16873] |   } /* foo */
    2.086 ms [16873] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-t 1ms -T mem_alloc@time=0'
+        self.option = "-t 1ms -T mem_alloc@time=0"

--- a/tests/t114_replay_trg_time.py
+++ b/tests/t114_replay_trg_time.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            result="""
 # DURATION    TID     FUNCTION
             [16873] | main() {
             [16873] |   foo() {
@@ -16,12 +20,13 @@ class TestCase(TestBase):
    2.071 ms [16873] |     } /* bar */
    2.085 ms [16873] |   } /* foo */
    2.086 ms [16873] | } /* main */
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-t 1ms -T mem_alloc@time=0'
+        self.subcmd = "replay"
+        self.option = "-t 1ms -T mem_alloc@time=0"

--- a/tests/t115_replay_field.py
+++ b/tests/t115_replay_field.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 #     TIMESTAMP      DURATION    TID     FUNCTION
     75691.369083031            [28337] | main() {
     75691.369083271            [28337] |   a() {
@@ -15,12 +19,13 @@ class TestCase(TestBase):
     75691.369085578   2.167 us [28337] |     } /* b */
     75691.369085788   2.517 us [28337] |   } /* a */
     75691.369085968   2.937 us [28337] | } /* main */
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-F main -f time,duration,tid'
+        self.subcmd = "replay"
+        self.option = "-F main -f time,duration,tid"

--- a/tests/t116_field_none.py
+++ b/tests/t116_field_none.py
@@ -2,10 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc',
-"""main() {
+        TestBase.__init__(
+            self,
+            "abc",
+            """main() {
   a() {
     b() {
       c() {
@@ -14,10 +17,11 @@ class TestCase(TestBase):
     } /* b */
   } /* a */
 } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-F main -f none'
+        self.option = "-F main -f none"
 
     def sort(self, output, ignore_children=False):
         return output

--- a/tests/t117_time_range.py
+++ b/tests/t117_time_range.py
@@ -4,11 +4,15 @@ import subprocess as sp
 
 from runtest import TestBase
 
-START=0
+START = 0
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 #     TIMESTAMP       FUNCTION
     74469.340765344 |       c() {
     74469.340765524 |         getpid();
@@ -16,27 +20,29 @@ class TestCase(TestBase):
     74469.340767195 |     } /* b */
     74469.340767372 |   } /* a */
     74469.340767541 | } /* main */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def prerun(self, timeout):
         global START
 
-        self.subcmd = 'record'
+        self.subcmd = "record"
         record_cmd = self.runcmd()
         sp.call(record_cmd.split())
 
         # find timestamp of function 'c'
-        self.subcmd = 'replay'
-        self.option = '-f time -F main'
+        self.subcmd = "replay"
+        self.option = "-f time -F main"
         replay_cmd = self.runcmd()
 
         p = sp.Popen(replay_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
-        r = p.communicate()[0].decode(errors='ignore')
-        START = r.split('\n')[4].split()[0] # skip header, main, a and b (= 4)
+        r = p.communicate()[0].decode(errors="ignore")
+        START = r.split("\n")[4].split()[0]  # skip header, main, a and b (= 4)
         p.wait()
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-f time -r %s~' % START
+        self.subcmd = "replay"
+        self.option = "-f time -r %s~" % START

--- a/tests/t118_thread_tsd.py
+++ b/tests/t118_thread_tsd.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'thread-tsd', ldflags='-pthread', result="""
+        TestBase.__init__(
+            self,
+            "thread-tsd",
+            ldflags="-pthread",
+            result="""
 # DURATION    TID     FUNCTION
    1.368 us [ 3336] | __monstartup();
    1.142 us [ 3336] | __cxa_atexit();
@@ -23,9 +28,13 @@ class TestCase(TestBase):
    0.549 us [ 3336] |   tsd_dtor();
    0.861 us [ 3336] |   pthread_key_delete();
  199.848 us [ 3336] | } /* main */
-""")
+""",
+        )
 
     def fixup(self, cflags, result):
-        return result.replace('tsd_dtor();', """tsd_dtor() {
+        return result.replace(
+            "tsd_dtor();",
+            """tsd_dtor() {
    0.347 us [ 3336] |     free();
-   0.549 us [ 3336] |   } /* tsd_dtor */""")
+   0.549 us [ 3336] |   } /* tsd_dtor */""",
+        )

--- a/tests/t119_malloc_hook.py
+++ b/tests/t119_malloc_hook.py
@@ -2,15 +2,21 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'malloc-hook', ldflags='-ldl', result="""
+        TestBase.__init__(
+            self,
+            "malloc-hook",
+            ldflags="-ldl",
+            result="""
 # DURATION    TID     FUNCTION
             [ 4408] | main() {
    0.470 us [ 4408] |   malloc();
    0.390 us [ 4408] |   free();
    1.512 us [ 4408] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-F main'
+        self.option = "-F main"

--- a/tests/t120_malloc_tsd.py
+++ b/tests/t120_malloc_tsd.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'malloc-tsd', ldflags='-pthread -ldl', result="""
+        TestBase.__init__(
+            self,
+            "malloc-tsd",
+            ldflags="-pthread -ldl",
+            result="""
 # DURATION    TID     FUNCTION
             [ 5078] | main() {
    2.139 us [ 5078] |   pthread_key_create();
@@ -23,7 +28,8 @@ class TestCase(TestBase):
    1.246 us [ 5078] |   } /* tsd_dtor */
    1.314 us [ 5078] |   pthread_key_delete();
  280.194 us [ 5078] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-F main -F thread'
+        self.option = "-F main -F thread"

--- a/tests/t121_malloc_fork.py
+++ b/tests/t121_malloc_fork.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'malloc-fork', ldflags='-ldl', result="""
+        TestBase.__init__(
+            self,
+            "malloc-fork",
+            ldflags="-ldl",
+            result="""
 # DURATION    TID     FUNCTION
             [22300] | __cxa_atexit() {
    1.328 us [22300] | } /* __cxa_atexit */
@@ -24,7 +29,8 @@ class TestCase(TestBase):
             [22304] |   free() {
    0.081 us [22304] |   } /* free */
             [22304] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '--no-merge'
+        self.option = "--no-merge"

--- a/tests/t122_time_range2.py
+++ b/tests/t122_time_range2.py
@@ -4,11 +4,15 @@ import subprocess as sp
 
 from runtest import TestBase
 
-START=0
+START = 0
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 #  ELAPSED    FUNCTION
    4.343 us |       c() {
    4.447 us |         getpid();
@@ -16,30 +20,32 @@ class TestCase(TestBase):
    5.436 us |     } /* b */
    5.544 us |   } /* a */
    5.626 us | } /* main */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def prerun(self, timeout):
         global START
 
-        self.subcmd = 'record'
+        self.subcmd = "record"
         record_cmd = self.runcmd()
         self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
         # find timestamp of function 'c'
-        self.subcmd = 'replay'
-        self.option = '-f elapsed -F main'
+        self.subcmd = "replay"
+        self.option = "-f elapsed -F main"
         replay_cmd = self.runcmd()
         self.pr_debug("prerun command: " + replay_cmd)
 
         p = sp.Popen(replay_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
-        r = p.communicate()[0].decode(errors='ignore')
-        START, unit = r.split('\n')[4].split()[0:2] # skip header, main, a and b (= 4)
+        r = p.communicate()[0].decode(errors="ignore")
+        START, unit = r.split("\n")[4].split()[0:2]  # skip header, main, a and b (= 4)
         START += unit
         p.wait()
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-f elapsed -r %s~' % START
+        self.subcmd = "replay"
+        self.option = "-f elapsed -r %s~" % START

--- a/tests/t123_backtrace.py
+++ b/tests/t123_backtrace.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'backtrace', lang='C++', result="""
+        TestBase.__init__(
+            self,
+            "backtrace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
    2.277 us [11616] | __cxa_atexit();
             [11616] | main() {
@@ -18,4 +23,5 @@ class TestCase(TestBase):
   53.031 us [11616] |     } /* b */
   53.317 us [11616] |   } /* a */
   53.703 us [11616] | } /* main */
-""")
+""",
+        )

--- a/tests/t124_exception.py
+++ b/tests/t124_exception.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'exception', lang='C++', result="""
+        TestBase.__init__(
+            self,
+            "exception",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
    2.777 us [10827] | __cxa_atexit();
             [10827] | _GLOBAL__sub_I__Z3foov() {
@@ -23,14 +28,21 @@ class TestCase(TestBase):
   84.652 us [10827] |   } /* test */
    0.090 us [10827] |   bar();
   85.590 us [10827] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-N personality_v.'
+        self.option = "-N personality_v."
 
     def fixup(self, cflags, result):
-        r = result.replace("} /* oops */", """} /* oops */
-   0.088 us [10827] |     std::exception::~exception();""")
-        r = r.replace("} /* main */", """} /* main */
- 108.818 us [10827] | std::ios_base::Init::~Init();""")
+        r = result.replace(
+            "} /* oops */",
+            """} /* oops */
+   0.088 us [10827] |     std::exception::~exception();""",
+        )
+        r = r.replace(
+            "} /* main */",
+            """} /* main */
+ 108.818 us [10827] | std::ios_base::Init::~Init();""",
+        )
         return r

--- a/tests/t125_report_range.py
+++ b/tests/t125_report_range.py
@@ -4,11 +4,15 @@ import subprocess as sp
 
 from runtest import TestBase
 
-START=0
+START = 0
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
   Total time   Self time       Calls  Function
   ==========  ==========  ==========  ====================================
     2.160 us    0.172 us           1  main
@@ -16,29 +20,31 @@ class TestCase(TestBase):
     1.862 us    0.375 us           1  b
     1.487 us    0.747 us           1  c
     0.740 us    0.740 us           1  getpid
-""", sort='report')
+""",
+            sort="report",
+        )
 
     def prerun(self, timeout):
         global START
 
-        self.subcmd = 'record'
+        self.subcmd = "record"
         record_cmd = self.runcmd()
         self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
         # find timestamp of function 'c'
-        self.subcmd = 'replay'
-        self.option = '-f time -F main'
+        self.subcmd = "replay"
+        self.option = "-f time -F main"
         replay_cmd = self.runcmd()
         self.pr_debug("prerun command: " + replay_cmd)
 
         p = sp.Popen(replay_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
-        r = p.communicate()[0].decode(errors='ignore')
-        START = r.split('\n')[6].split()[0] # skip header, main, a, b, c and getpid (= 6)
+        r = p.communicate()[0].decode(errors="ignore")
+        START = r.split("\n")[6].split()[0]  # skip header, main, a, b, c and getpid (= 6)
         p.wait()
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '-F main -r ~%s' % START
+        self.subcmd = "report"
+        self.option = "-F main -r ~%s" % START

--- a/tests/t126_arg_regex.py
+++ b/tests/t126_arg_regex.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'allocfree', """
+        TestBase.__init__(
+            self,
+            "allocfree",
+            """
 # DURATION    TID     FUNCTION
    2.417 us [32130] | __monstartup();
    1.535 us [32130] | __cxa_atexit();
@@ -32,11 +36,12 @@ class TestCase(TestBase):
    4.641 us [32130] |     } /* free2 */
    5.271 us [32130] |   } /* free1 */
   21.319 us [32130] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)

--- a/tests/t127_arg_module.py
+++ b/tests/t127_arg_module.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'allocfree', """
+        TestBase.__init__(
+            self,
+            "allocfree",
+            """
 # DURATION    TID     FUNCTION
    2.417 us [32130] | __monstartup();
    1.535 us [32130] | __cxa_atexit();
@@ -32,11 +36,12 @@ class TestCase(TestBase):
    4.641 us [32130] |     } /* free2 */
    5.271 us [32130] |   } /* free1 */
   21.319 us [32130] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)

--- a/tests/t128_arg_module2.py
+++ b/tests/t128_arg_module2.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'allocfree', """
+        TestBase.__init__(
+            self,
+            "allocfree",
+            """
 # DURATION    TID     FUNCTION
    3.937 us [  447] | __monstartup();
    1.909 us [  447] | __cxa_atexit();
@@ -32,11 +36,12 @@ class TestCase(TestBase):
    5.713 us [  447] |     } /* free2 */
    6.341 us [  447] |   } /* free1 */
   21.174 us [  447] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)

--- a/tests/t129_session_tid.py
+++ b/tests/t129_session_tid.py
@@ -6,9 +6,13 @@ from runtest import TestBase
 
 # Test that task.txt files with a tid in the SESS line still work
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
   62.202 us [28141] | __cxa_atexit();
             [28141] | main() {
@@ -20,14 +24,15 @@ class TestCase(TestBase):
    1.915 us [28141] |     } /* b */
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        ret  = TestBase.build(self, 'abc', cflags, ldflags)
+    def build(self, name, cflags="", ldflags=""):
+        ret = TestBase.build(self, "abc", cflags, ldflags)
         return ret
 
     def prerun(self, timeout):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         record_cmd = self.runcmd()
         self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
@@ -39,4 +44,4 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'replay'
+        self.subcmd = "replay"

--- a/tests/t130_thread_exec.py
+++ b/tests/t130_thread_exec.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'thread-exec', """
+        TestBase.__init__(
+            self,
+            "thread-exec",
+            """
 # DURATION    TID     FUNCTION
             [23290] | main() {
   29.452 us [23290] |   pthread_create();
@@ -24,12 +28,13 @@ uftrace stopped tracing with remaining functions
 ================================================
 task: 23290
 [0] main
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        ret  = TestBase.build(self, 'abc', cflags, ldflags)
-        ret += TestBase.build(self, self.name, cflags, ldflags + ' -pthread')
+    def build(self, name, cflags="", ldflags=""):
+        ret = TestBase.build(self, "abc", cflags, ldflags)
+        ret += TestBase.build(self, self.name, cflags, ldflags + " -pthread")
         return ret
 
     def setup(self):
-        self.option = '-N ^__'
+        self.option = "-N ^__"

--- a/tests/t131_lib_dlopen.py
+++ b/tests/t131_lib_dlopen.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'dlopen', """1
+        TestBase.__init__(
+            self,
+            "dlopen",
+            """1
 # DURATION    TID     FUNCTION
    1.404 us [22207] | __cxa_atexit();
             [22207] | main() {
@@ -23,12 +27,12 @@ class TestCase(TestBase):
   19.869 us [22207] |   } /* foo */
   13.391 us [22207] |   dlclose();
  274.723 us [22207] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         if TestBase.build_libabc(self, cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
-        if TestBase.build_libfoo(self, 'foo', cflags, ldflags) != 0:
+        if TestBase.build_libfoo(self, "foo", cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
-        return TestBase.build_libmain(self, name, 's-dlopen.c', ['libdl.so'],
-                                      cflags, ldflags)
+        return TestBase.build_libmain(self, name, "s-dlopen.c", ["libdl.so"], cflags, ldflags)

--- a/tests/t132_trigger_kernel.py
+++ b/tests/t132_trigger_kernel.py
@@ -7,7 +7,11 @@ from runtest import TestBase
 # there was a problem applying depth filter if it contains kernel functions
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "openclose",
+            serial=True,
+            result="""
 # DURATION    TID     FUNCTION
    0.714 us [ 4435] | __monstartup();
    0.349 us [ 4435] | __cxa_atexit();
@@ -19,30 +23,35 @@ class TestCase(TestBase):
    8.389 us [ 4435] |     sys_close();
    9.949 us [ 4435] |   } /* fclose */
   17.632 us [ 4435] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
             return TestBase.TEST_SKIP
-        if os.path.exists('/.dockerenv'):
+        if os.path.exists("/.dockerenv"):
             return TestBase.TEST_SKIP
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.option  = '-K3 '
-        self.option += '-T ^sys_@kernel,depth=1 '
-        self.option += '-T ^__x64_@kernel,depth=1 '
-        self.option += '-N exit_to_usermode_loop@kernel '
-        self.option += '-N _*do_page_fault@kernel'
+        self.option = "-K3 "
+        self.option += "-T ^sys_@kernel,depth=1 "
+        self.option += "-T ^__x64_@kernel,depth=1 "
+        self.option += "-N exit_to_usermode_loop@kernel "
+        self.option += "-N _*do_page_fault@kernel"
 
     def fixup(self, cflags, result):
         uname = os.uname()
 
         # Linux v4.17 (x86_64) changed syscall routines
-        major, minor, release = uname[2].split('.')
-        if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
-            result = result.replace('sys_', '__x64_sys_')
+        major, minor, release = uname[2].split(".")
+        if (
+            uname[0] == "Linux"
+            and uname[4] == "x86_64"
+            and int(major) >= 5
+            or (int(major) == 4 and int(minor) >= 17)
+        ):
+            result = result.replace("sys_", "__x64_sys_")
 
-        return result.replace(' sys_open', ' sys_openat')
+        return result.replace(" sys_open", " sys_openat")

--- a/tests/t133_long_string.py
+++ b/tests/t133_long_string.py
@@ -2,23 +2,28 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'hello', """
+        TestBase.__init__(
+            self,
+            "hello",
+            """
 # DURATION    TID     FUNCTION
   62.202 us [28141] | __cxa_atexit();
             [28141] | main() {
    2.405 us [28141] |   printf("Hello %s\\n", "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234...");
    3.005 us [28141] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option  = '-A printf@arg1/s,arg2/s'
-        self.exearg += ' ' + "0123456789" * 10
+        self.option = "-A printf@arg1/s,arg2/s"
+        self.exearg += " " + "0123456789" * 10

--- a/tests/t134_pic_pie.py
+++ b/tests/t134_pic_pie.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
   62.202 us [28141] | __cxa_atexit();
             [28141] | main() {
@@ -16,10 +20,11 @@ class TestCase(TestBase):
    1.915 us [28141] |     } /* b */
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags = '', ldflags = ''):
-        if cflags.find('-pg') < 0:
-            return TestBase.build(self, name, cflags + ' -fPIC', ldflags + ' -pie')
+    def build(self, name, cflags="", ldflags=""):
+        if cflags.find("-pg") < 0:
+            return TestBase.build(self, name, cflags + " -fPIC", ldflags + " -pie")
         else:
-            return TestBase.build(self, name, cflags + ' -fno-PIC', ldflags + ' -no-pie')
+            return TestBase.build(self, name, cflags + " -fno-PIC", ldflags + " -no-pie")

--- a/tests/t135_trigger_time2.py
+++ b/tests/t135_trigger_time2.py
@@ -4,13 +4,17 @@ import subprocess as sp
 
 from runtest import TestBase
 
-TDIR='xxx'
-TIME=0
-UNIT=''
+TDIR = "xxx"
+TIME = 0
+UNIT = ""
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', """
+        TestBase.__init__(
+            self,
+            "sleep",
+            """
 # DURATION    TID     FUNCTION
             [27437] | main() {
             [27437] |   foo() {
@@ -23,31 +27,33 @@ class TestCase(TestBase):
    3.806 us [27437] |     } /* mem_free */
    2.191 ms [27437] |   } /* foo */
    2.192 ms [27437] | } /* main */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def prerun(self, timeout):
         global TIME, UNIT
 
-        self.subcmd = 'record'
-        self.option = '-F main'
+        self.subcmd = "record"
+        self.option = "-F main"
         record_cmd = self.runcmd()
         self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
         # find timestamp of function 'malloc'
-        self.subcmd = 'replay'
-        self.option = '-F malloc'
+        self.subcmd = "replay"
+        self.option = "-F malloc"
         replay_cmd = self.runcmd()
         self.pr_debug("prerun command: " + replay_cmd)
 
         p = sp.Popen(replay_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
-        r = p.communicate()[0].decode(errors='ignore')
-        TIME, UNIT = r.split('\n')[1].split()[0:2] # skip header
-        TIME = float(TIME) + 0.001 # for time filtering
+        r = p.communicate()[0].decode(errors="ignore")
+        TIME, UNIT = r.split("\n")[1].split()[0:2]  # skip header
+        TIME = float(TIME) + 0.001  # for time filtering
         p.wait()
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-T main@time=%.3f%s' % (TIME, UNIT)
+        self.subcmd = "replay"
+        self.option = "-T main@time=%.3f%s" % (TIME, UNIT)

--- a/tests/t136_dynamic.py
+++ b/tests/t136_dynamic.py
@@ -2,25 +2,30 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
   62.202 us [28141] | __cxa_atexit();
             [28141] | main() {
    2.405 us [28141] |   a();
    3.005 us [28141] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         if not TestBase.check_arch_mfentry_mnop_mcount_support(self):
             return TestBase.TEST_SKIP
-        if cflags.find('-finstrument-functions') >= 0:
-             return TestBase.TEST_SKIP
-        if self.supported_lang['C']['cc'] == 'clang':
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
-        cflags += ' -mfentry -mnop-mcount'
-        cflags += ' -fno-pie -fno-plt'  # workaround of build failure
+        if self.supported_lang["C"]["cc"] == "clang":
+            return TestBase.TEST_SKIP
+        cflags += " -mfentry -mnop-mcount"
+        cflags += " -fno-pie -fno-plt"  # workaround of build failure
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):

--- a/tests/t137_kernel_tid_update.py
+++ b/tests/t137_kernel_tid_update.py
@@ -4,9 +4,14 @@ import os
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork2', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "fork2",
+            serial=True,
+            result="""
 # DURATION    TID     FUNCTION
             [19227] | main() {
  328.451 us [19227] |   fork();
@@ -27,30 +32,35 @@ class TestCase(TestBase):
    2.950 us [19227] |     sys_close();
    9.520 us [19227] |   } /* close */
   41.010 ms [19227] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
             return TestBase.TEST_SKIP
-        if os.path.exists('/.dockerenv'):
+        if os.path.exists("/.dockerenv"):
             return TestBase.TEST_SKIP
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.option  = '-k -F main '
-        self.option += '-F sys_open*@kernel '
-        self.option += '-F sys_close*@kernel'
+        self.option = "-k -F main "
+        self.option += "-F sys_open*@kernel "
+        self.option += "-F sys_close*@kernel"
 
     def fixup(self, cflags, result):
         uname = os.uname()
 
-        result = result.replace(' sys_open', ' sys_openat')
+        result = result.replace(" sys_open", " sys_openat")
 
         # Linux v4.17 (x86_64) changed syscall routines
-        major, minor, release = uname[2].split('.')
-        if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
-            result = result.replace('sys_', '__x64_sys_')
+        major, minor, release = uname[2].split(".")
+        if (
+            uname[0] == "Linux"
+            and uname[4] == "x86_64"
+            and int(major) >= 5
+            or (int(major) == 4 and int(minor) >= 17)
+        ):
+            result = result.replace("sys_", "__x64_sys_")
 
         return result

--- a/tests/t138_kernel_dynamic.py
+++ b/tests/t138_kernel_dynamic.py
@@ -4,9 +4,14 @@ import os
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "openclose",
+            serial=True,
+            result="""
 # DURATION    TID     FUNCTION
             [ 9875] | main() {
             [ 9875] |   fopen() {
@@ -16,30 +21,35 @@ class TestCase(TestBase):
    3.380 us [ 9875] |     sys_close();
    9.720 us [ 9875] |   } /* fclose */
   37.051 us [ 9875] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
             return TestBase.TEST_SKIP
-        if os.path.exists('/.dockerenv'):
+        if os.path.exists("/.dockerenv"):
             return TestBase.TEST_SKIP
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.option  = '-k -F main '
-        self.option += '-P sys_open*@kernel '
-        self.option += '-P sys_close*@kernel'
+        self.option = "-k -F main "
+        self.option += "-P sys_open*@kernel "
+        self.option += "-P sys_close*@kernel"
 
     def fixup(self, cflags, result):
         uname = os.uname()
 
-        result = result.replace(' sys_open', ' sys_openat')
+        result = result.replace(" sys_open", " sys_openat")
 
         # Linux v4.17 (x86_64) changed syscall routines
-        major, minor, release = uname[2].split('.')
-        if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
-            result = result.replace('sys_', '__x64_sys_')
+        major, minor, release = uname[2].split(".")
+        if (
+            uname[0] == "Linux"
+            and uname[4] == "x86_64"
+            and int(major) >= 5
+            or (int(major) == 4 and int(minor) >= 17)
+        ):
+            result = result.replace("sys_", "__x64_sys_")
 
         return result

--- a/tests/t139_kernel_dynamic2.py
+++ b/tests/t139_kernel_dynamic2.py
@@ -4,9 +4,14 @@ import os
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "openclose",
+            serial=True,
+            result="""
 # DURATION    TID     FUNCTION
             [ 9875] | main() {
             [ 9875] |   fopen() {
@@ -14,12 +19,13 @@ class TestCase(TestBase):
   19.099 us [ 9875] |   } /* fopen */
    9.720 us [ 9875] |   fclose();
   37.051 us [ 9875] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
             return TestBase.TEST_SKIP
-        if os.path.exists('/.dockerenv'):
+        if os.path.exists("/.dockerenv"):
             return TestBase.TEST_SKIP
 
         return TestBase.TEST_SUCCESS
@@ -32,9 +38,13 @@ class TestCase(TestBase):
         uname = os.uname()
 
         # Linux v4.17 (x86_64) changed syscall routines
-        major, minor, release = uname[2].split('.')
-        if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
-            return result.replace(' sys_open', ' __x64_sys_openat')
+        major, minor, release = uname[2].split(".")
+        if (
+            uname[0] == "Linux"
+            and uname[4] == "x86_64"
+            and int(major) >= 5
+            or (int(major) == 4 and int(minor) >= 17)
+        ):
+            return result.replace(" sys_open", " __x64_sys_openat")
         else:
-            return result.replace(' sys_open', ' sys_openat')
+            return result.replace(" sys_open", " sys_openat")

--- a/tests/t140_dynamic_xray.py
+++ b/tests/t140_dynamic_xray.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
   62.202 us [28141] | __cxa_atexit();
             [28141] | main() {
@@ -12,18 +16,21 @@ class TestCase(TestBase):
    0.753 us [28141] |     getpid();
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        if TestBase.get_elf_machine(self) == 'arm':
+        if TestBase.get_elf_machine(self) == "arm":
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
-    def build(self, name, cflags='', ldflags=''):
-        old_cc = TestBase.supported_lang['C']['cc']
-        TestBase.supported_lang['C']['cc'] = 'clang'
-        r = TestBase.build(self, name, '-fxray-instrument -fxray-instruction-threshold=1', '-lstdc++')
-        TestBase.supported_lang['C']['cc'] = old_cc
+    def build(self, name, cflags="", ldflags=""):
+        old_cc = TestBase.supported_lang["C"]["cc"]
+        TestBase.supported_lang["C"]["cc"] = "clang"
+        r = TestBase.build(
+            self, name, "-fxray-instrument -fxray-instruction-threshold=1", "-lstdc++"
+        )
+        TestBase.supported_lang["C"]["cc"] = old_cc
         return r
 
     def setup(self):

--- a/tests/t141_recv_basic.py
+++ b/tests/t141_recv_basic.py
@@ -5,11 +5,15 @@ import subprocess as sp
 
 from runtest import TestBase
 
-TDIR  = 'xxx'
+TDIR = "xxx"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
   62.202 us [28141] | __cxa_atexit();
             [28141] | main() {
@@ -21,30 +25,31 @@ class TestCase(TestBase):
    1.915 us [28141] |     } /* b */
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         self.gen_port()
 
-        self.subcmd = 'recv'
-        self.option = '-d %s --port %s' % (TDIR, self.port)
-        self.exearg = ''
+        self.subcmd = "recv"
+        self.option = "-d %s --port %s" % (TDIR, self.port)
+        self.exearg = ""
         recv_cmd = self.runcmd()
         self.pr_debug("prerun command: " + recv_cmd)
         self.recv_p = sp.Popen(recv_cmd.split())
 
-        self.subcmd = 'record'
-        self.option = '--host %s --port %s' % ('localhost', self.port)
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.option = "--host %s --port %s" % ("localhost", self.port)
+        self.exearg = "t-" + self.name
         record_cmd = self.runcmd()
         self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-d ' + os.path.join(TDIR, 'uftrace.data')
-        self.exearg = ''
+        self.subcmd = "replay"
+        self.option = "-d " + os.path.join(TDIR, "uftrace.data")
+        self.exearg = ""
 
     def postrun(self, ret):
         self.recv_p.terminate()

--- a/tests/t142_recv_multi.py
+++ b/tests/t142_recv_multi.py
@@ -6,11 +6,15 @@ import subprocess as sp
 
 from runtest import TestBase
 
-TDIR  = 'xxx'
+TDIR = "xxx"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
   62.202 us [28141] | __cxa_atexit();
             [28141] | main() {
@@ -22,40 +26,41 @@ class TestCase(TestBase):
    1.915 us [28141] |     } /* b */
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         self.gen_port()
 
-        self.subcmd = 'recv'
-        self.option = '-d %s --port %s' % (TDIR, self.port)
-        self.exearg = ''
+        self.subcmd = "recv"
+        self.option = "-d %s --port %s" % (TDIR, self.port)
+        self.exearg = ""
         recv_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + recv_cmd)
+        self.pr_debug("prerun command: " + recv_cmd)
         self.recv_p = sp.Popen(recv_cmd.split())
 
         # recorded but not used
-        self.subcmd = 'record'
-        self.option = '--host %s --port %s' % ('localhost', self.port)
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.option = "--host %s --port %s" % ("localhost", self.port)
+        self.exearg = "t-" + self.name
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
         # use this
-        self.pr_debug('run another record')
-        self.dirname = 'dir-' + str(random.randint(100000, 999999))
-        self.pr_debug('after randint')
-        self.option += ' -d ' + self.dirname
+        self.pr_debug("run another record")
+        self.dirname = "dir-" + str(random.randint(100000, 999999))
+        self.pr_debug("after randint")
+        self.option += " -d " + self.dirname
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-d %s' % os.path.join(TDIR, self.dirname)
+        self.subcmd = "replay"
+        self.option = "-d %s" % os.path.join(TDIR, self.dirname)
 
     def postrun(self, ret):
         self.recv_p.terminate()

--- a/tests/t143_recv_kernel.py
+++ b/tests/t143_recv_kernel.py
@@ -6,11 +6,16 @@ import subprocess as sp
 
 from runtest import TestBase
 
-TDIR  = 'xxx'
+TDIR = "xxx"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "openclose",
+            serial=True,
+            result="""
 # DURATION    TID     FUNCTION
    1.088 us [18343] | __monstartup();
    0.640 us [18343] | __cxa_atexit();
@@ -22,37 +27,38 @@ class TestCase(TestBase):
   10.781 us [18343] |     sys_close();
   37.325 us [18343] |   } /* fclose */
  128.387 us [18343] | } /* main */
-""")
+""",
+        )
         self.recv_p = None
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
             return TestBase.TEST_SKIP
-        if os.path.exists('/.dockerenv'):
+        if os.path.exists("/.dockerenv"):
             return TestBase.TEST_SKIP
 
         self.gen_port()
 
-        self.subcmd = 'recv'
-        self.option = '-d %s --port %s' % (TDIR, self.port)
-        self.exearg = ''
+        self.subcmd = "recv"
+        self.option = "-d %s --port %s" % (TDIR, self.port)
+        self.exearg = ""
         recv_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + recv_cmd)
+        self.pr_debug("prerun command: " + recv_cmd)
         self.recv_p = sp.Popen(recv_cmd.split())
 
-        self.dirname = 'dir-%d' % random.randint(100000, 999999)
-        self.subcmd = 'record'
-        self.option = '--host %s --port %s -d %s' % ('localhost', self.port, self.dirname)
-        self.exearg = 't-' + self.name
+        self.dirname = "dir-%d" % random.randint(100000, 999999)
+        self.subcmd = "record"
+        self.option = "--host %s --port %s -d %s" % ("localhost", self.port, self.dirname)
+        self.exearg = "t-" + self.name
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-d %s' % os.path.join(TDIR, self.dirname)
+        self.subcmd = "replay"
+        self.option = "-d %s" % os.path.join(TDIR, self.dirname)
 
     def postrun(self, ret):
         self.recv_p.terminate()
@@ -62,9 +68,13 @@ class TestCase(TestBase):
         uname = os.uname()
 
         # Linux v4.17 (x86_64) changed syscall routines
-        major, minor, release = uname[2].split('.')
-        if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
-            result = result.replace('sys_', '__x64_sys_')
+        major, minor, release = uname[2].split(".")
+        if (
+            uname[0] == "Linux"
+            and uname[4] == "x86_64"
+            and int(major) >= 5
+            or (int(major) == 4 and int(minor) >= 17)
+        ):
+            result = result.replace("sys_", "__x64_sys_")
 
-        return result.replace(' sys_open', ' sys_openat')
+        return result.replace(" sys_open", " sys_openat")

--- a/tests/t144_longjmp2.py
+++ b/tests/t144_longjmp2.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'longjmp2', """
+        TestBase.__init__(
+            self,
+            "longjmp2",
+            """
 # DURATION    TID     FUNCTION
    1.517 us [ 3024] | __monstartup();
    0.971 us [ 3024] | __cxa_atexit();
@@ -18,4 +22,5 @@ class TestCase(TestBase):
             [ 3024] |       longjmp() {
    0.671 us [ 3024] |   } /* _setjmp */
    7.291 us [ 3024] | } /* main */
-""")
+""",
+        )

--- a/tests/t145_longjmp3.py
+++ b/tests/t145_longjmp3.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'longjmp3', """
+        TestBase.__init__(
+            self,
+            "longjmp3",
+            """
 # DURATION    TID     FUNCTION
    1.164 us [ 4107] | __monstartup();
    0.657 us [ 4107] | __cxa_atexit();
@@ -29,7 +33,8 @@ class TestCase(TestBase):
             [ 4107] |       longjmp(4) {
    0.642 us [ 4107] |   } = 4; /* _setjmp */
   18.019 us [ 4107] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-A .?longjmp@arg2 -R .?setjmp@retval'
+        self.option = "-A .?longjmp@arg2 -R .?setjmp@retval"

--- a/tests/t146_arg_std_string.py
+++ b/tests/t146_arg_std_string.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'std-string', lang='C++', result="""
+        TestBase.__init__(
+            self,
+            "std-string",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
             [71555] | main() {
    7.549 us [71555] |   std_string_arg("Hello"s);
@@ -14,11 +19,12 @@ class TestCase(TestBase):
    0.124 us [71555] |   std_string_ret::cxx11() = "World!"s;
    0.110 us [71555] |   std_string_ret::cxx11() = "std::string support is done!"s;
   10.346 us [71555] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
@@ -28,6 +34,6 @@ class TestCase(TestBase):
         return result.replace("std_string_ret::cxx11()", "std_string_ret()")
 
     def setup(self):
-        self.option  = '-A ^std_string_arg@arg1/S '
-        self.option += '-R ^std_string_ret@retval/S '
-        self.option += '-F main -F ^std_string_ -D 1'
+        self.option = "-A ^std_string_arg@arg1/S "
+        self.option += "-R ^std_string_ret@retval/S "
+        self.option += "-F main -F ^std_string_ -D 1"

--- a/tests/t147_event_sdt.py
+++ b/tests/t147_event_sdt.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sdt', """
+        TestBase.__init__(
+            self,
+            "sdt",
+            """
 # DURATION    TID     FUNCTION
    9.392 us [28141] | __monstartup();
   12.912 us [28141] | __cxa_atexit();
@@ -13,12 +17,13 @@ class TestCase(TestBase):
             [28141] |     /* uftrace:event */
    2.896 us [28141] |   } /* foo */
    3.017 us [28141] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         if not TestBase.check_arch_sdt_support(self):
             return TestBase.TEST_SKIP
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-E uftrace:* --match glob'
+        self.option = "-E uftrace:* --match glob"

--- a/tests/t148_event_kernel.py
+++ b/tests/t148_event_kernel.py
@@ -4,9 +4,14 @@ import os
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            serial=True,
+            result="""
 # DURATION    TID     FUNCTION
             [24464] | main() {
             [24464] |   foo() {
@@ -25,36 +30,37 @@ class TestCase(TestBase):
    2.215 ms [24464] |   } /* foo */
    2.216 ms [24464] | } /* main */
 
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
             return TestBase.TEST_SKIP
-        if os.path.exists('/.dockerenv'):
+        if os.path.exists("/.dockerenv"):
             return TestBase.TEST_SKIP
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.option  = '-E sched:sched_switch@kernel'
+        self.option = "-E sched:sched_switch@kernel"
 
-    def sort(self, output, ignored=''):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+    def sort(self, output, ignored=""):
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
         before_main = True
-        for ln in output.split('\n'):
-            if ln.find(' | main()') > 0:
+        for ln in output.split("\n"):
+            if ln.find(" | main()") > 0:
                 before_main = False
             if before_main:
                 continue
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
             # delete event specific info
-            if ln.find('sched:sched_switch') > 0:
-                ln = ' |         /* sched:sched_switch */'
-            func = ln.split('|', 1)[-1]
+            if ln.find("sched:sched_switch") > 0:
+                ln = " |         /* sched:sched_switch */"
+            func = ln.split("|", 1)[-1]
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t149_event_kernel2.py
+++ b/tests/t149_event_kernel2.py
@@ -4,9 +4,14 @@ import os
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "fork",
+            serial=True,
+            result="""
 # DURATION    TID     FUNCTION
             [ 6532] | /* sched:sched_process_exec (filename=t-fork pid=6532 old_pid=6532) */
             [ 6532] | main() {
@@ -35,36 +40,37 @@ class TestCase(TestBase):
    6.522 us [ 6532] |   } /* a */
   50.451 ms [ 6532] | } /* main */
             [ 6532] | /* sched:sched_process_exit (comm=t-fork pid=6532 prio=120) */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
             return TestBase.TEST_SKIP
-        if os.path.exists('/.dockerenv'):
+        if os.path.exists("/.dockerenv"):
             return TestBase.TEST_SKIP
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.option  = '-E sched:sched_process_*@kernel --kernel-full --event-full'
+        self.option = "-E sched:sched_process_*@kernel --kernel-full --event-full"
 
-    def sort(self, output, ignored=''):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+    def sort(self, output, ignored=""):
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
         before_main = True
-        for ln in output.split('\n'):
-            if ln.find(' | main()') > 0:
+        for ln in output.split("\n"):
+            if ln.find(" | main()") > 0:
                 before_main = False
             if before_main:
                 continue
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
             # delete event specific info
-            if ln.find('sched:sched_') > 0:
-                ln = ln.split('(', 1)[0] + '*/'
-            func = ln.split('|', 1)[-1]
+            if ln.find("sched:sched_") > 0:
+                ln = ln.split("(", 1)[0] + "*/"
+            func = ln.split("|", 1)[-1]
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t150_recv_event.py
+++ b/tests/t150_recv_event.py
@@ -5,11 +5,15 @@ import subprocess as sp
 
 from runtest import TestBase
 
-TDIR  = 'xxx'
+TDIR = "xxx"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sdt', """
+        TestBase.__init__(
+            self,
+            "sdt",
+            """
 # DURATION    TID     FUNCTION
    9.392 us [28141] | __monstartup();
   12.912 us [28141] | __cxa_atexit();
@@ -18,36 +22,37 @@ class TestCase(TestBase):
             [28141] |     /* uftrace:event */
    2.896 us [28141] |   } /* foo */
    3.017 us [28141] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         self.gen_port()
 
-        self.subcmd = 'recv'
-        self.option = '-d %s --port %s' % (TDIR, self.port)
-        self.exearg = ''
+        self.subcmd = "recv"
+        self.option = "-d %s --port %s" % (TDIR, self.port)
+        self.exearg = ""
         recv_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + recv_cmd)
+        self.pr_debug("prerun command: " + recv_cmd)
         self.recv_p = sp.Popen(recv_cmd.split())
 
-        self.subcmd = 'record'
-        self.option = '--host %s --port %s -E uftrace:event' % ('localhost', self.port)
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.option = "--host %s --port %s -E uftrace:event" % ("localhost", self.port)
+        self.exearg = "t-" + self.name
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
         return TestBase.TEST_SUCCESS
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         if not TestBase.check_arch_sdt_support(self):
             return TestBase.TEST_SKIP
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-E uftrace:event -d ' + os.path.join(TDIR, 'uftrace.data')
-        self.exearg = ''
+        self.subcmd = "replay"
+        self.option = "-E uftrace:event -d " + os.path.join(TDIR, "uftrace.data")
+        self.exearg = ""
 
     def postrun(self, ret):
         self.recv_p.terminate()

--- a/tests/t151_recv_runcmd.py
+++ b/tests/t151_recv_runcmd.py
@@ -4,12 +4,16 @@ import subprocess as sp
 
 from runtest import TestBase
 
-TDIR = 'xxx'
-TMPF = 'out'
+TDIR = "xxx"
+TMPF = "out"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
   62.202 us [28141] | __cxa_atexit();
             [28141] | main() {
@@ -21,31 +25,32 @@ class TestCase(TestBase):
    1.915 us [28141] |     } /* b */
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         self.gen_port()
-        self.file_p = open(TMPF, 'w+')
+        self.file_p = open(TMPF, "w+")
 
-        recv_cmd  = [TestBase.uftrace_cmd, 'recv']
+        recv_cmd = [TestBase.uftrace_cmd, "recv"]
         recv_cmd += TestBase.default_opt.split()
-        recv_cmd += ['-d', TDIR, '--port', str(self.port)]
-        recv_cmd += ['--run-cmd', '%s %s' % (TestBase.uftrace_cmd, 'replay')]
-        self.pr_debug('prerun command: ' + ' '.join(recv_cmd))
+        recv_cmd += ["-d", TDIR, "--port", str(self.port)]
+        recv_cmd += ["--run-cmd", "%s %s" % (TestBase.uftrace_cmd, "replay")]
+        self.pr_debug("prerun command: " + " ".join(recv_cmd))
         self.recv_p = sp.Popen(recv_cmd, stdout=self.file_p, stderr=self.file_p)
 
-        record_cmd  = [TestBase.uftrace_cmd, 'record']
+        record_cmd = [TestBase.uftrace_cmd, "record"]
         record_cmd += TestBase.default_opt.split()
-        record_cmd += ['--host', 'localhost', '--port', str(self.port)]
-        record_cmd += ['t-' + self.name]
-        self.pr_debug('prerun command: ' + ' '.join(record_cmd))
+        record_cmd += ["--host", "localhost", "--port", str(self.port)]
+        record_cmd += ["t-" + self.name]
+        self.pr_debug("prerun command: " + " ".join(record_cmd))
         sp.call(record_cmd)
 
         return TestBase.TEST_SUCCESS
 
     def runcmd(self):
         # run replay at recv time and print the result now
-        return 'cat ' + TMPF
+        return "cat " + TMPF
 
     def postrun(self, ret):
         self.recv_p.terminate()

--- a/tests/t152_read_proc_statm.py
+++ b/tests/t152_read_proc_statm.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
             [32417] | main() {
             [32417] |   a() {
@@ -17,23 +21,24 @@ class TestCase(TestBase):
   16.914 us [32417] |     } /* b */
   17.083 us [32417] |   } /* a */
   17.873 us [32417] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-F main -T b@read=proc/statm'
+        self.option = "-F main -T b@read=proc/statm"
 
     def sort(self, output):
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            func = ln.split('|', 1)[-1]
+            func = ln.split("|", 1)[-1]
             # remove actual numbers in proc.statm
-            if func.find('read:proc/statm') > 0:
-                func = '       /* read:proc/statm */'
-            if func.find('diff:proc/statm') > 0:
-                func = '       /* diff:proc/statm */'
+            if func.find("read:proc/statm") > 0:
+                func = "       /* read:proc/statm */"
+            if func.find("diff:proc/statm") > 0:
+                func = "       /* diff:proc/statm */"
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t153_read_page_fault.py
+++ b/tests/t153_read_page_fault.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
             [32766] | main() {
             [32766] |   a() {
@@ -17,23 +21,24 @@ class TestCase(TestBase):
   24.950 us [32766] |     } /* b */
   25.564 us [32766] |   } /* a */
   26.963 us [32766] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-F main -T b@read=page-fault'
+        self.option = "-F main -T b@read=page-fault"
 
     def sort(self, output):
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            func = ln.split('|', 1)[-1]
+            func = ln.split("|", 1)[-1]
             # remove actual numbers in page-fault
-            if func.find('read:page-fault') > 0:
-                func = '       /* read:page-fault */'
-            if func.find('diff:page-fault') > 0:
-                func = '       /* diff:page-fault */'
+            if func.find("read:page-fault") > 0:
+                func = "       /* read:page-fault */"
+            if func.find("diff:page-fault") > 0:
+                func = "       /* diff:page-fault */"
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t154_keep_pid.py
+++ b/tests/t154_keep_pid.py
@@ -1,8 +1,12 @@
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'daemon', """
+        TestBase.__init__(
+            self,
+            "daemon",
+            """
 # DURATION    TID     FUNCTION
             [22067] | main() {
             [22067] |   daemon() {
@@ -21,7 +25,8 @@ uftrace stopped tracing with remaining functions
 task: 22067
 [1] daemon
 [0] main
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '--keep-pid --no-pager'
+        self.option = "--keep-pid --no-pager"

--- a/tests/t155_trigger_finish.py
+++ b/tests/t155_trigger_finish.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
             [ 4131] | main() {
             [ 4131] |   a() {
@@ -21,13 +25,15 @@ task: 4131
 [2] b
 [1] a
 [0] main
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-F main -T getpid@finish'
-
+        self.option = "-F main -T getpid@finish"
 
     def fixup(self, cflags, result):
-        return result.replace("""         getpid() {
+        return result.replace(
+            """         getpid() {
             [ 4131] |           /* linux:task-exit */""",
-                                "         getpid() {")
+            "         getpid() {",
+        )

--- a/tests/t156_trigger_finish2.py
+++ b/tests/t156_trigger_finish2.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', """
+        TestBase.__init__(
+            self,
+            "namespace",
+            """
 # DURATION    TID     FUNCTION
             [ 6565] | main() {
    2.234 us [ 6565] |   operator new();
@@ -23,12 +27,16 @@ task: 6565
 [2] ns::ns1::foo::bar1
 [1] ns::ns1::foo::bar
 [0] main
-""", lang='C++')
+""",
+            lang="C++",
+        )
 
     def setup(self):
-        self.option = '-F main -T ns::ns1::foo::bar3@finish'
+        self.option = "-F main -T ns::ns1::foo::bar3@finish"
 
     def fixup(self, cflags, result):
-        return result.replace("""ns::ns1::foo::bar3() {
+        return result.replace(
+            """ns::ns1::foo::bar3() {
             [ 6565] |           /* linux:task-exit */""",
-                                "ns::ns1::foo::bar3() {")
+            "ns::ns1::foo::bar3() {",
+        )

--- a/tests/t157_script_python.py
+++ b/tests/t157_script_python.py
@@ -4,23 +4,24 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', '5')
+        TestBase.__init__(self, "abc", "5")
 
     def prerun(self, timeout):
-        self.subcmd = 'script'
-        self.option = '-S %s/scripts/count.py --record' % self.basedir
+        self.subcmd = "script"
+        self.option = "-S %s/scripts/count.py --record" % self.basedir
         script_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + script_cmd)
+        self.pr_debug("prerun command: " + script_cmd)
 
         p = sp.Popen(script_cmd.split(), stdout=sp.PIPE, stderr=sp.PIPE)
-        if p.communicate()[1].decode(errors='ignore').startswith('WARN:'):
+        if p.communicate()[1].decode(errors="ignore").startswith("WARN:"):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.option = '-F main -S %s/scripts/count.py' % self.basedir
+        self.option = "-F main -S %s/scripts/count.py" % self.basedir
 
     def sort(self, output):
         return output.strip()

--- a/tests/t158_report_diff_policy1.py
+++ b/tests/t158_report_diff_policy1.py
@@ -4,12 +4,16 @@ import subprocess as sp
 
 from runtest import TestBase
 
-XDIR='xxx'
-YDIR='yyy'
+XDIR = "xxx"
+YDIR = "yyy"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'diff', """
+        TestBase.__init__(
+            self,
+            "diff",
+            """
 #
 # uftrace diff
 #  [0] base: xxx   (from uftrace record -d xxx -F main tests/t-diff 0 )
@@ -22,46 +26,47 @@ class TestCase(TestBase):
      +1.225 ms    +2.609 us           +0   foo
    +158.450 us    +1.305 us           +0   bar
      -0.066 us    -0.066 us           +0   atoi
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        self.subcmd = 'record'
-        self.option = '-d %s -F main' % XDIR
-        self.exearg = 't-' + self.name + ' 0'
+        self.subcmd = "record"
+        self.option = "-d %s -F main" % XDIR
+        self.exearg = "t-" + self.name + " 0"
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
-        self.option = '-d %s -F main' % YDIR
-        self.exearg = 't-' + self.name + ' 1'
+        self.option = "-d %s -F main" % YDIR
+        self.exearg = "t-" + self.name + " 1"
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '--diff-policy compact,no-percent,abs'  # new default
-        self.exearg = '-d %s --diff %s' % (XDIR, YDIR)
+        self.subcmd = "report"
+        self.option = "--diff-policy compact,no-percent,abs"  # new default
+        self.exearg = "-d %s --diff %s" % (XDIR, YDIR)
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.startswith('#') or ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.startswith("#") or ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Total':
+            if line[0] == "Total":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]  [1]    [2]  [3]   [4]   [5]
             # total unit  self unit  call  function
-            if line[-1].startswith('__'):
+            if line[-1].startswith("__"):
                 continue
-            result.append('%s %s' % (line[-2], line[-1]))
+            result.append("%s %s" % (line[-2], line[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t159_report_diff_policy2.py
+++ b/tests/t159_report_diff_policy2.py
@@ -4,12 +4,16 @@ import subprocess as sp
 
 from runtest import TestBase
 
-XDIR='xxx'
-YDIR='yyy'
+XDIR = "xxx"
+YDIR = "yyy"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'diff', """
+        TestBase.__init__(
+            self,
+            "diff",
+            """
 #
 # uftrace diff
 #  [0] base: xxx   (from uftrace record -d yyy -F main tests/t-diff 1 )
@@ -22,46 +26,47 @@ class TestCase(TestBase):
     1.235 ms    0.645 us    -1.235 ms     3.276 us    0.527 us    -2.749 us            1          1         +0   foo
     1.309 ms    3.975 us    -1.305 ms     2.601 us    2.282 us    -0.319 us            1          1         +0   main
     1.300 ms           -    -1.300 ms     1.300 ms           -    -1.300 ms            3          0         -3   usleep
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        self.subcmd = 'record'
-        self.option = '-d %s -F main' % XDIR
-        self.exearg = 't-' + self.name + ' 0'
+        self.subcmd = "record"
+        self.option = "-d %s -F main" % XDIR
+        self.exearg = "t-" + self.name + " 0"
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
-        self.option = '-d %s -F main' % YDIR
-        self.exearg = 't-' + self.name + ' 1'
+        self.option = "-d %s -F main" % YDIR
+        self.exearg = "t-" + self.name + " 1"
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '--diff-policy full,no-abs -s call,total'
-        self.exearg = '-d %s --diff %s' % (YDIR, XDIR)
+        self.subcmd = "report"
+        self.option = "--diff-policy full,no-abs -s call,total"
+        self.exearg = "-d %s --diff %s" % (YDIR, XDIR)
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.startswith('#') or ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.startswith("#") or ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Total':
+            if line[0] == "Total":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]  [1]  [2]  [3]  [4]  [5]   [6]  [7]  [8]  [9]  [10] [11]   [12]   [13]   [14]    [15]
             # tT/0 unit tT/1 unit tT/d unit  tS/0 unit tS/1 unit tS/d unit   call/0 call/1 call/d  function
-            if line[-1].startswith('__'):
+            if line[-1].startswith("__"):
                 continue
-            result.append('%s %s %s %s' % (line[-4], line[-3], line[-2], line[-1]))
+            result.append("%s %s %s %s" % (line[-4], line[-3], line[-2], line[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t160_report_diff_policy3.py
+++ b/tests/t160_report_diff_policy3.py
@@ -4,12 +4,16 @@ import subprocess as sp
 
 from runtest import TestBase
 
-XDIR='xxx'
-YDIR='yyy'
+XDIR = "xxx"
+YDIR = "yyy"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'diff', """
+        TestBase.__init__(
+            self,
+            "diff",
+            """
 #
 # uftrace diff
 #  [0] base: xxx   (from uftrace record -d xxx -F main tests/t-diff 0 )
@@ -22,46 +26,47 @@ class TestCase(TestBase):
     +999.99%     +498.85%           +0   foo
     +999.99%      +10.47%           +0   main
     +999.99%     +999.99%           +3   usleep
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        self.subcmd = 'record'
-        self.option = '-d %s -F main' % XDIR
-        self.exearg = 't-' + self.name + ' 0'
+        self.subcmd = "record"
+        self.option = "-d %s -F main" % XDIR
+        self.exearg = "t-" + self.name + " 0"
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
-        self.option = '-d %s -F main' % YDIR
-        self.exearg = 't-' + self.name + ' 1'
+        self.option = "-d %s -F main" % YDIR
+        self.exearg = "t-" + self.name + " 1"
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: %s' + record_cmd)
+        self.pr_debug("prerun command: %s" + record_cmd)
         sp.call(record_cmd.split())
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '--diff-policy percent -s func'
-        self.exearg = '-d %s --diff %s' % (XDIR, YDIR)
+        self.subcmd = "report"
+        self.option = "--diff-policy percent -s func"
+        self.exearg = "-d %s --diff %s" % (XDIR, YDIR)
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.startswith('#') or ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.startswith("#") or ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Total':
+            if line[0] == "Total":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]   [1]      [2]  [3]      [4]   [5]
             # total percent  self percent  call  function
-            if line[-1].startswith('__'):
+            if line[-1].startswith("__"):
                 continue
-            result.append('%s %s' % (line[-2], line[-1]))
+            result.append("%s %s" % (line[-2], line[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t161_pltbind_now.py
+++ b/tests/t161_pltbind_now.py
@@ -2,15 +2,20 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', """
+        TestBase.__init__(
+            self,
+            "openclose",
+            """
 # DURATION    TID     FUNCTION
             [15973] | main() {
    5.903 us [15973] |   fopen();
    4.374 us [15973] |   fclose();
   15.262 us [15973] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         return TestBase.build(self, name, cflags, ldflags + " -Wl,-z,now -Wl,-z,relro")

--- a/tests/t162_pltbind_now_pie.py
+++ b/tests/t162_pltbind_now_pie.py
@@ -2,16 +2,20 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', """
+        TestBase.__init__(
+            self,
+            "openclose",
+            """
 # DURATION    TID     FUNCTION
             [15973] | main() {
    5.903 us [15973] |   fopen();
    4.374 us [15973] |   fclose();
   15.262 us [15973] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        return TestBase.build(self, name, cflags + " -fpie",
-                              ldflags + " -Wl,-pie,-z,now,-z,relro")
+    def build(self, name, cflags="", ldflags=""):
+        return TestBase.build(self, name, cflags + " -fpie", ldflags + " -Wl,-pie,-z,now,-z,relro")

--- a/tests/t163_event_sched.py
+++ b/tests/t163_event_sched.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            serial=True,
+            result="""
 # DURATION    TID     FUNCTION
             [  395] | main() {
             [  395] |   foo() {
@@ -15,14 +20,15 @@ class TestCase(TestBase):
    2.109 ms [  395] |     } /* bar */
    2.120 ms [  395] |   } /* foo */
    2.121 ms [  395] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        if not TestBase.check_dependency(self, 'perf_context_switch'):
+        if not TestBase.check_dependency(self, "perf_context_switch"):
             return TestBase.TEST_SKIP
         if not TestBase.check_perf_paranoid(self):
             return TestBase.TEST_SKIP
         return TestCase.TEST_SUCCESS
 
     def setup(self):
-        self.option = '-D 2 -F main -F bar -E linux:schedule'
+        self.option = "-D 2 -F main -F bar -E linux:schedule"

--- a/tests/t164_report_sched.py
+++ b/tests/t164_report_sched.py
@@ -4,9 +4,14 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sort', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "sort",
+            serial=True,
+            result="""
   Total time   Self time       Calls  Function
   ==========  ==========  ==========  ====================================
     1.152 ms   71.683 us           1  main
@@ -17,25 +22,27 @@ class TestCase(TestBase):
    37.525 us    1.137 us           2  foo
    36.388 us   36.388 us           6  loop
     1.200 us    1.200 us           1  __cxa_atexit   # and this too
-""", sort='report')
+""",
+            sort="report",
+        )
 
     def prerun(self, timeout):
-        if not TestBase.check_dependency(self, 'perf_context_switch'):
+        if not TestBase.check_dependency(self, "perf_context_switch"):
             return TestBase.TEST_SKIP
         if not TestBase.check_perf_paranoid(self):
             return TestBase.TEST_SKIP
 
-        self.subcmd = 'record'
-        self.option = '-E linux:schedule'
+        self.subcmd = "record"
+        self.option = "-E linux:schedule"
         record_cmd = TestBase.runcmd(self)
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '-E linux:schedule'
+        self.subcmd = "report"
+        self.option = "-E linux:schedule"
 
     def runcmd(self):
         cmd = TestBase.runcmd(self)
-        return cmd.replace('--no-event', '')
+        return cmd.replace("--no-event", "")

--- a/tests/t165_graph_sched.py
+++ b/tests/t165_graph_sched.py
@@ -4,11 +4,16 @@ import subprocess as sp
 
 from runtest import TestBase
 
-FUNC='main'
+FUNC = "main"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sort', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "sort",
+            serial=True,
+            result="""
 # Function Call Graph for 'main' (session: 54047ea45c46ad91)
 =============== BACKTRACE ===============
  backtrace #0: hit 1, time  10.329 ms
@@ -22,28 +27,30 @@ class TestCase(TestBase):
   10.150 ms :  +-(1) bar
   10.102 ms :    (1) usleep
   10.088 ms :    (1) linux:schedule
-""", sort='graph')
+""",
+            sort="graph",
+        )
 
     def prerun(self, timeout):
-        if not TestBase.check_dependency(self, 'perf_context_switch'):
+        if not TestBase.check_dependency(self, "perf_context_switch"):
             return TestBase.TEST_SKIP
         if not TestBase.check_perf_paranoid(self):
             return TestBase.TEST_SKIP
 
-        self.subcmd = 'record'
-        self.option = '-E linux:schedule'
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.option = "-E linux:schedule"
+        self.exearg = "t-" + self.name
 
         record_cmd = TestBase.runcmd(self)
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'graph'
-        self.option = ''
-        self.exearg = 'main'
+        self.subcmd = "graph"
+        self.option = ""
+        self.exearg = "main"
 
     def runcmd(self):
         cmd = TestBase.runcmd(self)
-        return cmd.replace('--no-event', '')
+        return cmd.replace("--no-event", "")

--- a/tests/t166_dump_sched.py
+++ b/tests/t166_dump_sched.py
@@ -4,9 +4,14 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            serial=True,
+            result="""
 {"traceEvents":[
 {"ts":0,"ph":"M","pid":306,"name":"process_name","args":{"name":"[306] t-sleep"}},
 {"ts":0,"ph":"M","pid":306,"name":"thread_name","args":{"name":"[306] t-sleep"}},
@@ -36,25 +41,27 @@ class TestCase(TestBase):
 "command_line":"uftrace record -d xxx -E linux:schedule t-sleep ",
 "recorded_time":"Fri Aug 25 14:23:29 2017"
 } }
-""", sort='chrome')
+""",
+            sort="chrome",
+        )
 
     def prerun(self, timeout):
-        if not TestBase.check_dependency(self, 'perf_context_switch'):
+        if not TestBase.check_dependency(self, "perf_context_switch"):
             return TestBase.TEST_SKIP
         if not TestBase.check_perf_paranoid(self):
             return TestBase.TEST_SKIP
 
-        self.subcmd = 'record'
-        self.option = '-E  linux:schedule'
+        self.subcmd = "record"
+        self.option = "-E  linux:schedule"
         record_cmd = TestBase.runcmd(self)
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'dump'
-        self.option = '-F main --chrome'
+        self.subcmd = "dump"
+        self.option = "-F main --chrome"
 
     def runcmd(self):
         cmd = TestBase.runcmd(self)
-        return cmd.replace('--no-event', '')
+        return cmd.replace("--no-event", "")

--- a/tests/t167_recv_sched.py
+++ b/tests/t167_recv_sched.py
@@ -5,11 +5,16 @@ import subprocess as sp
 
 from runtest import TestBase
 
-TDIR  = 'xxx'
+TDIR = "xxx"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            serial=True,
+            result="""
 # DURATION    TID     FUNCTION
             [  395] | main() {
             [  395] |   foo() {
@@ -26,42 +31,43 @@ class TestCase(TestBase):
    3.783 us [  395] |     } /* mem_free */
    2.120 ms [  395] |   } /* foo */
    2.121 ms [  395] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        if not TestBase.check_dependency(self, 'perf_context_switch'):
+        if not TestBase.check_dependency(self, "perf_context_switch"):
             return TestBase.TEST_SKIP
         if not TestBase.check_perf_paranoid(self):
             return TestBase.TEST_SKIP
 
         self.gen_port()
-        self.subcmd = 'recv'
-        self.option = '-d %s --port %s' % (TDIR, self.port)
-        self.exearg = ''
+        self.subcmd = "recv"
+        self.option = "-d %s --port %s" % (TDIR, self.port)
+        self.exearg = ""
 
         recv_cmd = TestBase.runcmd(self)
-        self.pr_debug('prerun command: ' + recv_cmd)
+        self.pr_debug("prerun command: " + recv_cmd)
         self.recv_p = sp.Popen(recv_cmd.split())
 
-        self.subcmd  = 'record'
-        self.option  = '--host %s --port %s ' % ('localhost', self.port)
-        self.option += '-E %s' % 'linux:schedule'
-        self.exearg  = 't-' + self.name
+        self.subcmd = "record"
+        self.option = "--host %s --port %s " % ("localhost", self.port)
+        self.option += "-E %s" % "linux:schedule"
+        self.exearg = "t-" + self.name
 
         record_cmd = TestBase.runcmd(self)
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-d ' + os.path.join(TDIR, 'uftrace.data')
-        self.exearg = ''
+        self.subcmd = "replay"
+        self.option = "-d " + os.path.join(TDIR, "uftrace.data")
+        self.exearg = ""
 
     def runcmd(self):
         cmd = TestBase.runcmd(self)
-        return cmd.replace('--no-event', '')
+        return cmd.replace("--no-event", "")
 
     def postrun(self, ret):
         self.recv_p.terminate()

--- a/tests/t168_lib_nested.py
+++ b/tests/t168_lib_nested.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'nest-libcall', """1
+        TestBase.__init__(
+            self,
+            "nest-libcall",
+            """1
 # DURATION    TID     FUNCTION
             [ 5363] | main() {
             [ 5363] |   lib_a() {
@@ -14,16 +18,17 @@ class TestCase(TestBase):
    9.405 us [ 5363] |     AAA::bar();
   17.133 us [ 5363] |   } /* foo */
   21.093 us [ 5363] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if TestBase.build_libabc(self, '', '') != 0:
+    def build(self, name, cflags="", ldflags=""):
+        if TestBase.build_libabc(self, "", "") != 0:
             return TestBase.TEST_BUILD_FAIL
-        if TestBase.build_libfoo(self, 'foo', '', '') != 0:
+        if TestBase.build_libfoo(self, "foo", "", "") != 0:
             return TestBase.TEST_BUILD_FAIL
-        return TestBase.build_libmain(self, name, 's-nest-libcall.c',
-                                      ['libabc_test_lib.so', 'libfoo.so'],
-                                      cflags, ldflags)
+        return TestBase.build_libmain(
+            self, name, "s-nest-libcall.c", ["libabc_test_lib.so", "libfoo.so"], cflags, ldflags
+        )
 
     def setup(self):
-        self.option = '-D3 --nest-libcall'
+        self.option = "-D3 --nest-libcall"

--- a/tests/t169_script_args.py
+++ b/tests/t169_script_args.py
@@ -4,7 +4,7 @@ import subprocess as sp
 
 from runtest import TestBase
 
-FILE='script.py'
+FILE = "script.py"
 
 script = """
 def uftrace_entry(ctx):
@@ -15,22 +15,23 @@ def uftrace_exit(ctx):
   pass
 """
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', 'fopen(/dev/null)')
+        TestBase.__init__(self, "openclose", "fopen(/dev/null)")
 
     def prerun(self, timeout):
-        script_cmd = '%s script' % (TestBase.uftrace_cmd)
+        script_cmd = "%s script" % (TestBase.uftrace_cmd)
         p = sp.Popen(script_cmd.split(), stdout=sp.PIPE, stderr=sp.PIPE)
-        if p.communicate()[1].decode(errors='ignore').startswith('WARN:'):
+        if p.communicate()[1].decode(errors="ignore").startswith("WARN:"):
             return TestBase.TEST_SKIP
 
-        f = open(FILE, 'w')
+        f = open(FILE, "w")
         f.write(script)
         f.close()
 
-        self.subcmd = 'record'
-        self.option = '-A fopen@arg1/s'
+        self.subcmd = "record"
+        self.option = "-A fopen@arg1/s"
         record_cmd = self.runcmd()
 
         self.pr_debug("prerun command: " + record_cmd)
@@ -38,8 +39,8 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'script'
-        self.option = '-S ' + FILE
+        self.subcmd = "script"
+        self.option = "-S " + FILE
 
     def sort(self, output):
         return output.strip()

--- a/tests/t170_script_filter.py
+++ b/tests/t170_script_filter.py
@@ -4,7 +4,7 @@ import subprocess as sp
 
 from runtest import TestBase
 
-FILE='script.py'
+FILE = "script.py"
 
 script = """
 UFTRACE_FUNCS = [ "a", "b" ]
@@ -16,28 +16,33 @@ def uftrace_exit(ctx):
   print("%s exit" % (ctx["name"]))
 """
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 a enter
 b enter
 b exit
 a exit
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        script_cmd = '%s script' % (TestBase.uftrace_cmd)
+        script_cmd = "%s script" % (TestBase.uftrace_cmd)
         p = sp.Popen(script_cmd.split(), stdout=sp.PIPE, stderr=sp.PIPE)
-        if p.communicate()[1].decode(errors='ignore').startswith('WARN:'):
+        if p.communicate()[1].decode(errors="ignore").startswith("WARN:"):
             return TestBase.TEST_SKIP
 
-        f = open(FILE, 'w')
+        f = open(FILE, "w")
         f.write(script)
         f.close()
 
-        self.subcmd = 'record'
-        self.option = ''
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.option = ""
+        self.exearg = "t-" + self.name
 
         record_cmd = self.runcmd()
         self.pr_debug("prerun command: " + record_cmd)
@@ -45,9 +50,9 @@ a exit
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'script'
-        self.option = '-S ' + FILE
-        self.exearg = ''
+        self.subcmd = "script"
+        self.option = "-S " + FILE
+        self.exearg = ""
 
     def sort(self, output):
         return output.strip()

--- a/tests/t171_script_option.py
+++ b/tests/t171_script_option.py
@@ -4,7 +4,7 @@ import subprocess as sp
 
 from runtest import TestBase
 
-FILE='script.py'
+FILE = "script.py"
 
 script = """
 # uftrace-option: -A fopen@arg1/s
@@ -17,28 +17,29 @@ def uftrace_exit(ctx):
   pass
 """
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', 'fopen(/dev/null)')
+        TestBase.__init__(self, "openclose", "fopen(/dev/null)")
 
     def prerun(self, timeout):
-        script_cmd = '%s script' % (TestBase.uftrace_cmd)
+        script_cmd = "%s script" % (TestBase.uftrace_cmd)
         p = sp.Popen(script_cmd.split(), stdout=sp.PIPE, stderr=sp.PIPE)
-        if p.communicate()[1].decode(errors='ignore').startswith('WARN:'):
+        if p.communicate()[1].decode(errors="ignore").startswith("WARN:"):
             return TestBase.TEST_SKIP
 
-        f = open(FILE, 'w')
+        f = open(FILE, "w")
         f.write(script)
         f.close()
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'script'
-        self.option = '-S %s --record' % FILE
+        self.subcmd = "script"
+        self.option = "-S %s --record" % FILE
 
     def sort(self, output):
         i = 0
         # skip warning for '-finstrument-functions'
-        if output.startswith('uftrace: -A or -R might not work'):
+        if output.startswith("uftrace: -A or -R might not work"):
             i = 1
-        return output.strip().split('\n')[i]
+        return output.strip().split("\n")[i]

--- a/tests/t172_trigger_filter.py
+++ b/tests/t172_trigger_filter.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
             [ 5908] | main() {
    7.545 us [ 5908] |   operator new();
@@ -17,7 +22,8 @@ class TestCase(TestBase):
    0.154 us [ 5908] |   operator new();
    0.177 us [ 5908] |   operator delete();
   25.925 us [ 5908] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-T main@filter,depth=3 -T ^ns::ns2@notrace'
+        self.option = "-T main@filter,depth=3 -T ^ns::ns2@notrace"

--- a/tests/t173_trigger_args.py
+++ b/tests/t173_trigger_args.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'namespace', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "namespace",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
             [ 5943] | main(1) {
    3.800 us [ 5943] |   operator new();
@@ -22,14 +27,16 @@ class TestCase(TestBase):
    1.895 us [ 5943] |   } /* ns::ns2::foo::bar */
    0.237 us [ 5943] |   operator delete();
   21.882 us [ 5943] | } /* main */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-T main@filter,depth=3,arg1'
+        self.option = "-T main@filter,depth=3,arg1"

--- a/tests/t174_replay_filter_kernel.py
+++ b/tests/t174_replay_filter_kernel.py
@@ -5,9 +5,14 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'openclose', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "openclose",
+            serial=True,
+            result="""
 # DURATION    TID     FUNCTION
             [18343] | main() {
             [18343] |   fopen() {
@@ -15,34 +20,39 @@ class TestCase(TestBase):
   89.018 us [18343] |   } /* fopen */
   37.325 us [18343] |   fclose();
  128.387 us [18343] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if os.geteuid() != 0:
             return TestBase.TEST_SKIP
-        if os.path.exists('/.dockerenv'):
+        if os.path.exists("/.dockerenv"):
             return TestBase.TEST_SKIP
 
-        self.subcmd = 'record'
-        self.option = '-k'
+        self.subcmd = "record"
+        self.option = "-k"
 
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-F main -D2 -F sys_open*@kernel'
+        self.subcmd = "replay"
+        self.option = "-F main -D2 -F sys_open*@kernel"
 
     def fixup(self, cflags, result):
         uname = os.uname()
 
         # Linux v4.17 (x86_64) changed syscall routines
-        major, minor, release = uname[2].split('.')
-        if uname[0] == 'Linux' and uname[4] == 'x86_64' and \
-           int(major) >= 5 or (int(major) == 4 and int(minor) >= 17):
-            result = result.replace('sys_', '__x64_sys_')
+        major, minor, release = uname[2].split(".")
+        if (
+            uname[0] == "Linux"
+            and uname[4] == "x86_64"
+            and int(major) >= 5
+            or (int(major) == 4 and int(minor) >= 17)
+        ):
+            result = result.replace("sys_", "__x64_sys_")
 
-        return result.replace(' sys_open', ' sys_openat')
+        return result.replace(" sys_open", " sys_openat")

--- a/tests/t175_filter_time_read.py
+++ b/tests/t175_filter_time_read.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', """
+        TestBase.__init__(
+            self,
+            "sleep",
+            """
 # DURATION    TID     FUNCTION
             [18219] | main() {
             [18219] |   foo() {
@@ -17,29 +21,33 @@ class TestCase(TestBase):
             [18219] |     /* diff:proc/statm (size=+0KB, rss=+0KB, shared=+0KB) */
    2.106 ms [18219] |   } /* foo */
    2.107 ms [18219] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option  = "-F main -t 1ms -T '(foo|bar)@read=proc/statm' "
+        self.option = "-F main -t 1ms -T '(foo|bar)@read=proc/statm' "
         self.option += "-E read:* -E diff:*"
 
     def sort(self, output):
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            func = ln.split('|', 1)[-1]
+            func = ln.split("|", 1)[-1]
             # remove actual numbers in proc.statm
-            if func.find('read:proc/statm') > 0:
-                func = '       /* read:proc/statm */'
-            if func.find('diff:proc/statm') > 0:
-                func = '       /* diff:proc/statm */'
+            if func.find("read:proc/statm") > 0:
+                func = "       /* read:proc/statm */"
+            if func.find("diff:proc/statm") > 0:
+                func = "       /* diff:proc/statm */"
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)
 
     def fixup(self, cflags, result):
-        return result.replace('usleep();', """usleep() {
+        return result.replace(
+            "usleep();",
+            """usleep() {
    2.090 ms [18219] |         /* linux:schedule */
-   2.093 ms [18219] |       } /* usleep */""")
+   2.093 ms [18219] |       } /* usleep */""",
+        )

--- a/tests/t176_arg_fptr.py
+++ b/tests/t176_arg_fptr.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'thread', ldflags='-pthread', result="""
+        TestBase.__init__(
+            self,
+            "thread",
+            ldflags="-pthread",
+            result="""
 # DURATION    TID     FUNCTION
             [ 1429] | main() {
             [ 1429] |   pthread_create(&foo) {
@@ -56,7 +61,8 @@ class TestCase(TestBase):
  121.139 us [ 1433] | } /* foo */
    0.390 us [ 1429] |   } /* pthread_join */
  658.759 us [ 1429] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '--no-merge -T pthread_create@arg3/p'
+        self.option = "--no-merge -T pthread_create@arg3/p"

--- a/tests/t177_report_diff_policy4.py
+++ b/tests/t177_report_diff_policy4.py
@@ -4,12 +4,16 @@ import subprocess as sp
 
 from runtest import TestBase
 
-XDIR='xxx'
-YDIR='yyy'
+XDIR = "xxx"
+YDIR = "yyy"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'diff', """
+        TestBase.__init__(
+            self,
+            "diff",
+            """
 #
 # uftrace diff
 #  [0] base: xxx   (from uftrace record -d xxx -F main tests/t-diff 0 )
@@ -22,48 +26,49 @@ class TestCase(TestBase):
     +1.235 ms     +2.749 us            +0   foo
     +1.305 ms     +0.319 us            +0   main
     +1.300 ms     +1.300 ms            +3   usleep
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        self.subcmd = 'record'
-        self.option = '-d %s -F main' % XDIR
-        self.exearg = 't-' + self.name + ' 0'
+        self.subcmd = "record"
+        self.option = "-d %s -F main" % XDIR
+        self.exearg = "t-" + self.name + " 0"
 
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
-        self.option = '-d %s -F main' % YDIR
-        self.exearg = 't-' + self.name + ' 1'
+        self.option = "-d %s -F main" % YDIR
+        self.exearg = "t-" + self.name + " 1"
 
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '--diff-policy compact -s func'
-        self.exearg = '-d %s --diff %s' % (XDIR, YDIR)
+        self.subcmd = "report"
+        self.option = "--diff-policy compact -s func"
+        self.exearg = "-d %s --diff %s" % (XDIR, YDIR)
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.startswith('#') or ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.startswith("#") or ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Total':
+            if line[0] == "Total":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]  [1]  [2]  [3]  [4]    [5]
             # tT   unit tS   unit call   function
-            if line[-1].startswith('__'):
+            if line[-1].startswith("__"):
                 continue
-            result.append('%s %s' % (line[-2], line[-1]))
+            result.append("%s %s" % (line[-2], line[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t178_arg_auto1.py
+++ b/tests/t178_arg_auto1.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'autoargs', result="""hello
+        TestBase.__init__(
+            self,
+            "autoargs",
+            result="""hello
 # DURATION    TID     FUNCTION
             [16523] | main() {
    2.670 us [16523] |   strlen("autoargs test") = 13;
@@ -13,8 +17,9 @@ class TestCase(TestBase):
    1.336 us [16523] |   strcmp("hello", "hello") = 0;
    4.017 us [16523] |   puts();
   18.574 us [16523] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option  = '-F main -A ^str -R ^str'
-        self.exearg += ' hello'
+        self.option = "-F main -A ^str -R ^str"
+        self.exearg += " hello"

--- a/tests/t179_arg_auto2.py
+++ b/tests/t179_arg_auto2.py
@@ -4,9 +4,13 @@ import re
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'autoargs', result="""hello
+        TestBase.__init__(
+            self,
+            "autoargs",
+            result="""hello
 # DURATION    TID     FUNCTION
             [16523] | main() {
    2.670 us [16523] |   strlen("autoargs test") = 13;
@@ -15,20 +19,21 @@ class TestCase(TestBase):
    1.336 us [16523] |   strcmp("hello", "hello") = 0;
    4.017 us [16523] |   puts("hello") = 6;
   18.574 us [16523] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option  = '-F main --auto-args'
-        self.exearg += ' hello'
+        self.option = "-F main --auto-args"
+        self.exearg += " hello"
 
     def sort(self, output):
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            line = ln.split('|', 1)[-1]
-            func = re.sub(r'0x[0-9a-f]+', '0xADDR', line)
+            line = ln.split("|", 1)[-1]
+            func = re.sub(r"0x[0-9a-f]+", "0xADDR", line)
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t180_arg_auto3.py
+++ b/tests/t180_arg_auto3.py
@@ -4,9 +4,13 @@ import re
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'autoargs', result="""hello
+        TestBase.__init__(
+            self,
+            "autoargs",
+            result="""hello
 # DURATION    TID     FUNCTION
             [16523] | main() {
    2.670 us [16523] |   strlen("autoargs test") = 13;
@@ -15,24 +19,25 @@ class TestCase(TestBase):
    1.336 us [16523] |   strcmp("hello", "hello") = 0;
    4.017 us [16523] |   puts("hello") = 6;
   18.574 us [16523] | } /* main */
-""")
+""",
+        )
 
     # override calloc() to save 2nd argument only
     def setup(self):
-        self.option  = '-F main -A calloc@arg2 --auto-args'
-        self.exearg += ' hello'
+        self.option = "-F main -A calloc@arg2 --auto-args"
+        self.exearg += " hello"
 
     def sort(self, output):
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
             # ignore uftrace message on -finstrument-functions
-            if ln.startswith('uftrace:'):
+            if ln.startswith("uftrace:"):
                 continue
-            line = ln.split('|', 1)[-1]
-            func = re.sub(r'0x[0-9a-f]+', '0xADDR', line)
+            line = ln.split("|", 1)[-1]
+            func = re.sub(r"0x[0-9a-f]+", "0xADDR", line)
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t181_graph_full.py
+++ b/tests/t181_graph_full.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'forkexec', result="""
+        TestBase.__init__(
+            self,
+            "forkexec",
+            result="""
 # Function Call Graph for 't-abc' (session: 327202376e209585)
 ========== FUNCTION CALL GRAPH ==========
    5.824 us : (1) t-abc
@@ -23,24 +27,29 @@ class TestCase(TestBase):
    3.527 ms :  +-(1) waitpid
             :  | 
             :  +-(1) execl
-""", sort='graph')
+""",
+            sort="graph",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        ret  = TestBase.build(self, 'abc', cflags, ldflags)
+    def build(self, name, cflags="", ldflags=""):
+        ret = TestBase.build(self, "abc", cflags, ldflags)
         ret += TestBase.build(self, self.name, cflags, ldflags)
         return ret
 
     def prepare(self):
-        self.subcmd = 'record'
-        self.option = '-N __monstartup -N __cxa_atexit'
+        self.subcmd = "record"
+        self.option = "-N __monstartup -N __cxa_atexit"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'graph'
-        self.option = ''
-        self.exearg = ''
+        self.subcmd = "graph"
+        self.option = ""
+        self.exearg = ""
 
     def fixup(self, cflags, result):
-        return result.replace("readlink", """memset
+        return result.replace(
+            "readlink",
+            """memset
             :  | 
-   9.814 us :  +-(1) readlink""")
+   9.814 us :  +-(1) readlink""",
+        )

--- a/tests/t182_thread_exit.py
+++ b/tests/t182_thread_exit.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'thread-exit', ldflags='-pthread', result="""
+        TestBase.__init__(
+            self,
+            "thread-exit",
+            ldflags="-pthread",
+            result="""
 1.000000
 1.000000
 # DURATION    TID     FUNCTION
@@ -26,7 +31,8 @@ class TestCase(TestBase):
             [26832] |   pthread_join() {
    1.000 us [26832] |   } /* pthread_join */
  457.662 us [26832] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '--no-merge'
+        self.option = "--no-merge"

--- a/tests/t183_info_quote.py
+++ b/tests/t183_info_quote.py
@@ -4,9 +4,13 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'hello', """
+        TestBase.__init__(
+            self,
+            "hello",
+            """
 # system information
 # ==================
 # program version     : uftrace v0.8.1-133-g7f71
@@ -32,26 +36,26 @@ class TestCase(TestBase):
 # context switch      : 1 / 0 (voluntary / involuntary)
 # max rss             : 3284 KB
 # page fault          : 0 / 197 (major / minor)
-# disk iops           : 0 / 16 (read / write)""")
-
+# disk iops           : 0 / 16 (read / write)""",
+        )
 
     def prerun(self, timeout):
-        self.subcmd  = 'record'
+        self.subcmd = "record"
         self.exearg += ' "uftrace"'
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
 
-        f = open('/dev/null')
+        f = open("/dev/null")
         sp.call(record_cmd.split(), stdout=f, stderr=f)
         f.close()
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'info'
-        self.exearg = ''
+        self.subcmd = "info"
+        self.exearg = ""
 
     def sort(self, output):
-        for ln in output.split('\n'):
-            if ln.startswith('# cmdline'):
+        for ln in output.split("\n"):
+            if ln.startswith("# cmdline"):
                 return ln.split()[-1]
-        return ''
+        return ""

--- a/tests/t184_arg_enum.py
+++ b/tests/t184_arg_enum.py
@@ -4,9 +4,13 @@ import re
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'mmap', result="""
+        TestBase.__init__(
+            self,
+            "mmap",
+            result="""
 # DURATION    TID     FUNCTION
             [14885] | main() {
             [14885] |   foo() {
@@ -17,30 +21,31 @@ class TestCase(TestBase):
    3.120 us [14885] |     close(FD) = 0;
   36.529 us [14885] |   } /* foo */
   37.849 us [14885] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-F main --auto-args'
+        self.option = "-F main --auto-args"
 
     def sort(self, output):
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            line = ln.split('|', 1)[-1]
+            line = ln.split("|", 1)[-1]
 
             # address might be different, so replace it as 0xADDR for comparison.
-            func = re.sub(r'0x[0-9a-f]+', '0xADDR', line)
+            func = re.sub(r"0x[0-9a-f]+", "0xADDR", line)
 
             # fd number might be different, so replace it as FD for comparison.
-            func = re.sub(r'O_RDONLY\) = [0-9]+', 'O_RDONLY) = FD', func)
-            func = re.sub(r'MAP_PRIVATE, [0-9]+, 0', 'MAP_PRIVATE, FD, 0', func)
-            func = re.sub(r'close\([0-9]+\)', 'close(FD)', func)
+            func = re.sub(r"O_RDONLY\) = [0-9]+", "O_RDONLY) = FD", func)
+            func = re.sub(r"MAP_PRIVATE, [0-9]+, 0", "MAP_PRIVATE, FD, 0", func)
+            func = re.sub(r"close\([0-9]+\)", "close(FD)", func)
 
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)
 
     def fixup(self, cflags, result):
-        return result.replace('5', '4')
+        return result.replace("5", "4")

--- a/tests/t185_exception2.py
+++ b/tests/t185_exception2.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'exception2', lang='C++', result="""
+        TestBase.__init__(
+            self,
+            "exception2",
+            lang="C++",
+            result="""
 # DURATION     TID     FUNCTION
             [ 25279] | _GLOBAL__sub_I__Z3foov() {
             [ 25279] |   __static_initialization_and_destruction_0() {
@@ -17,7 +22,8 @@ class TestCase(TestBase):
   22.451 us [ 25279] |   } /* foo */
    0.087 us [ 25279] |   bar();
   23.092 us [ 25279] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-N personality_v.'
+        self.option = "-N personality_v."

--- a/tests/t186_exception3.py
+++ b/tests/t186_exception3.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'exception3', lang='C++', result="""
+        TestBase.__init__(
+            self,
+            "exception3",
+            lang="C++",
+            result="""
 # DURATION     TID     FUNCTION
             [ 16014] | main() {
    0.205 us [ 16014] |   A::A();
@@ -45,7 +50,8 @@ class TestCase(TestBase):
   14.698 us [ 16014] |     } /* bar */
   14.948 us [ 16014] |   } /* catch_exc */
   85.226 us [ 16014] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-N personality_v.'
+        self.option = "-N personality_v."

--- a/tests/t187_graph_field.py
+++ b/tests/t187_graph_field.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sort', """
+        TestBase.__init__(
+            self,
+            "sort",
+            """
 # Function Call Graph for 'main' (session: 67af3e650b051216)
 =============== BACKTRACE ===============
  backtrace #0: hit 1, time  10.148 ms
@@ -18,13 +22,15 @@ class TestCase(TestBase):
                                        :  | 
    10.094 ms   13.365 us  560e956bd802 :  +-(1) bar
    10.081 ms   10.081 ms  560e956bd608 :    (1) usleep
-""", sort='graph')
+""",
+            sort="graph",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'graph'
-        self.option = '-f +self,addr'
-        self.exearg = 'main'
+        self.subcmd = "graph"
+        self.option = "-f +self,addr"
+        self.exearg = "main"

--- a/tests/t188_graph_field_none.py
+++ b/tests/t188_graph_field_none.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sort', """
+        TestBase.__init__(
+            self,
+            "sort",
+            """
 # Function Call Graph for 'main' (session: 6085c5f021e501d0)
 =============== BACKTRACE ===============
  backtrace #0: hit 1, time  10.321 ms
@@ -18,13 +22,15 @@ class TestCase(TestBase):
  +-(1) bar
    (1) usleep
 
-""", sort='graph')
+""",
+            sort="graph",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'graph'
-        self.option = '-f none'
-        self.exearg = 'main'
+        self.subcmd = "graph"
+        self.option = "-f none"
+        self.exearg = "main"

--- a/tests/t189_replay_field2.py
+++ b/tests/t189_replay_field2.py
@@ -4,9 +4,15 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'taskname', ldflags='-pthread', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "taskname",
+            ldflags="-pthread",
+            serial=True,
+            result="""
 #      TASK NAME   FUNCTION
       t-taskname | main() {
       t-taskname |   task_name1() {
@@ -19,28 +25,29 @@ class TestCase(TestBase):
              bar |     } /* pthread_setname_np */
              bar |   } /* task_name2 */
              bar | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_perf_paranoid(self):
             return TestBase.TEST_SKIP
 
-        self.subcmd = 'record'
-        self.option = '-E linux:task-name'
+        self.subcmd = "record"
+        self.option = "-E linux:task-name"
 
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-F main -f task'
+        self.subcmd = "replay"
+        self.option = "-F main -f task"
 
     def sort(self, output, ignore_children=False):
         result = []
-        for ln in output.split('\n'):
-            if ln.strip() == '':
-                continue;
+        for ln in output.split("\n"):
+            if ln.strip() == "":
+                continue
             result.append(ln)
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t190_trigger_autoargs.py
+++ b/tests/t190_trigger_autoargs.py
@@ -2,17 +2,22 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'autoargs', result="""hello
+        TestBase.__init__(
+            self,
+            "autoargs",
+            result="""hello
 # DURATION    TID     FUNCTION
             [16523] | main() {
    2.670 us [16523] |   strlen();
    1.336 us [16523] |   strcmp("hello", "hello") = 0;
    4.017 us [16523] |   puts();
   18.574 us [16523] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option  = '-F main -T calloc@trace-off -T strcmp@trace-on,auto-args'
-        self.exearg += ' hello'
+        self.option = "-F main -T calloc@trace-off -T strcmp@trace-on,auto-args"
+        self.exearg += " hello"

--- a/tests/t191_posix_spawn.py
+++ b/tests/t191_posix_spawn.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'posix_spawn', """
+        TestBase.__init__(
+            self,
+            "posix_spawn",
+            """
 # DURATION    TID     FUNCTION
             [ 9874] | main() {
  142.145 us [ 9874] |   posix_spawn();
@@ -28,13 +32,14 @@ class TestCase(TestBase):
    2.515 ms [ 9874] |   } /* waitpid */
    2.708 ms [ 9874] | } /* main */
 
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        ret  = TestBase.build(self, 'abc', cflags, ldflags)
-        ret += TestBase.build(self, 'openclose', cflags, ldflags)
+    def build(self, name, cflags="", ldflags=""):
+        ret = TestBase.build(self, "abc", cflags, ldflags)
+        ret += TestBase.build(self, "openclose", cflags, ldflags)
         ret += TestBase.build(self, self.name, cflags, ldflags)
         return ret
 
     def setup(self):
-        self.option = '-F main'
+        self.option = "-F main"

--- a/tests/t192_lib_name.py
+++ b/tests/t192_lib_name.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'nest-libcall', """1
+        TestBase.__init__(
+            self,
+            "nest-libcall",
+            """1
 # DURATION     TID        MODULE NAME   FUNCTION
             [ 26884]   t-nest-libcall | main() {
             [ 26884]   t-nest-libcall |   lib_a@libabc_test_lib.so() {
@@ -14,16 +18,17 @@ class TestCase(TestBase):
    0.880 us [ 26884]        libfoo.so |     AAA::bar@libfoo.so();
    2.423 us [ 26884]   t-nest-libcall |   } /* foo@libfoo.so */
   13.722 us [ 26884]   t-nest-libcall | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if TestBase.build_libabc(self, '', '') != 0:
+    def build(self, name, cflags="", ldflags=""):
+        if TestBase.build_libabc(self, "", "") != 0:
             return TestBase.TEST_BUILD_FAIL
-        if TestBase.build_libfoo(self, 'foo', '', '') != 0:
+        if TestBase.build_libfoo(self, "foo", "", "") != 0:
             return TestBase.TEST_BUILD_FAIL
-        return TestBase.build_libmain(self, name, 's-nest-libcall.c',
-                                      ['libabc_test_lib.so', 'libfoo.so'],
-                                      cflags, ldflags)
+        return TestBase.build_libmain(
+            self, name, "s-nest-libcall.c", ["libabc_test_lib.so", "libfoo.so"], cflags, ldflags
+        )
 
     def setup(self):
         self.option = "--nest-libcall --libname -f +module"
@@ -40,8 +45,8 @@ class TestCase(TestBase):
         # ldd (GNU libc) 2.26    <-- use this
         # Copyright (C) 2017 Free Software Foundation, Inc.
         # ...
-        v = sp.check_output(["ldd", "--version"]).decode(errors='ignore')
-        ver = v.split('\n')[0].split(') ')[1]
+        v = sp.check_output(["ldd", "--version"]).decode(errors="ignore")
+        ver = v.split("\n")[0].split(") ")[1]
         ver.strip()
 
         return re.sub("libc-[\d.]+.so", "libc-%s.so" % ver, result)

--- a/tests/t193_read_pmu_cycle.py
+++ b/tests/t193_read_pmu_cycle.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
             [32417] | main() {
             [32417] |   a() {
@@ -17,7 +21,8 @@ class TestCase(TestBase):
   16.914 us [32417] |     } /* b */
   17.083 us [32417] |   } /* a */
   17.873 us [32417] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_perf_paranoid(self):
@@ -25,20 +30,20 @@ class TestCase(TestBase):
         return TestCase.TEST_SUCCESS
 
     def setup(self):
-        self.option = '-F main -T b@read=pmu-cycle'
+        self.option = "-F main -T b@read=pmu-cycle"
 
     def sort(self, output):
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            func = ln.split('|', 1)[-1]
+            func = ln.split("|", 1)[-1]
             # remove actual numbers in pmu-cycle
-            if func.find('read:pmu-cycle') > 0:
-                func = '       /* read:pmu-cycle */'
-            if func.find('diff:pmu-cycle') > 0:
-                func = '       /* diff:pmu-cycle */'
+            if func.find("read:pmu-cycle") > 0:
+                func = "       /* read:pmu-cycle */"
+            if func.find("diff:pmu-cycle") > 0:
+                func = "       /* diff:pmu-cycle */"
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t194_read_pmu_cache.py
+++ b/tests/t194_read_pmu_cache.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
             [32417] | main() {
             [32417] |   a() {
@@ -17,7 +21,8 @@ class TestCase(TestBase):
   16.914 us [32417] |     } /* b */
   17.083 us [32417] |   } /* a */
   17.873 us [32417] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_perf_paranoid(self):
@@ -25,20 +30,20 @@ class TestCase(TestBase):
         return TestCase.TEST_SUCCESS
 
     def setup(self):
-        self.option = '-F main -T b@read=pmu-cache'
+        self.option = "-F main -T b@read=pmu-cache"
 
     def sort(self, output):
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            func = ln.split('|', 1)[-1]
+            func = ln.split("|", 1)[-1]
             # remove actual numbers in pmu-cache
-            if func.find('read:pmu-cache') > 0:
-                func = '       /* read:pmu-cache */'
-            if func.find('diff:pmu-cache') > 0:
-                func = '       /* diff:pmu-cache */'
+            if func.find("read:pmu-cache") > 0:
+                func = "       /* read:pmu-cache */"
+            if func.find("diff:pmu-cache") > 0:
+                func = "       /* diff:pmu-cache */"
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t195_read_pmu_branch.py
+++ b/tests/t195_read_pmu_branch.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
             [32417] | main() {
             [32417] |   a() {
@@ -17,7 +21,8 @@ class TestCase(TestBase):
   16.914 us [32417] |     } /* b */
   17.083 us [32417] |   } /* a */
   17.873 us [32417] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_perf_paranoid(self):
@@ -25,20 +30,20 @@ class TestCase(TestBase):
         return TestCase.TEST_SUCCESS
 
     def setup(self):
-        self.option = '-F main -T b@read=pmu-branch'
+        self.option = "-F main -T b@read=pmu-branch"
 
     def sort(self, output):
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            func = ln.split('|', 1)[-1]
+            func = ln.split("|", 1)[-1]
             # remove actual numbers in pmu-branch
-            if func.find('read:pmu-branch') > 0:
-                func = '       /* read:pmu-branch */'
-            if func.find('diff:pmu-branch') > 0:
-                func = '       /* diff:pmu-branch */'
+            if func.find("read:pmu-branch") > 0:
+                func = "       /* read:pmu-branch */"
+            if func.find("diff:pmu-branch") > 0:
+                func = "       /* diff:pmu-branch */"
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t196_chrome_taskname.py
+++ b/tests/t196_chrome_taskname.py
@@ -4,9 +4,15 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'taskname', ldflags='-pthread', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "taskname",
+            ldflags="-pthread",
+            serial=True,
+            result="""
 {"traceEvents":[
 {"ts":0,"ph":"M","pid":4694,"name":"process_name","args":{"name":"[4694] bar"}},
 {"ts":0,"ph":"M","pid":4694,"name":"thread_name","args":{"name":"[4694] bar"}},
@@ -30,24 +36,26 @@ class TestCase(TestBase):
 "command_line":"../uftrace record --no-pager --no-event -L.. t-taskname",
 "recorded_time":"Tue Jan 30 16:05:24 2018"
 } }
-""", sort='chrome')
+""",
+            sort="chrome",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_perf_paranoid(self):
             return TestBase.TEST_SKIP
 
-        self.subcmd = 'record'
-        self.option = '-E linux:task-name'
+        self.subcmd = "record"
+        self.option = "-E linux:task-name"
 
         record_cmd = TestBase.runcmd(self)
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'dump'
-        self.option = '--chrome -F main'
+        self.subcmd = "dump"
+        self.option = "--chrome -F main"
 
     def runcmd(self):
         cmd = TestBase.runcmd(self)
-        return cmd.replace('--no-event', '')
+        return cmd.replace("--no-event", "")

--- a/tests/t197_filter_glob.py
+++ b/tests/t197_filter_glob.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'allocfree', """
+        TestBase.__init__(
+            self,
+            "allocfree",
+            """
 # DURATION    TID     FUNCTION
             [11583] | alloc1() {
             [11583] |   alloc2() {
@@ -17,7 +21,9 @@ class TestCase(TestBase):
    4.239 us [11583] |     } /* alloc3 */
    5.016 us [11583] |   } /* alloc2 */
  104.119 us [11583] | } /* alloc1 */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def setup(self):
         self.option = '-F "alloc*"'

--- a/tests/t198_lib_arg_float.py
+++ b/tests/t198_lib_arg_float.py
@@ -2,24 +2,29 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'float-libcall', result="""
+        TestBase.__init__(
+            self,
+            "float-libcall",
+            result="""
 # DURATION    TID     FUNCTION
             [18276] | main() {
    0.371 ms [18276] |   expf(1.000000) = 2.718282;
    0.118 ms [18276] |   log(2.718282) = 1.000000;
    3.281 ms [18276] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         ldflags += " -lm"
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option  = '-A "expf@fparg1/32" -R "expf@retval/f32" '
+        self.option = '-A "expf@fparg1/32" -R "expf@retval/f32" '
         self.option += '-A "log@fparg1/64"  -R "log@retval/f64" '

--- a/tests/t199_script_info.py
+++ b/tests/t199_script_info.py
@@ -4,37 +4,42 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 False
 v0.8.3-10/gfbfac3
 ('foo', 'bar')
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        self.subcmd = 'script'
-        self.option = ''
-        self.exearg = ''
+        self.subcmd = "script"
+        self.option = ""
+        self.exearg = ""
 
         script_cmd = self.runcmd()
         p = sp.Popen(script_cmd.split(), stdout=sp.PIPE, stderr=sp.PIPE)
-        if p.communicate()[1].decode(errors='ignore').startswith('WARN:'):
+        if p.communicate()[1].decode(errors="ignore").startswith("WARN:"):
             return TestBase.TEST_SKIP
 
-        self.subcmd = 'record'
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.exearg = "t-" + self.name
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'script'
-        self.option = '-F main -S %s/scripts/info.py' % self.basedir
-        self.exearg = 'foo bar'
+        self.subcmd = "script"
+        self.option = "-F main -S %s/scripts/info.py" % self.basedir
+        self.exearg = "foo bar"
 
     def sort(self, output):
-        result = output.strip().split('\n')
-        result[1] = 'uftrace version'  # overwrite the version number
-        return '\n'.join(result)
+        result = output.strip().split("\n")
+        result[1] = "uftrace version"  # overwrite the version number
+        return "\n".join(result)

--- a/tests/t200_lib_dlopen2.py
+++ b/tests/t200_lib_dlopen2.py
@@ -4,11 +4,17 @@ import os
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     """This tests when dlopen() loads multiple libraries (libbar and libbaz)
-       at once.  The Parent code is in libbar while Child is in libbaz."""
+    at once.  The Parent code is in libbar while Child is in libbaz."""
+
     def __init__(self):
-        TestBase.__init__(self, 'dlopen2', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "dlopen2",
+            lang="C++",
+            result="""
 # DURATION     TID     FUNCTION
             [ 29510] | main() {
  398.509 us [ 29510] |   dlopen();
@@ -21,16 +27,16 @@ class TestCase(TestBase):
    0.133 us [ 29510] |   Child::func();
   48.519 us [ 29510] |   dlclose();
  465.432 us [ 29510] | } /* main */
-""")
-        os.environ['LD_LIBRARY_PATH'] = "."
+""",
+        )
+        os.environ["LD_LIBRARY_PATH"] = "."
 
-    def build(self, name, cflags='', ldflags=''):
-        if TestBase.build_libfoo(self, 'bar', cflags, ldflags) != 0:
+    def build(self, name, cflags="", ldflags=""):
+        if TestBase.build_libfoo(self, "bar", cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
-        if TestBase.build_libfoo(self, 'baz', cflags, ldflags + ' -L. -lbar') != 0:
+        if TestBase.build_libfoo(self, "baz", cflags, ldflags + " -L. -lbar") != 0:
             return TestBase.TEST_BUILD_FAIL
-        return TestBase.build_libmain(self, name, 's-dlopen2.cpp', ['libdl.so'],
-                                      cflags, ldflags)
+        return TestBase.build_libmain(self, name, "s-dlopen2.cpp", ["libdl.so"], cflags, ldflags)
 
     def setup(self):
-        self.option = '-F a'
+        self.option = "-F a"

--- a/tests/t201_arg_dwarf1.py
+++ b/tests/t201_arg_dwarf1.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'dwarf1', """
+        TestBase.__init__(
+            self,
+            "dwarf1",
+            """
 # DURATION     TID     FUNCTION
             [ 29831] | main() {
    0.495 us [ 29831] |   foo(-1, 32768) = 32767;
@@ -15,15 +19,17 @@ class TestCase(TestBase):
    0.323 us [ 29831] |     foo(1, -1) = 0;
    1.291 us [ 29831] |   } /* baz */
  449.927 us [ 29831] | } = 0; /* main */
-""", cflags='-g')
+""",
+            cflags="-g",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-A . -R. -F main'
+        self.option = "-A . -R. -F main"

--- a/tests/t202_arg_dwarf2.py
+++ b/tests/t202_arg_dwarf2.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'dwarf2', """
+        TestBase.__init__(
+            self,
+            "dwarf2",
+            """
 # DURATION     TID     FUNCTION
             [ 23714] | main() {
  482.922 us [ 23714] |   A::A(0x7ffecd0fe6e0, empty{}, FOO, 4, "debug info test");
@@ -12,33 +16,36 @@ class TestCase(TestBase):
    5.713 us [ 23714] |   std::sort(0x7ffecd0fe700, 0x7ffecd0fe714, less{...});
    5.853 us [ 23714] |   std::sort(0x7ffecd0fe700, 0x7ffecd0fe714, {...});
  515.511 us [ 23714] | } = 0; /* main */
-""", lang='C++', cflags='-g -std=c++11')
+""",
+            lang="C++",
+            cflags="-g -std=c++11",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-A . -R . -D2 -F main'
+        self.option = "-A . -R . -D2 -F main"
 
     def sort(self, output):
         import re
 
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            line = ln.split('|', 1)[-1]
-            func = re.sub(r'0x[0-9a-f]+', '0xADDR', line)
+            line = ln.split("|", 1)[-1]
+            func = re.sub(r"0x[0-9a-f]+", "0xADDR", line)
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)
 
     def fixup(self, cflags, result):
         # -O2 makes specialization of std::sort() (without 3rd arg)
-        return result.replace(', 0x7ffecd0fe700)', ')')
+        return result.replace(", 0x7ffecd0fe700)", ")")

--- a/tests/t203_arg_dwarf3.py
+++ b/tests/t203_arg_dwarf3.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'dwarf3', """
+        TestBase.__init__(
+            self,
+            "dwarf3",
+            """
 # DURATION     TID     FUNCTION
             [ 28332] | main() {
             [ 28332] |   C::C(0x7ffce3e4fe30, 1, "debug info") {
@@ -22,29 +26,32 @@ class TestCase(TestBase):
    1.332 us [ 28332] |     } /* C::C */
    2.225 us [ 28332] |   } = C{...}; /* foo */
  457.250 us [ 28332] | } = 0; /* main */
-""", lang='C++', cflags='-g')
+""",
+            lang="C++",
+            cflags="-g",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-A . -R . -F main'
+        self.option = "-A . -R . -F main"
 
     def sort(self, output):
         import re
 
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            line = ln.split('|', 1)[-1]
-            func = re.sub(r'0x[0-9a-f]+', '0xADDR', line)
+            line = ln.split("|", 1)[-1]
+            func = re.sub(r"0x[0-9a-f]+", "0xADDR", line)
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t204_arg_dwarf4.py
+++ b/tests/t204_arg_dwarf4.py
@@ -2,38 +2,45 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'exception4', """
+        TestBase.__init__(
+            self,
+            "exception4",
+            """
 # DURATION     TID     FUNCTION
             [ 15296] | main() {
             [ 15296] |   foo(1) {
    2.490 us [ 15296] |     __cxa_allocate_exception();
   47.390 us [ 15296] |   } /* foo */
   51.560 us [ 15296] | } = 0; /* main */
-""", lang='C++', cflags='-g')
+""",
+            lang="C++",
+            cflags="-g",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-A . -R . -F main -N personality_v.'
+        self.option = "-A . -R . -F main -N personality_v."
 
     def sort(self, output):
         import re
 
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            line = ln.split('|', 1)[-1]
-            func = re.sub(r'0x[0-9a-f]+', '0xADDR', line)
+            line = ln.split("|", 1)[-1]
+            func = re.sub(r"0x[0-9a-f]+", "0xADDR", line)
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t205_arg_auto4.py
+++ b/tests/t205_arg_auto4.py
@@ -4,9 +4,13 @@ import re
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'autoargs', result="""autoargs test
+        TestBase.__init__(
+            self,
+            "autoargs",
+            result="""autoargs test
 # DURATION     TID     FUNCTION
             [ 16523] | main(2, 0xADDR) {
    2.670 us [ 16523] |   strlen("autoargs test") = 13;
@@ -15,29 +19,31 @@ class TestCase(TestBase):
    1.336 us [ 16523] |   strcmp("hello", "bye") = 6;
    4.017 us [ 16523] |   puts("autoargs test") = 14;
   18.574 us [ 16523] | } = 0; /* main */
-""", cflags='-g')
+""",
+            cflags="-g",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option  = '-F main --auto-args'
-        self.exearg += ' bye'
+        self.option = "-F main --auto-args"
+        self.exearg += " bye"
 
     def sort(self, output):
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            line = ln.split('|', 1)[-1]
-            func = re.sub(r'0x[0-9a-f]+', '0xADDR', line)
+            line = ln.split("|", 1)[-1]
+            func = re.sub(r"0x[0-9a-f]+", "0xADDR", line)
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t206_arg_enum2.py
+++ b/tests/t206_arg_enum2.py
@@ -4,37 +4,43 @@ import re
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'enum', result="""
+        TestBase.__init__(
+            self,
+            "enum",
+            result="""
 # DURATION     TID     FUNCTION
             [ 14885] | main() {
    6.183 us [ 14885] |   kill(0, SIGNULL);
    3.120 us [ 14885] |   foo(0);
    4.095 us [ 14885] |   foo(XXX);
   17.849 us [ 14885] | } /* main */
-""", cflags='-g')
+""",
+            cflags="-g",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-F main -A kill -A foo'
+        self.option = "-F main -A kill -A foo"
 
     def sort(self, output):
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            line = ln.split('|', 1)[-1]
-            func = re.sub(r'0x[0-9a-f]+', '0xADDR', line)
+            line = ln.split("|", 1)[-1]
+            func = re.sub(r"0x[0-9a-f]+", "0xADDR", line)
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t207_dump_graphviz.py
+++ b/tests/t207_dump_graphviz.py
@@ -4,9 +4,13 @@ import os.path
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """digraph "%s" {
+        TestBase.__init__(
+            self,
+            "abc",
+            """digraph "%s" {
 
         # Attributes
         splines=ortho;
@@ -20,25 +24,26 @@ class TestCase(TestBase):
         "a" -> "b" [xlabel = "Calls : 1"]
         "b" -> "c" [xlabel = "Calls : 1"]
         }
-        """)
+        """,
+        )
         self.result = self.result % os.path.join(self.test_dir, "t-abc")
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'dump'
-        self.option = '-F main -D 4 --graphviz'
+        self.subcmd = "dump"
+        self.option = "-F main -D 4 --graphviz"
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for line, ln in enumerate(output.split('\n')):
+        for line, ln in enumerate(output.split("\n")):
             # remove all comments
             ln = ln.strip()
-            if ln.startswith('#'):
+            if ln.startswith("#"):
                 continue
             result.append(ln)
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t208_watch_cpu.py
+++ b/tests/t208_watch_cpu.py
@@ -4,9 +4,14 @@ import re
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'chcpu', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "chcpu",
+            serial=True,
+            result="""
 # DURATION     TID     FUNCTION
             [ 19611] | main() {
             [ 19611] |   /* watch:cpu (cpu=6) */
@@ -21,7 +26,8 @@ class TestCase(TestBase):
             [ 19611] |     /* watch:cpu (cpu=6) */
   37.281 us [ 19611] |   } /* sched_setaffinity */
  142.912 us [ 19611] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
         # ignore unexpected memset on ARM (raspbian)
@@ -29,15 +35,15 @@ class TestCase(TestBase):
 
     def sort(self, output):
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            line = ln.split('|', 1)[-1]
-            func = re.sub(r'cpu=[0-9a-f]+', 'cpu=N', line)
+            line = ln.split("|", 1)[-1]
+            func = re.sub(r"cpu=[0-9a-f]+", "cpu=N", line)
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)
 
     def fixup(self, cflags, result):
-        return re.sub(r'.*/\* linux:schedule \*/\n', '', result)
+        return re.sub(r".*/\* linux:schedule \*/\n", "", result)

--- a/tests/t209_filter_caller.py
+++ b/tests/t209_filter_caller.py
@@ -2,16 +2,21 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', """
+        TestBase.__init__(
+            self,
+            "sleep",
+            """
 # DURATION     TID     FUNCTION
             [ 30702] | main() {
             [ 30702] |   foo() {
    6.933 us [ 30702] |     mem_alloc();
    2.139 ms [ 30702] |   } /* foo */
    2.141 ms [ 30702] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-C mem_alloc'
+        self.option = "-C mem_alloc"

--- a/tests/t210_filter_time_C.py
+++ b/tests/t210_filter_time_C.py
@@ -2,16 +2,21 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            result="""
 # DURATION    TID     FUNCTION
             [18219] | main() {
             [18219] |   foo() {
    2.095 ms [18219] |     bar();
    2.106 ms [18219] |   } /* foo */
    2.107 ms [18219] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-t 1ms -C bar'
+        self.option = "-t 1ms -C bar"

--- a/tests/t211_replay_filter_C.py
+++ b/tests/t211_replay_filter_C.py
@@ -2,21 +2,26 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep', result="""
+        TestBase.__init__(
+            self,
+            "sleep",
+            result="""
 # DURATION     TID     FUNCTION
             [ 30702] | main() {
             [ 30702] |   foo() {
    6.933 us [ 30702] |     mem_alloc();
    2.139 ms [ 30702] |   } /* foo */
    2.141 ms [ 30702] | } /* main */
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-C mem_alloc'
+        self.subcmd = "replay"
+        self.option = "-C mem_alloc"

--- a/tests/t212_noplt_libcall.py
+++ b/tests/t212_noplt_libcall.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION     TID     FUNCTION
             [ 28141] | main() {
             [ 28141] |   a() {
@@ -15,7 +19,10 @@ class TestCase(TestBase):
    1.915 us [ 28141] |     } /* b */
    2.405 us [ 28141] |   } /* a */
    3.005 us [ 28141] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        return TestBase.build(self, name, cflags + " -fno-plt", ldflags + " -Wl,-z,now -Wl,-z,relro")
+    def build(self, name, cflags="", ldflags=""):
+        return TestBase.build(
+            self, name, cflags + " -fno-plt", ldflags + " -Wl,-z,now -Wl,-z,relro"
+        )

--- a/tests/t213_arg_symbol.py
+++ b/tests/t213_arg_symbol.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'data', result="""
+        TestBase.__init__(
+            self,
+            "data",
+            result="""
 # DURATION     TID     FUNCTION
             [ 16187] | main() {
    0.967 us [ 16187] |   foo(&static_var, 1);
@@ -12,16 +16,17 @@ class TestCase(TestBase):
    0.143 us [ 16187] |   foo(&weak_var, 3);
    0.166 us [ 16187] |   filecmp(&_IO_2_1_stdout_, &_IO_2_1_stderr_);
    3.189 us [ 16187] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-A foo@arg1/p,arg2 -A filecmp@arg1/p,arg2/p'
+        self.option = "-A foo@arg1/p,arg2 -A filecmp@arg1/p,arg2/p"

--- a/tests/t214_signal_trigger.py
+++ b/tests/t214_signal_trigger.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'signal', """
+        TestBase.__init__(
+            self,
+            "signal",
+            """
 # DURATION     TID     FUNCTION
             [ 11892] | main() {
    0.241 us [ 11892] |   foo();
@@ -20,11 +24,15 @@ task: 11892
 [2] sighandler
 [1] raise
 [0] main
-""")
+""",
+        )
 
     def setup(self):
         self.option = "--signal SIGUSR1@finish"
 
     def fixup(self, cflags, result):
-        return result.replace("""     } /* sighandler */
-""", "")
+        return result.replace(
+            """     } /* sighandler */
+""",
+            "",
+        )

--- a/tests/t215_no_libcall_replay.py
+++ b/tests/t215_no_libcall_replay.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'signal', """
+        TestBase.__init__(
+            self,
+            "signal",
+            """
 # DURATION     TID     FUNCTION
             [ 73755] | main() {
    0.236 us [ 73755] |   foo();
@@ -13,12 +17,13 @@ class TestCase(TestBase):
    0.734 us [ 73755] |   } /* sighandler */
    0.117 us [ 73755] |   foo();
   18.227 us [ 73755] | } /* main */
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '--no-libcall'
+        self.subcmd = "replay"
+        self.option = "--no-libcall"

--- a/tests/t216_no_libcall_report.py
+++ b/tests/t216_no_libcall_report.py
@@ -2,21 +2,27 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'signal', """
+        TestBase.__init__(
+            self,
+            "signal",
+            """
   Total time   Self time       Calls  Function
   ==========  ==========  ==========  ====================
     0.125 us    0.125 us           2  foo
     9.500 us    0.459 us           1  main
     0.209 us    0.126 us           1  sighandler
     0.083 us    0.083 us           1  bar
-""", sort='report')
+""",
+            sort="report",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '--no-libcall -s call,total'
+        self.subcmd = "report"
+        self.option = "--no-libcall -s call,total"

--- a/tests/t217_no_libcall_dump.py
+++ b/tests/t217_no_libcall_dump.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'signal', """
+        TestBase.__init__(
+            self,
+            "signal",
+            """
 uftrace file header: magic         = 4674726163652100
 uftrace file header: version       = 4
 uftrace file header: header size   = 40
@@ -24,12 +28,14 @@ reading 73755.dat
 50895.869969790  73755: [entry] foo(40071f) depth: 1
 50895.869969907  73755: [exit ] foo(40071f) depth: 1
 50895.869970227  73755: [exit ] main(400787) depth: 0
-""", sort='dump')
+""",
+            sort="dump",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'dump'
-        self.option = '--no-libcall'
+        self.subcmd = "dump"
+        self.option = "--no-libcall"

--- a/tests/t218_no_libcall_graph.py
+++ b/tests/t218_no_libcall_graph.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'signal', """
+        TestBase.__init__(
+            self,
+            "signal",
+            """
 # Function Call Graph for 't-signal' (session: 0fa6f0e678964bde)
 ========== FUNCTION CALL GRAPH ==========
 # TOTAL TIME   FUNCTION
@@ -14,13 +18,15 @@ class TestCase(TestBase):
              :  | 
     0.734 us :  +-(1) sighandler
     0.144 us :    (1) bar
-""", sort='graph')
+""",
+            sort="graph",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'graph'
-        self.option = '--no-libcall'
-        self.exearg = ''
+        self.subcmd = "graph"
+        self.option = "--no-libcall"
+        self.exearg = ""

--- a/tests/t219_no_libcall_script.py
+++ b/tests/t219_no_libcall_script.py
@@ -4,9 +4,13 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'signal', """
+        TestBase.__init__(
+            self,
+            "signal",
+            """
 uftrace_begin(ctx)
   record  : False
   version : v0.9.1-161-g13755 ( dwarf python tui perf sched )
@@ -24,27 +28,29 @@ uftrace_begin(ctx)
 50895.869970227  73755: [exit ] main(400787) depth: 0
 
 uftrace_end()
-""", sort='dump')
+""",
+            sort="dump",
+        )
 
     def prerun(self, timeout):
-        self.subcmd = 'script'
-        self.option = ''
-        self.exearg = ''
+        self.subcmd = "script"
+        self.option = ""
+        self.exearg = ""
 
         script_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + script_cmd)
+        self.pr_debug("prerun command: " + script_cmd)
         p = sp.Popen(script_cmd.split(), stdout=sp.PIPE, stderr=sp.PIPE)
-        if p.communicate()[1].decode(errors='ignore').startswith('WARN:'):
+        if p.communicate()[1].decode(errors="ignore").startswith("WARN:"):
             return TestBase.TEST_SKIP
 
-        self.subcmd = 'record'
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.exearg = "t-" + self.name
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'script'
-        self.option = '-S %s/scripts/dump.py --no-libcall' % self.basedir
-        self.exearg = ''
+        self.subcmd = "script"
+        self.option = "-S %s/scripts/dump.py --no-libcall" % self.basedir
+        self.exearg = ""

--- a/tests/t220_trace_script.py
+++ b/tests/t220_trace_script.py
@@ -7,9 +7,13 @@ from runtest import TestBase
 
 TEST_SCRIPT = "./test-script.sh"
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
  133.697 us [28137] | fork();
             [28141] | } /* fork */
@@ -22,12 +26,16 @@ class TestCase(TestBase):
    1.915 us [28141] |     } /* b */
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
         f = open(TEST_SCRIPT, "w")
-        f.write("""#!/bin/sh
+        f.write(
+            """#!/bin/sh
 ./t-abc
-""")
+"""
+        )
         f.close()
         os.chmod(TEST_SCRIPT, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)
 

--- a/tests/t221_taskname_time.py
+++ b/tests/t221_taskname_time.py
@@ -2,9 +2,15 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'taskname', ldflags='-pthread', serial=True, result="""
+        TestBase.__init__(
+            self,
+            "taskname",
+            ldflags="-pthread",
+            serial=True,
+            result="""
 #      TASK NAME   FUNCTION
         taskname | main() {
         taskname |   task_name1() {
@@ -19,7 +25,9 @@ class TestCase(TestBase):
              bar |     } /* pthread_setname_np */
              bar |   } /* task_name2 */
              bar | } /* main */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_perf_paranoid(self):
@@ -27,4 +35,4 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.option = '-F main -E linux:task-name -t 1'
+        self.option = "-F main -E linux:task-name -t 1"

--- a/tests/t222_external_data.py
+++ b/tests/t222_external_data.py
@@ -5,9 +5,13 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
             [28141] | main() {
             [28141] | /* external-data: user message */
@@ -19,20 +23,21 @@ class TestCase(TestBase):
    1.915 us [28141] |     } /* b */
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        self.subcmd = 'record'
-        self.option = ''
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.option = ""
+        self.exearg = "t-" + self.name
 
         record_cmd = TestBase.runcmd(self)
         self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
-        self.subcmd = 'replay'
-        self.option = '-F main -f time'
-        self.exearg = ''
+        self.subcmd = "replay"
+        self.option = "-F main -f time"
+        self.exearg = ""
         replay_cmd = TestBase.runcmd(self)
         self.pr_debug("prerun command: " + replay_cmd)
 
@@ -40,29 +45,29 @@ class TestCase(TestBase):
         if p.wait() != 0:
             return TestBase.TEST_NONZERO_RETURN
 
-        output = p.communicate()[0].decode(errors='ignore')
-        for l in output.split('\n'):
-            if l.startswith('#'):
-                continue;
+        output = p.communicate()[0].decode(errors="ignore")
+        for l in output.split("\n"):
+            if l.startswith("#"):
+                continue
             # parse first line to get the timestamp
-            t = l.split(' | ')[0].strip()
-            point = t.find('.')
-            nsec = int(t[point+1:point+10])
+            t = l.split(" | ")[0].strip()
+            point = t.find(".")
+            nsec = int(t[point + 1 : point + 10])
 
             # add the external data right after the first line
-            msg = '%s.%d %s\n' % (t[:point], nsec + 1, 'user message')
+            msg = "%s.%d %s\n" % (t[:point], nsec + 1, "user message")
 
-            data_file = open(os.path.join('uftrace.data', 'extern.dat'), 'w')
+            data_file = open(os.path.join("uftrace.data", "extern.dat"), "w")
             data_file.write(msg)
             data_file.close()
             break
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = ''
-        self.exearg = ''
+        self.subcmd = "replay"
+        self.option = ""
+        self.exearg = ""
 
     def runcmd(self):
         cmd = TestBase.runcmd(self)
-        return cmd.replace('--no-event', '')
+        return cmd.replace("--no-event", "")

--- a/tests/t223_dynamic_full.py
+++ b/tests/t223_dynamic_full.py
@@ -2,26 +2,31 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'dynamic', """
+        TestBase.__init__(
+            self,
+            "dynamic",
+            """
 # DURATION     TID     FUNCTION
          [ 63876] | main() {
 0.739 us [ 63876] |   foo();
 0.833 us [ 63876] |   bar();
 1.903 us [ 63876] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_arch_full_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
-    def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
-        cflags += ' -fno-pie -fno-plt'  # workaround of build failure
+    def build(self, name, cflags="", ldflags=""):
+        cflags = cflags.replace("-pg", "")
+        cflags = cflags.replace("-finstrument-functions", "")
+        cflags += " -fno-pie -fno-plt"  # workaround of build failure
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-P main -P foo -P bar --no-libcall'
+        self.option = "-P main -P foo -P bar --no-libcall"

--- a/tests/t224_dynamic_lib.py
+++ b/tests/t224_dynamic_lib.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'dynmain', """
+        TestBase.__init__(
+            self,
+            "dynmain",
+            """
 # DURATION     TID     FUNCTION
          [ 26661] | main() {
          [ 26661] |   lib_a() {
@@ -18,22 +22,29 @@ class TestCase(TestBase):
 1.266 us [ 26661] |     } /* lib_e */
 1.438 us [ 26661] |   } /* lib_d */
 7.607 us [ 26661] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_arch_full_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
-    def build(self, name, cflags='', ldflags=''):
-        if TestBase.build_notrace_lib(self, 'dyn1', 'libdyn1', cflags, ldflags) != 0:
+    def build(self, name, cflags="", ldflags=""):
+        if TestBase.build_notrace_lib(self, "dyn1", "libdyn1", cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
-        if TestBase.build_notrace_lib(self, 'dyn2', 'libdyn2', cflags, ldflags) != 0:
+        if TestBase.build_notrace_lib(self, "dyn2", "libdyn2", cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
 
-        return TestBase.build_libmain(self, name, 's-dynmain.c',
-                                      ['libdyn1.so', 'libdyn2.so'],
-                                      cflags, ldflags, instrument=False)
+        return TestBase.build_libmain(
+            self,
+            name,
+            "s-dynmain.c",
+            ["libdyn1.so", "libdyn2.so"],
+            cflags,
+            ldflags,
+            instrument=False,
+        )
 
     def setup(self):
-        self.option = '-Pmain -P.@libdyn1.so -P.@libdyn2.so --no-libcall'
+        self.option = "-Pmain -P.@libdyn1.so -P.@libdyn2.so --no-libcall"

--- a/tests/t225_dynamic_size.py
+++ b/tests/t225_dynamic_size.py
@@ -2,26 +2,31 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'unroll', """
+        TestBase.__init__(
+            self,
+            "unroll",
+            """
 # DURATION    TID     FUNCTION
             [ 72208] | main() {
    0.252 us [ 72208] |   big();
    1.802 us [ 72208] | } /* main */
 
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_arch_full_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
-    def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
-        cflags += ' -funroll-loops'
+    def build(self, name, cflags="", ldflags=""):
+        cflags = cflags.replace("-pg", "")
+        cflags = cflags.replace("-finstrument-functions", "")
+        cflags += " -funroll-loops"
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-P. -Z 100'
+        self.option = "-P. -Z 100"

--- a/tests/t226_default_opts.py
+++ b/tests/t226_default_opts.py
@@ -2,22 +2,27 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sleep2', result="""
+        TestBase.__init__(
+            self,
+            "sleep2",
+            result="""
 # DURATION     TID     FUNCTION
             [ 41487] | main() {
             [ 41487] |   foo() {
    5.107 ms [ 41487] |     usleep();
    8.220 ms [ 41487] |   } /* foo */
    9.336 ms [ 41487] | } /* main */
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
-        self.option = '-t 2ms'
+        self.subcmd = "record"
+        self.option = "-t 2ms"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '-t 4ms'
+        self.subcmd = "replay"
+        self.option = "-t 4ms"

--- a/tests/t227_read_pmu_cycle2.py
+++ b/tests/t227_read_pmu_cycle2.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION     TID     FUNCTION
             [ 32417] | main() {
             [ 32417] |   a() {
@@ -19,7 +23,8 @@ class TestCase(TestBase):
   16.914 us [ 32417] |     } /* b */
   17.083 us [ 32417] |   } /* a */
   17.873 us [ 32417] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_perf_paranoid(self):
@@ -31,16 +36,16 @@ class TestCase(TestBase):
 
     def sort(self, output):
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            func = ln.split('|', 1)[-1]
+            func = ln.split("|", 1)[-1]
             # remove actual numbers in pmu-cycle
-            if func.find('read:pmu-cycle') > 0:
-                func = '       /* read:pmu-cycle */'
-            if func.find('diff:pmu-cycle') > 0:
-                func = '       /* diff:pmu-cycle */'
+            if func.find("read:pmu-cycle") > 0:
+                func = "       /* read:pmu-cycle */"
+            if func.find("diff:pmu-cycle") > 0:
+                func = "       /* diff:pmu-cycle */"
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t228_read_pmu_cycle3.py
+++ b/tests/t228_read_pmu_cycle3.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', """
+        TestBase.__init__(
+            self,
+            "fork",
+            """
 # DURATION     TID     FUNCTION
             [  3309] | main() {
             [  3324] | a() {
@@ -25,7 +29,8 @@ class TestCase(TestBase):
  124.879 us [  3309] |     } /* b */
  125.839 us [  3309] |   } /* a */
    2.630 ms [  3309] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_perf_paranoid(self):
@@ -33,20 +38,20 @@ class TestCase(TestBase):
         return TestCase.TEST_SUCCESS
 
     def setup(self):
-        self.option = '-T c@read=pmu-cycle --no-libcall'
+        self.option = "-T c@read=pmu-cycle --no-libcall"
 
     def sort(self, output):
         result = []
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
-            func = ln.split('|', 1)[-1]
+            func = ln.split("|", 1)[-1]
             # remove actual numbers in pmu-cycle
-            if func.find('read:pmu-cycle') > 0:
-                func = '       /* read:pmu-cycle */'
-            if func.find('diff:pmu-cycle') > 0:
-                func = '       /* diff:pmu-cycle */'
+            if func.find("read:pmu-cycle") > 0:
+                func = "       /* read:pmu-cycle */"
+            if func.find("diff:pmu-cycle") > 0:
+                func = "       /* diff:pmu-cycle */"
             result.append(func)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t229_info_task.py
+++ b/tests/t229_info_task.py
@@ -2,36 +2,42 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', """
+        TestBase.__init__(
+            self,
+            "fork",
+            """
 #         TIMESTAMP       FLAGS     TID    TASK              DATA SIZE
         347768.688479931  FS     [ 27364]  t-fork                0.000 MB
         347768.711664373  F      [ 27366]  t-fork                0.000 MB
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'info'
-        self.option = '--task'
+        self.subcmd = "info"
+        self.option = "--task"
 
     def sort(self, output):
         import re
+
         result = []
 
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             # ignore blank lines and comments
-            if ln.strip() == '' or ln.startswith('#'):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
 
             # ignore time part
             ln = ln[24:]
 
             # replace tid part into common string
-            task = re.sub(r'\[ *[0-9]+\]', '[TID]', ln)
+            task = re.sub(r"\[ *[0-9]+\]", "[TID]", ln)
             result.append(task)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t230_graph_task.py
+++ b/tests/t230_graph_task.py
@@ -4,41 +4,46 @@ import re
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'fork', result="""
+        TestBase.__init__(
+            self,
+            "fork",
+            result="""
 ========== TASK GRAPH ==========
 # TOTAL TIME   SELF TIME     TID     TASK NAME
    16.172 ms  356.762 us  [129306] : t-fork
                                    :  |    
    11.015 us   11.015 us  [129317] :  +----t-fork
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'graph'
-        self.option = '--task'
-        self.exearg = ''
+        self.subcmd = "graph"
+        self.option = "--task"
+        self.exearg = ""
 
     def sort(self, output, ignored=False):
-        """ This function post-processes output of the test to be compared.
-            It ignores blank and comment (#) lines and header lines.  """
+        """This function post-processes output of the test to be compared.
+        It ignores blank and comment (#) lines and header lines."""
         result = []
-        for ln in output.split('\n'):
-            if ln.strip() == '' or ln.startswith('#'):
+        for ln in output.split("\n"):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
             # A graph result consists of backtrace and calling functions
-            if ln.startswith('========== TASK GRAPH =========='):
+            if ln.startswith("========== TASK GRAPH =========="):
                 continue
 
             if " : " in ln:
-                line = ln.split(':')[1]  # remove time part
-                line = re.sub('\[\d+\]', 'TID', line)
+                line = ln.split(":")[1]  # remove time part
+                line = re.sub("\[\d+\]", "TID", line)
                 result.append(line)
             else:
                 result.append(ln)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t231_arg_bound.py
+++ b/tests/t231_arg_bound.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'arg', """
+        TestBase.__init__(
+            self,
+            "arg",
+            """
 # DURATION     TID     FUNCTION
    0.647 us [ 17685] | __monstartup();
    0.117 us [ 17685] | __cxa_atexit();
@@ -25,11 +29,12 @@ class TestCase(TestBase):
    0.083 us [ 17685] |     check();
    0.303 us [ 17685] |   } /* pass */
  162.699 us [ 17685] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
         return TestBase.build(self, name, cflags, ldflags)
 

--- a/tests/t232_dynamic_unpatch.py
+++ b/tests/t232_dynamic_unpatch.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
   62.202 us [28141] | __cxa_atexit();
             [28141] | main() {
@@ -12,18 +16,19 @@ class TestCase(TestBase):
    0.913 us [28141] |     c();
    2.210 us [28141] |   } /* b */
    3.005 us [28141] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
+    def build(self, name, cflags="", ldflags=""):
         if not TestBase.check_arch_mfentry_mnop_mcount_support(self):
             return TestBase.TEST_SKIP
-        if cflags.find('-finstrument-functions') >= 0:
-             return TestBase.TEST_SKIP
-        if self.supported_lang['C']['cc'] == 'clang':
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
-        cflags += ' -mfentry -mnop-mcount'
-        cflags += ' -fno-pie -fno-plt'  # workaround of build failure
+        if self.supported_lang["C"]["cc"] == "clang":
+            return TestBase.TEST_SKIP
+        cflags += " -mfentry -mnop-mcount"
+        cflags += " -fno-pie -fno-plt"  # workaround of build failure
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-P . -U a --no-libcall'
+        self.option = "-P . -U a --no-libcall"

--- a/tests/t233_dynamic_unpatch2.py
+++ b/tests/t233_dynamic_unpatch2.py
@@ -2,25 +2,30 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'dynamic', """
+        TestBase.__init__(
+            self,
+            "dynamic",
+            """
 # DURATION     TID     FUNCTION
          [ 63876] | main() {
 0.739 us [ 63876] |   foo();
 1.903 us [ 63876] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_arch_full_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
-    def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
-        cflags += ' -fno-pie -fno-plt'  # workaround of build failure
+    def build(self, name, cflags="", ldflags=""):
+        cflags = cflags.replace("-pg", "")
+        cflags = cflags.replace("-finstrument-functions", "")
+        cflags += " -fno-pie -fno-plt"  # workaround of build failure
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-P . -U bar --no-libcall'
+        self.option = "-P . -U bar --no-libcall"

--- a/tests/t234_script_luajit.py
+++ b/tests/t234_script_luajit.py
@@ -4,23 +4,24 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', '5')
+        TestBase.__init__(self, "abc", "5")
 
     def prerun(self, timeout):
-        self.subcmd = 'script'
-        self.option = '-S %s/scripts/count.lua --record' % self.basedir
+        self.subcmd = "script"
+        self.option = "-S %s/scripts/count.lua --record" % self.basedir
         script_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + script_cmd)
+        self.pr_debug("prerun command: " + script_cmd)
 
         p = sp.Popen(script_cmd.split(), stdout=sp.PIPE, stderr=sp.PIPE)
-        if p.communicate()[1].decode(errors='ignore').startswith('WARN:'):
+        if p.communicate()[1].decode(errors="ignore").startswith("WARN:"):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.option = '-F main -S %s/scripts/count.lua' % self.basedir
+        self.option = "-F main -S %s/scripts/count.lua" % self.basedir
 
     def sort(self, output):
         return output.strip()

--- a/tests/t235_report_srcline.py
+++ b/tests/t235_report_srcline.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
   Total time   Self time       Calls  Function [Source]
   ==========  ==========  ==========  ====================
     2.559 us    0.306 us           1  main [tests/s-abc.c:26]
@@ -14,43 +18,45 @@ class TestCase(TestBase):
     1.064 us    1.064 us           1  getpid
     0.372 us    0.372 us           1  __monstartup
     0.186 us    0.186 us           1  __cxa_atexit
-""", cflags='-g')
+""",
+            cflags="-g",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
         return TestBase.build(self, name, cflags, ldflags)
 
     def prepare(self):
-        self.subcmd = 'record'
-        self.option = '--srcline'
+        self.subcmd = "record"
+        self.option = "--srcline"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '--srcline'
+        self.subcmd = "report"
+        self.option = "--srcline"
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Total':
+            if line[0] == "Total":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]         [1]   [2]        [3]   [4]     [5]       [6]
             # total_time  unit  self_time  unit  called  function  srcline
-            if line[-1].startswith('__'):
+            if line[-1].startswith("__"):
                 continue
 
-            if len(line) < 7 :
-                result.append('%s %s' % (line[-2], line[-1]))
-            else :
-                result.append('%s %s %s' % (line[-3], line[-2], line[-1][1:-1].split('/')[-1]))
+            if len(line) < 7:
+                result.append("%s %s" % (line[-2], line[-1]))
+            else:
+                result.append("%s %s %s" % (line[-3], line[-2], line[-1][1:-1].split("/")[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t236_replay_srcline.py
+++ b/tests/t236_replay_srcline.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION     TID     FUNCTION [SOURCE]
    0.678 us [ 19939] | __monstartup();
    0.234 us [ 19939] | __cxa_atexit();
@@ -17,41 +21,43 @@ class TestCase(TestBase):
    2.044 us [ 19939] |     } /* b */
    2.329 us [ 19939] |   } /* a */
    2.644 us [ 19939] | } /* main */
-""", cflags='-g')
+""",
+            cflags="-g",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
         return TestBase.build(self, name, cflags, ldflags)
 
     def prepare(self):
-        self.subcmd = 'record'
-        self.option = '--srcline'
+        self.subcmd = "record"
+        self.option = "--srcline"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '--srcline'
+        self.subcmd = "replay"
+        self.option = "--srcline"
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
         before_main = True
-        for ln in output.split('\n'):
-            if ln.find(' | main()') > 0:
+        for ln in output.split("\n"):
+            if ln.find(" | main()") > 0:
                 before_main = False
             if before_main:
                 continue
             # ignore result of remaining functions which follows a blank line
-            if ln.strip() == '':
+            if ln.strip() == "":
                 break
 
-            func = ln.split('|', 1)[-1].split('/*')
+            func = ln.split("|", 1)[-1].split("/*")
 
-            if len(func) < 2 :
-                result.append('%s' % (func[0]))
-            else :
-                result.append('%s %s' % (func[-2], func[-1][0:-3].split('/')[-1]))
+            if len(func) < 2:
+                result.append("%s" % (func[0]))
+            else:
+                result.append("%s %s" % (func[-2], func[-1][0:-3].split("/")[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t237_report_field1.py
+++ b/tests/t237_report_field1.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sort', """
+        TestBase.__init__(
+            self,
+            "sort",
+            """
   Total time       Calls   Function
   ==========  ==========   ====================
    11.173 ms           1   main
@@ -14,33 +18,34 @@ class TestCase(TestBase):
   204.033 us           6   loop
     0.763 us           1   __monstartup
     0.299 us           1   __cxa_atexit
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '-f total,call'
+        self.subcmd = "report"
+        self.option = "-f total,call"
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Total':
+            if line[0] == "Total":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]         [1]   [2]     [3]
             # total_time  unit  called  function
-            if line[-1].startswith('__'):
+            if line[-1].startswith("__"):
                 continue
-            result.append('%s %s' % (line[-2], line[-1]))
+            result.append("%s %s" % (line[-2], line[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t238_report_field2.py
+++ b/tests/t238_report_field2.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sort', """
+        TestBase.__init__(
+            self,
+            "sort",
+            """
   Total time   Total max    Self min       Calls   Function
   ==========  ==========  ==========  ==========   ====================
    10.297 ms   10.297 ms   10.297 ms           1   usleep
@@ -14,33 +18,34 @@ class TestCase(TestBase):
   207.139 us  105.930 us    1.190 us           2   foo
     0.763 us    0.763 us    0.763 us           1   __monstartup
     0.299 us    0.299 us    0.299 us           1   __cxa_atexit
-""")
+""",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '-f total,total-max,self-min,call -s self-min,total-min'
+        self.subcmd = "report"
+        self.option = "-f total,total-max,self-min,call -s self-min,total-min"
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Total':
+            if line[0] == "Total":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]         [1]   [2]        [3]   [4]       [5]  [6]     [7]
             # total_time  unit  total_max  unit  self_min  unit called  function
-            if line[-1].startswith('__'):
+            if line[-1].startswith("__"):
                 continue
-            result.append('%s %s' % (line[-2], line[-1]))
+            result.append("%s %s" % (line[-2], line[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t239_report_diff_field1.py
+++ b/tests/t239_report_diff_field1.py
@@ -4,12 +4,16 @@ import subprocess as sp
 
 from runtest import TestBase
 
-XDIR='xxx'
-YDIR='yyy'
+XDIR = "xxx"
+YDIR = "yyy"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 #
 # uftrace diff
 #  [0] base: xxx   (from uftrace record -d xxx tests/t-abc )
@@ -22,42 +26,45 @@ class TestCase(TestBase):
     5.925 us    5.385 us    -9.11%     0.786 us    0.554 us   -29.52%            1          1         +0   b
     5.139 us    4.831 us    -5.99%     3.517 us    3.137 us   -10.80%            1          1         +0   c
     1.622 us    1.694 us    +4.44%     1.622 us    1.694 us    +4.44%            1          1         +0   getpid
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        self.subcmd = 'record'
-        self.option = '-d ' + XDIR
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.option = "-d " + XDIR
+        self.exearg = "t-" + self.name
         record_cmd = self.runcmd()
         sp.call(record_cmd.split())
 
-        self.option = '-d ' + YDIR
+        self.option = "-d " + YDIR
         record_cmd = self.runcmd()
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '-f total,self,call --sort-column 0 --diff-policy full,percent'  # old behavior
-        self.exearg = '-d %s --diff %s' % (XDIR, YDIR)
+        self.subcmd = "report"
+        self.option = (
+            "-f total,self,call --sort-column 0 --diff-policy full,percent"  # old behavior
+        )
+        self.exearg = "-d %s --diff %s" % (XDIR, YDIR)
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.startswith('#') or ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.startswith("#") or ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Total':
+            if line[0] == "Total":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]  [1]  [2]  [3]  [4]      [5]  [6]  [7]  [8]  [9]      [10]   [11]   [12]       [13]
             # tT/0 unit tT/1 unit percent  tS/0 unit tS/1 unit percent  call/0 call/1 call/diff  function
-            if line[-1].startswith('__'):
+            if line[-1].startswith("__"):
                 continue
-            result.append('%s %s %s %s' % (line[-4], line[-3], line[-2], line[-1]))
+            result.append("%s %s %s %s" % (line[-4], line[-3], line[-2], line[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t240_report_diff_field2.py
+++ b/tests/t240_report_diff_field2.py
@@ -4,12 +4,16 @@ import subprocess as sp
 
 from runtest import TestBase
 
-XDIR='xxx'
-YDIR='yyy'
+XDIR = "xxx"
+YDIR = "yyy"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'diff', """
+        TestBase.__init__(
+            self,
+            "diff",
+            """
 #
 # uftrace diff
 #  [0] base: xxx   (from uftrace record -d xxx -F main tests/t-diff 0 )
@@ -22,46 +26,47 @@ class TestCase(TestBase):
      +1.225 ms           +0   foo
    +158.450 us           +0   bar
      -0.066 us           +0   atoi
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        self.subcmd = 'record'
-        self.option = '-d %s -F main' % XDIR
-        self.exearg = 't-' + self.name + ' 0'
+        self.subcmd = "record"
+        self.option = "-d %s -F main" % XDIR
+        self.exearg = "t-" + self.name + " 0"
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
-        self.option = '-d %s -F main' % YDIR
-        self.exearg = 't-' + self.name + ' 1'
+        self.option = "-d %s -F main" % YDIR
+        self.exearg = "t-" + self.name + " 1"
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '-f total,call --diff-policy compact,no-percent,abs'  # new default
-        self.exearg = '-d %s --diff %s' % (XDIR, YDIR)
+        self.subcmd = "report"
+        self.option = "-f total,call --diff-policy compact,no-percent,abs"  # new default
+        self.exearg = "-d %s --diff %s" % (XDIR, YDIR)
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.startswith('#') or ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.startswith("#") or ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Total':
+            if line[0] == "Total":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]  [1]    [2]   [3]
             # total unit  call  function
-            if line[-1].startswith('__'):
+            if line[-1].startswith("__"):
                 continue
-            result.append('%s %s' % (line[-2], line[-1]))
+            result.append("%s %s" % (line[-2], line[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t241_report_diff_field3.py
+++ b/tests/t241_report_diff_field3.py
@@ -4,12 +4,16 @@ import subprocess as sp
 
 from runtest import TestBase
 
-XDIR='xxx'
-YDIR='yyy'
+XDIR = "xxx"
+YDIR = "yyy"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'diff', """
+        TestBase.__init__(
+            self,
+            "diff",
+            """
 #
 # uftrace diff
 #  [0] base: xxx   (from uftrace record -d yyy -F main tests/t-diff 1 )
@@ -22,46 +26,47 @@ class TestCase(TestBase):
     1.235 ms    0.645 us    -1.235 ms     3.276 us    0.527 us    -2.749 us            1          1         +0   foo
     1.309 ms    3.975 us    -1.305 ms     2.601 us    2.282 us    -0.319 us            1          1         +0   main
     1.300 ms           -    -1.300 ms     1.300 ms           -    -1.300 ms            3          0         -3   usleep
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        self.subcmd = 'record'
-        self.option = '-d %s -F main' % XDIR
-        self.exearg = 't-' + self.name + ' 0'
+        self.subcmd = "record"
+        self.option = "-d %s -F main" % XDIR
+        self.exearg = "t-" + self.name + " 0"
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
-        self.option = '-d %s -F main' % YDIR
-        self.exearg = 't-' + self.name + ' 1'
+        self.option = "-d %s -F main" % YDIR
+        self.exearg = "t-" + self.name + " 1"
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '-f total,self,call --diff-policy full,no-abs -s call,total'
-        self.exearg = '-d %s --diff %s' % (YDIR, XDIR)
+        self.subcmd = "report"
+        self.option = "-f total,self,call --diff-policy full,no-abs -s call,total"
+        self.exearg = "-d %s --diff %s" % (YDIR, XDIR)
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.startswith('#') or ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.startswith("#") or ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Total':
+            if line[0] == "Total":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]  [1]  [2]  [3]  [4]  [5]   [6]  [7]  [8]  [9]  [10] [11]   [12]   [13]   [14]    [15]
             # tT/0 unit tT/1 unit tT/d unit  tS/0 unit tS/1 unit tS/d unit   call/0 call/1 call/d  function
-            if line[-1].startswith('__'):
+            if line[-1].startswith("__"):
                 continue
-            result.append('%s %s %s %s' % (line[-4], line[-3], line[-2], line[-1]))
+            result.append("%s %s %s %s" % (line[-4], line[-3], line[-2], line[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t242_report_diff_field4.py
+++ b/tests/t242_report_diff_field4.py
@@ -4,12 +4,16 @@ import subprocess as sp
 
 from runtest import TestBase
 
-XDIR='xxx'
-YDIR='yyy'
+XDIR = "xxx"
+YDIR = "yyy"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'diff', """
+        TestBase.__init__(
+            self,
+            "diff",
+            """
 #
 # uftrace diff
 #  [0] base: xxx   (from uftrace record -d xxx -F main tests/t-diff 0 )
@@ -23,46 +27,47 @@ class TestCase(TestBase):
      +273.85%           +0  foo
       +17.78%           +0  main
          N/A            +3  usleep
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        self.subcmd = 'record'
-        self.option = '-d %s -F main' % XDIR
-        self.exearg = 't-' + self.name + ' 0'
+        self.subcmd = "record"
+        self.option = "-d %s -F main" % XDIR
+        self.exearg = "t-" + self.name + " 0"
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
-        self.option = '-d %s -F main' % YDIR
-        self.exearg = 't-' + self.name + ' 1'
+        self.option = "-d %s -F main" % YDIR
+        self.exearg = "t-" + self.name + " 1"
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: %s' + record_cmd)
+        self.pr_debug("prerun command: %s" + record_cmd)
         sp.call(record_cmd.split())
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '-f self,call --diff-policy percent -s func'
-        self.exearg = '-d %s --diff %s' % (XDIR, YDIR)
+        self.subcmd = "report"
+        self.option = "-f self,call --diff-policy percent -s func"
+        self.exearg = "-d %s --diff %s" % (XDIR, YDIR)
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.startswith('#') or ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.startswith("#") or ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Self':
+            if line[0] == "Self":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]  [1]      [2]   [3]
             # self percent  call  function
-            if line[-1].startswith('__'):
+            if line[-1].startswith("__"):
                 continue
-            result.append('%s %s' % (line[-2], line[-1]))
+            result.append("%s %s" % (line[-2], line[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t243_report_diff_field5.py
+++ b/tests/t243_report_diff_field5.py
@@ -4,12 +4,16 @@ import subprocess as sp
 
 from runtest import TestBase
 
-XDIR='xxx'
-YDIR='yyy'
+XDIR = "xxx"
+YDIR = "yyy"
+
 
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'diff', """
+        TestBase.__init__(
+            self,
+            "diff",
+            """
 #
 # uftrace diff
 #  [0] base: xxx   (from uftrace record -d xxx -F main tests/t-diff 0 )
@@ -22,48 +26,49 @@ class TestCase(TestBase):
     +1.235 ms     +2.749 us            +0   foo
     +1.305 ms     +0.319 us            +0   main
     +1.300 ms     +1.300 ms            +3   usleep
-""")
+""",
+        )
 
     def prerun(self, timeout):
-        self.subcmd = 'record'
-        self.option = '-d %s -F main' % XDIR
-        self.exearg = 't-' + self.name + ' 0'
+        self.subcmd = "record"
+        self.option = "-d %s -F main" % XDIR
+        self.exearg = "t-" + self.name + " 0"
 
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
-        self.option = '-d %s -F main' % YDIR
-        self.exearg = 't-' + self.name + ' 1'
+        self.option = "-d %s -F main" % YDIR
+        self.exearg = "t-" + self.name + " 1"
 
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
         sp.call(record_cmd.split())
 
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '-f total,self,call --diff-policy compact -s func'
-        self.exearg = '-d %s --diff %s' % (XDIR, YDIR)
+        self.subcmd = "report"
+        self.option = "-f total,self,call --diff-policy compact -s func"
+        self.exearg = "-d %s --diff %s" % (XDIR, YDIR)
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.startswith('#') or ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.startswith("#") or ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Total':
+            if line[0] == "Total":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]  [1]  [2]  [3]  [4]    [5]
             # tT   unit tS   unit call   function
-            if line[-1].startswith('__'):
+            if line[-1].startswith("__"):
                 continue
-            result.append('%s %s' % (line[-2], line[-1]))
+            result.append("%s %s" % (line[-2], line[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t244_report_task_field.py
+++ b/tests/t244_report_task_field.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'thread', """
+        TestBase.__init__(
+            self,
+            "thread",
+            """
      TID   Num funcs  Task name
   ======  ==========  ====================
    36562           1  t-thread
@@ -12,32 +16,34 @@ class TestCase(TestBase):
    36577           4  t-thread
    36580           4  t-thread
    36579           4  t-thread
-""", ldflags='-pthread')
+""",
+            ldflags="-pthread",
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
-        self.option = '--no-libcall'
+        self.subcmd = "record"
+        self.option = "--no-libcall"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '--task -f tid,func'
+        self.subcmd = "report"
+        self.option = "--task -f tid,func"
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'TID':
+            if line[0] == "TID":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]  [1]        [2]
             # tid  num_funcs  task_name
-            result.append('%s %s' % (line[-2], line[-1]))
+            result.append("%s %s" % (line[-2], line[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t245_report_field_none.py
+++ b/tests/t245_report_field_none.py
@@ -2,22 +2,27 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc',
-"""  main
+        TestBase.__init__(
+            self,
+            "abc",
+            """  main
   a
   b
   c
   getpid
-""")
+""",
+        )
+
     def prepare(self):
-        self.subcmd = 'record'
+        self.subcmd = "record"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '-F main -f none'
+        self.subcmd = "report"
+        self.option = "-F main -f none"
 
     def sort(self, output, ignore_children=False):
         return output

--- a/tests/t246_report_srcline2.py
+++ b/tests/t246_report_srcline2.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'lib', """
+        TestBase.__init__(
+            self,
+            "lib",
+            """
   Total time   Self time       Calls  Function [Source]
   ==========  ==========  ==========  ====================
     4.362 us    0.212 us           1  main [xxx/uftrace/tests/s-libmain.c:16]
@@ -12,47 +16,49 @@ class TestCase(TestBase):
     1.804 us    0.186 us           1  lib_a [xxx/uftrace/tests/s-lib.c:10]
     1.618 us    0.980 us           1  lib_b [xxx/uftrace/tests/s-lib.c:15]
     0.638 us    0.638 us           1  lib_c [xxx/uftrace/tests/s-lib.c:20]
-""", cflags='-g')
+""",
+            cflags="-g",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
         if TestBase.build_libabc(self, cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
-        return TestBase.build_libmain(self, name, 's-libmain.c',
-                                      ['libabc_test_lib.so'],
-                                      cflags, ldflags)
+        return TestBase.build_libmain(
+            self, name, "s-libmain.c", ["libabc_test_lib.so"], cflags, ldflags
+        )
 
     def prepare(self):
-        self.subcmd = 'record'
-        self.option = '--srcline --no-libcall'
+        self.subcmd = "record"
+        self.option = "--srcline --no-libcall"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'report'
-        self.option = '--srcline'
+        self.subcmd = "report"
+        self.option = "--srcline"
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared .
-            It ignores blank and comment (#) lines and remaining functions.  """
+        """This function post-processes output of the test to be compared .
+        It ignores blank and comment (#) lines and remaining functions."""
         result = []
-        for ln in output.split('\n'):
-            if ln.strip() == '':
+        for ln in output.split("\n"):
+            if ln.strip() == "":
                 continue
             line = ln.split()
-            if line[0] == 'Total':
+            if line[0] == "Total":
                 continue
-            if line[0].startswith('='):
+            if line[0].startswith("="):
                 continue
             # A report line consists of following data
             # [0]         [1]   [2]        [3]   [4]     [5]       [6]
             # total_time  unit  self_time  unit  called  function  srcline
-            if line[-1].startswith('__'):
+            if line[-1].startswith("__"):
                 continue
 
-            if len(line) < 7 :
-                result.append('%s %s' % (line[-2], line[-1]))
-            else :
-                result.append('%s %s %s' % (line[-3], line[-2], line[-1][1:-1].split('/')[-1]))
+            if len(line) < 7:
+                result.append("%s %s" % (line[-2], line[-1]))
+            else:
+                result.append("%s %s %s" % (line[-3], line[-2], line[-1][1:-1].split("/")[-1]))
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t247_graph_srcline.py
+++ b/tests/t247_graph_srcline.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'sort', result="""
+        TestBase.__init__(
+            self,
+            "sort",
+            result="""
 # Function Call Graph for 'main' (session: de27777d0a966d5a)
 =============== BACKTRACE ===============
  backtrace #0: hit 1, time  13.120 ms
@@ -18,53 +22,56 @@ class TestCase(TestBase):
              :  | 
    10.748 ms :  +-(1) bar [/home/eslee/soft/uftrace/tests/s-sort.c:17]
    10.183 ms :    (1) usleep
-""", sort='graph', cflags='-g')
+""",
+            sort="graph",
+            cflags="-g",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
         return TestBase.build(self, name, cflags, ldflags)
 
     def prepare(self):
-        self.subcmd = 'record'
-        self.option = '--srcline'
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.option = "--srcline"
+        self.exearg = "t-" + self.name
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'graph'
-        self.option = '--srcline'
-        self.exearg = 'main'
+        self.subcmd = "graph"
+        self.option = "--srcline"
+        self.exearg = "main"
 
     def sort(self, output):
-        """ This function post-processes output of the test to be compared.
-            It ignores blank and comment (#) lines and header lines.  """
+        """This function post-processes output of the test to be compared.
+        It ignores blank and comment (#) lines and header lines."""
         result = []
         mode = 0
-        for ln in output.split('\n'):
-            if ln.strip() == '' or ln.startswith('#'):
+        for ln in output.split("\n"):
+            if ln.strip() == "" or ln.startswith("#"):
                 continue
             # A graph result consists of backtrace and calling functions
-            if ln.startswith('=============== BACKTRACE ==============='):
+            if ln.startswith("=============== BACKTRACE ==============="):
                 mode = 1
                 continue
-            if ln.startswith('========== FUNCTION CALL GRAPH =========='):
+            if ln.startswith("========== FUNCTION CALL GRAPH =========="):
                 mode = 2
                 continue
             if mode == 1:
-                if ln.startswith(' backtrace #'):
-                    result.append(ln.split(',')[0])  # remove time part
-                if ln.startswith('   ['):
-                    result.append(ln.split('(')[0])  # remove '(addr)' part
+                if ln.startswith(" backtrace #"):
+                    result.append(ln.split(",")[0])  # remove time part
+                if ln.startswith("   ["):
+                    result.append(ln.split("(")[0])  # remove '(addr)' part
             if mode == 2:
                 if " : " in ln:
-                    func = ln.split(':', 1)[1].split('[')  # remove time part
-                    if len(func) < 2 :
-                        result.append('%s' % (func[-1]))
-                    else :
+                    func = ln.split(":", 1)[1].split("[")  # remove time part
+                    if len(func) < 2:
+                        result.append("%s" % (func[-1]))
+                    else:
                         # extract basename and line number of source location
-                        result.append('%s %s' % (func[-2], func[-1][0:-1].split('/')[-1]))
+                        result.append("%s %s" % (func[-2], func[-1][0:-1].split("/")[-1]))
                 else:
                     result.append(ln)
 
-        return '\n'.join(result)
+        return "\n".join(result)

--- a/tests/t248_dynamic_dlopen.py
+++ b/tests/t248_dynamic_dlopen.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'dlopen', """
+        TestBase.__init__(
+            self,
+            "dlopen",
+            """
 # DURATION     TID     FUNCTION
            [108977] | main() {
 187.389 us [108977] |   dlopen();
@@ -20,23 +24,23 @@ class TestCase(TestBase):
   0.765 us [108977] |   foo();
 108.059 us [108977] |   dlclose();
 488.088 us [108977] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_arch_full_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
-    def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
+    def build(self, name, cflags="", ldflags=""):
+        cflags = cflags.replace("-pg", "")
+        cflags = cflags.replace("-finstrument-functions", "")
 
         if TestBase.build_libabc(self, cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
-        if TestBase.build_libfoo(self, 'foo', cflags, ldflags) != 0:
+        if TestBase.build_libfoo(self, "foo", cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
-        return TestBase.build_libmain(self, name, 's-dlopen.c', ['libdl.so'],
-                                      cflags, ldflags)
+        return TestBase.build_libmain(self, name, "s-dlopen.c", ["libdl.so"], cflags, ldflags)
 
     def setup(self):
-        self.option = ' -P. -P.@libfoo.so -P.@libabc_test_lib.so'
+        self.option = " -P. -P.@libfoo.so -P.@libabc_test_lib.so"

--- a/tests/t249_estimate_return.py
+++ b/tests/t249_estimate_return.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
             [28141] | main() {
             [28141] |   a() {
@@ -15,7 +19,8 @@ class TestCase(TestBase):
    1.915 us [28141] |     } /* b */
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '--estimate-return -F main'
+        self.option = "--estimate-return -F main"

--- a/tests/t250_indirect_return.py
+++ b/tests/t250_indirect_return.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'indirect-return', lang="C++", result="""
+        TestBase.__init__(
+            self,
+            "indirect-return",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
             [418122] | main() {
  178.233 us [418122] |   std::__cxx11::basic_ostringstream::basic_ostringstream();
@@ -12,4 +17,6 @@ class TestCase(TestBase):
    1.476 us [418122] |   std::__cxx11::basic_string::~basic_string();
   10.450 us [418122] |   std::__cxx11::basic_ostringstream::~basic_ostringstream();
  201.943 us [418122] | } /* main */
-""", sort='simple')
+""",
+            sort="simple",
+        )

--- a/tests/t251_exception4.py
+++ b/tests/t251_exception4.py
@@ -2,9 +2,14 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'libexcept-main', lang='C++', result="""
+        TestBase.__init__(
+            self,
+            "libexcept-main",
+            lang="C++",
+            result="""
 # DURATION    TID     FUNCTION
             [423633] | main() {
             [423633] |   XXX::XXX() {
@@ -15,14 +20,19 @@ class TestCase(TestBase):
    0.541 us [423633] |     std::runtime_error::runtime_error();
    5.670 us [423633] |   } /* YYY::YYY */
   42.354 us [423633] | } /* main */
-""")
+""",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if TestBase.build_libfoo(self, 'except', cflags, ldflags) != 0:
+    def build(self, name, cflags="", ldflags=""):
+        if TestBase.build_libfoo(self, "except", cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
-        return TestBase.build_libmain(self, name, 's-libexcept-main.cpp', ['libexcept.so'],
-                                      cflags, ldflags)
+        return TestBase.build_libmain(
+            self, name, "s-libexcept-main.cpp", ["libexcept.so"], cflags, ldflags
+        )
 
     def fixup(self, cflags, result):
-        return result.replace("""   6.353 us [423633] |   std::runtime_error:~runtime_error();
-""", '')
+        return result.replace(
+            """   6.353 us [423633] |   std::runtime_error:~runtime_error();
+""",
+            "",
+        )

--- a/tests/t252_filter_H.py
+++ b/tests/t252_filter_H.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION     TID     FUNCTION
             [ 30217] | main() {
             [ 30217] |   a() {
@@ -13,7 +17,8 @@ class TestCase(TestBase):
    8.600 us [ 30217] |     } /* b */
   11.500 us [ 30217] |   } /* a */
   14.500 us [ 30217] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-H c'
+        self.option = "-H c"

--- a/tests/t253_trigger_hide.py
+++ b/tests/t253_trigger_hide.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION     TID     FUNCTION
             [ 30217] | main() {
             [ 30217] |   a() {
@@ -13,7 +17,8 @@ class TestCase(TestBase):
    8.600 us [ 30217] |     } /* b */
   11.500 us [ 30217] |   } /* a */
   14.500 us [ 30217] | } /* main */
-""")
+""",
+        )
 
     def setup(self):
-        self.option = '-T c@hide'
+        self.option = "-T c@hide"

--- a/tests/t254_arg_dwarf5.py
+++ b/tests/t254_arg_dwarf5.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'dwarf5', """
+        TestBase.__init__(
+            self,
+            "dwarf5",
+            """
 # DURATION     TID     FUNCTION
             [1167172] | main() {
  143.049 us [1167172] |   pass_int1(int1{...}, 1, "2", 3.000000) = 1;
@@ -18,15 +22,17 @@ class TestCase(TestBase):
    0.255 us [1167172] |   pass_mix3(mix3{...}, 1, "2", 3.000000) = 1;
  154.430 us [1167172] | } /* main */
 
-""", cflags='-g')
+""",
+            cflags="-g",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-A ^pass -R ^pass -F main'
+        self.option = "-A ^pass -R ^pass -F main"

--- a/tests/t255_arg_dwarf6.py
+++ b/tests/t255_arg_dwarf6.py
@@ -2,23 +2,30 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'dwarf6', """
+        TestBase.__init__(
+            self,
+            "dwarf6",
+            """
 # DURATION     TID     FUNCTION
             [152673] | main() {
   83.549 us [152673] |   addString(" uftrace "s, "test") = " uftrace test"s;
    4.597 us [152673] |   addItem(vector{...}, 0) = vector{...};
  116.117 us [152673] | } /* main */
-""", lang='C++', cflags='-g -std=c++11')
+""",
+            lang="C++",
+            cflags="-g -std=c++11",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-F main -N ^std -A ^add -R ^add'
+        self.option = "-F main -N ^std -A ^add -R ^add"

--- a/tests/t256_arg_dwarf7.py
+++ b/tests/t256_arg_dwarf7.py
@@ -2,22 +2,29 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'dwarf7', """
+        TestBase.__init__(
+            self,
+            "dwarf7",
+            """
 # DURATION     TID     FUNCTION
             [1279330] | main() {
    0.166 us [1279330] |   compare_iters(__normal_iterator{...}, __normal_iterator{...}) = 0;
    5.959 us [1279330] | } = 0; /* main */
-""", lang='C++', cflags='-g -std=c++11')
+""",
+            lang="C++",
+            cflags="-g -std=c++11",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-a -C compare_iters'
+        self.option = "-a -C compare_iters"

--- a/tests/t257_arg_struct_replay.py
+++ b/tests/t257_arg_struct_replay.py
@@ -2,22 +2,28 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'struct', """
+        TestBase.__init__(
+            self,
+            "struct",
+            """
 # DURATION     TID     FUNCTION
             [ 54277] | main() {
  207.329 us [ 54277] |   foo(Option{...}, StringRef{}, 44, 55, 66);
  208.750 us [ 54277] | } = 0; /* main */
-""", cflags='-g')
+""",
+            cflags="-g",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-a --no-libcall'
+        self.option = "-a --no-libcall"

--- a/tests/t258_arg_struct_dump.py
+++ b/tests/t258_arg_struct_dump.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'struct', """
+        TestBase.__init__(
+            self,
+            "struct",
+            """
 uftrace file header: magic         = 4674726163652100
 uftrace file header: version       = 4
 uftrace file header: header size   = 40
@@ -27,24 +31,27 @@ reading 3121.dat
 11431966.433135754   3121: [exit ] main(400673) depth: 0
 11431966.433135754   3121: [retval] length = 8
   retval d64: 0x0000000000000000
-""", cflags='-g', sort='dump')
+""",
+            cflags="-g",
+            sort="dump",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature:
             return TestBase.TEST_SKIP
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
         return TestBase.build(self, name, cflags, ldflags)
 
     def prepare(self):
-        self.subcmd = 'record'
-        self.option = '-a --no-libcall'
+        self.subcmd = "record"
+        self.option = "-a --no-libcall"
         return self.runcmd()
 
     def setup(self):
-        self.subcmd = 'dump'
+        self.subcmd = "dump"
 
     def fixup(self, cflags, result):
         # 32-bit will show the output differently
-        return result.replace('d64: 0x00000000', 'd32: 0x')
+        return result.replace("d64: 0x00000000", "d32: 0x")

--- a/tests/t259_arg_struct_script.py
+++ b/tests/t259_arg_struct_script.py
@@ -4,9 +4,13 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'struct', """
+        TestBase.__init__(
+            self,
+            "struct",
+            """
 uftrace_begin(ctx)
   record  : False
   version : v0.10-17-g8d1b ( x86_64 dwarf python luajit tui perf sched dynamic )
@@ -24,26 +28,29 @@ uftrace_begin(ctx)
   retval  <class 'int'>: 0
 
 uftrace_end()
-""", cflags='-g', sort='dump')
+""",
+            cflags="-g",
+            sort="dump",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature or not 'python' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature or not "python" in self.feature:
             return TestBase.TEST_SKIP
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
         return TestBase.build(self, name, cflags, ldflags)
 
     def prerun(self, timeout):
-        script_cmd = '%s script' % (TestBase.uftrace_cmd)
+        script_cmd = "%s script" % (TestBase.uftrace_cmd)
         p = sp.Popen(script_cmd.split(), stdout=sp.PIPE, stderr=sp.PIPE)
-        if p.communicate()[1].decode(errors='ignore').startswith('WARN:'):
+        if p.communicate()[1].decode(errors="ignore").startswith("WARN:"):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'script'
-        self.option = '-S %s/scripts/dump.py -a --no-libcall --no-event --record' % self.basedir
+        self.subcmd = "script"
+        self.option = "-S %s/scripts/dump.py -a --no-libcall --no-event --record" % self.basedir
 
     def fixup(self, cflags, result):
         # handle the difference between python2 and python3 output

--- a/tests/t260_arg_struct_luajit.py
+++ b/tests/t260_arg_struct_luajit.py
@@ -4,9 +4,13 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'struct', """
+        TestBase.__init__(
+            self,
+            "struct",
+            """
 uftrace_begin(ctx)
   record  : false
   version : v0.10-17-g8d1b ( x86_64 dwarf python luajit tui perf sched dynamic )
@@ -24,23 +28,26 @@ uftrace_begin(ctx)
   retval  number: 0
 
 uftrace_end()
-""", cflags='-g', sort='dump')
+""",
+            cflags="-g",
+            sort="dump",
+        )
 
-    def build(self, name, cflags='', ldflags=''):
-        if not 'dwarf' in self.feature or not 'luajit' in self.feature:
+    def build(self, name, cflags="", ldflags=""):
+        if not "dwarf" in self.feature or not "luajit" in self.feature:
             return TestBase.TEST_SKIP
         # cygprof doesn't support arguments now
-        if cflags.find('-finstrument-functions') >= 0:
+        if cflags.find("-finstrument-functions") >= 0:
             return TestBase.TEST_SKIP
         return TestBase.build(self, name, cflags, ldflags)
 
     def prerun(self, timeout):
-        script_cmd = '%s script' % (TestBase.uftrace_cmd)
+        script_cmd = "%s script" % (TestBase.uftrace_cmd)
         p = sp.Popen(script_cmd.split(), stdout=sp.PIPE, stderr=sp.PIPE)
-        if p.communicate()[1].decode(errors='ignore').startswith('WARN:'):
+        if p.communicate()[1].decode(errors="ignore").startswith("WARN:"):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'script'
-        self.option = '-S %s/scripts/dump.lua -a --no-libcall --no-event --record' % self.basedir
+        self.subcmd = "script"
+        self.option = "-S %s/scripts/dump.lua -a --no-libcall --no-event --record" % self.basedir

--- a/tests/t261_info_note.py
+++ b/tests/t261_info_note.py
@@ -4,9 +4,13 @@ import subprocess as sp
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'hello', """
+        TestBase.__init__(
+            self,
+            "hello",
+            """
 # system information
 # ==================
 # program version     : v0.10-52-gca6c ( x86_64 dwarf python luajit tui perf sched dynamic )
@@ -37,33 +41,34 @@ class TestCase(TestBase):
 #
 # extra note information
 # ======================
-You can leave a note for the recorded data.""")
+You can leave a note for the recorded data.""",
+        )
 
     def prerun(self, timeout):
-        self.subcmd  = 'record'
-        self.exearg += ' note.txt'
+        self.subcmd = "record"
+        self.exearg += " note.txt"
         record_cmd = self.runcmd()
-        self.pr_debug('prerun command: ' + record_cmd)
+        self.pr_debug("prerun command: " + record_cmd)
 
-        f = open('/dev/null')
+        f = open("/dev/null")
         sp.call(record_cmd.split(), stdout=f, stderr=f)
         f.close()
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        with open('uftrace.data/note.txt', 'w+') as f:
-            f.write('You can leave a note for the recorded data.')
-        self.subcmd = 'info'
-        self.exearg = ''
+        with open("uftrace.data/note.txt", "w+") as f:
+            f.write("You can leave a note for the recorded data.")
+        self.subcmd = "info"
+        self.exearg = ""
 
     def sort(self, output):
         header_match = 0
-        for ln in output.split('\n'):
+        for ln in output.split("\n"):
             if header_match == 0:
-                if ln.startswith('# extra note information'):
+                if ln.startswith("# extra note information"):
                     header_match = 1
             elif header_match == 1:
                 header_match = 2
             elif header_match == 2:
                 return ln
-        return ''
+        return ""

--- a/tests/t262_replay_with_syms.py
+++ b/tests/t262_replay_with_syms.py
@@ -6,9 +6,13 @@ from runtest import TestBase
 
 SYMDIR = "abc.syms"
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION    TID     FUNCTION
   62.202 us [28141] | __cxa_atexit();
             [28141] | main() {
@@ -20,24 +24,25 @@ class TestCase(TestBase):
    1.915 us [28141] |     } /* b */
    2.405 us [28141] |   } /* a */
    3.005 us [28141] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         # record a data with symbols
-        self.subcmd = 'record'
-        self.option = '-d ' + SYMDIR
-        self.exearg = 't-' + self.name
+        self.subcmd = "record"
+        self.option = "-d " + SYMDIR
+        self.exearg = "t-" + self.name
 
         record_cmd = self.runcmd()
         sp.call(record_cmd.split())
         self.pr_debug("prerun command1: " + record_cmd)
 
-        strip_cmd = 'strip ' + self.exearg
+        strip_cmd = "strip " + self.exearg
         sp.call(strip_cmd.split())
         self.pr_debug("prerun command2: " + strip_cmd)
 
         # record again with the stripped binary
-        self.option = ''
+        self.option = ""
 
         record_cmd = self.runcmd()
         sp.call(record_cmd.split())
@@ -46,6 +51,6 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def setup(self):
-        self.subcmd = 'replay'
-        self.option = '--with-syms ' + SYMDIR
-        self.exearg = ''
+        self.subcmd = "replay"
+        self.option = "--with-syms " + SYMDIR
+        self.exearg = ""

--- a/tests/t263_patchable_dynamic.py
+++ b/tests/t263_patchable_dynamic.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'abc', """
+        TestBase.__init__(
+            self,
+            "abc",
+            """
 # DURATION     TID     FUNCTION
             [ 54963] | main() {
             [ 54963] |   a() {
@@ -13,25 +17,26 @@ class TestCase(TestBase):
    3.772 us [ 54963] |     } /* b */
    4.376 us [ 54963] |   } /* a */
    5.484 us [ 54963] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_arch_full_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
-    def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
+    def build(self, name, cflags="", ldflags=""):
+        cflags = cflags.replace("-pg", "")
+        cflags = cflags.replace("-finstrument-functions", "")
 
         # add patchable function entry option
         machine = TestBase.get_machine(self)
-        if machine == 'x86_64':
-            cflags += ' -fpatchable-function-entry=5'
-        elif machine == 'aarch64':
-            cflags += ' -fpatchable-function-entry=2'
+        if machine == "x86_64":
+            cflags += " -fpatchable-function-entry=5"
+        elif machine == "aarch64":
+            cflags += " -fpatchable-function-entry=2"
 
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-P . --no-libcall'
+        self.option = "-P . --no-libcall"

--- a/tests/t264_patchable_dynamic2.py
+++ b/tests/t264_patchable_dynamic2.py
@@ -2,26 +2,31 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'patchable-abc', """
+        TestBase.__init__(
+            self,
+            "patchable-abc",
+            """
 # DURATION     TID     FUNCTION
             [  2331] | main() {
             [  2331] |   a() {
    0.897 us [  2331] |     c();
    2.555 us [  2331] |   } /* a */
    3.468 us [  2331] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_arch_full_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
-    def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
+    def build(self, name, cflags="", ldflags=""):
+        cflags = cflags.replace("-pg", "")
+        cflags = cflags.replace("-finstrument-functions", "")
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-P . --no-libcall'
+        self.option = "-P . --no-libcall"

--- a/tests/t265_patchable_dynamic3.py
+++ b/tests/t265_patchable_dynamic3.py
@@ -2,24 +2,29 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'patchable-abc', """
+        TestBase.__init__(
+            self,
+            "patchable-abc",
+            """
 # DURATION     TID     FUNCTION
             [  6907] | main() {
    1.138 us [  6907] |   c();
    4.345 us [  6907] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_arch_full_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
-    def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
+    def build(self, name, cflags="", ldflags=""):
+        cflags = cflags.replace("-pg", "")
+        cflags = cflags.replace("-finstrument-functions", "")
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-P . -U a --no-libcall'
+        self.option = "-P . -U a --no-libcall"

--- a/tests/t266_patchable_dynamic4.py
+++ b/tests/t266_patchable_dynamic4.py
@@ -2,9 +2,13 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'lib', """
+        TestBase.__init__(
+            self,
+            "lib",
+            """
 # DURATION     TID     FUNCTION
             [  9519] | main() {
             [  9519] |   foo() {
@@ -13,28 +17,29 @@ class TestCase(TestBase):
    1.455 us [  9519] |     } /* lib_a */
    2.125 us [  9519] |   } /* foo */
    3.114 us [  9519] | } /* main */
-""", sort='simple')
+""",
+            sort="simple",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_arch_full_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
-    def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
+    def build(self, name, cflags="", ldflags=""):
+        cflags = cflags.replace("-pg", "")
+        cflags = cflags.replace("-finstrument-functions", "")
 
         # add patchable function entry option
         machine = TestBase.get_machine(self)
-        if machine == 'x86_64':
-            cflags += ' -fpatchable-function-entry=5'
-        elif machine == 'aarch64':
-            cflags += ' -fpatchable-function-entry=2'
+        if machine == "x86_64":
+            cflags += " -fpatchable-function-entry=5"
+        elif machine == "aarch64":
+            cflags += " -fpatchable-function-entry=2"
 
         if TestBase.build_libabc(self, cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL
-        return TestBase.build_libmain(self, name, 's-libmain.c',
-                                      ['libabc_test_lib.so'], cflags)
+        return TestBase.build_libmain(self, name, "s-libmain.c", ["libabc_test_lib.so"], cflags)
 
     def setup(self):
-        self.option = '-P . -P .@libabc_test_lib.so -U lib_b@libabc_test_lib.so --no-libcall'
+        self.option = "-P . -P .@libabc_test_lib.so -U lib_b@libabc_test_lib.so --no-libcall"

--- a/tests/t267_patchable_dynamic5.py
+++ b/tests/t267_patchable_dynamic5.py
@@ -2,27 +2,32 @@
 
 from runtest import TestBase
 
+
 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'patchable-abc', """
+        TestBase.__init__(
+            self,
+            "patchable-abc",
+            """
 # DURATION     TID     FUNCTION
             [  2331] | main() {
             [  2331] |   a() {
    0.897 us [  2331] |     c();
    2.555 us [  2331] |   } /* a */
    3.468 us [  2331] | } /* main */
-""")
+""",
+        )
 
     def prerun(self, timeout):
         if not TestBase.check_arch_full_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
-    def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
-        cflags += ' -Wl,--gc-sections'
+    def build(self, name, cflags="", ldflags=""):
+        cflags = cflags.replace("-pg", "")
+        cflags = cflags.replace("-finstrument-functions", "")
+        cflags += " -Wl,--gc-sections"
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):
-        self.option = '-P . --no-libcall'
+        self.option = "-P . --no-libcall"


### PR DESCRIPTION
python: Following python coding style in automated way with black

We can maintain python coding style using black[1].
If you install black and run

    $ black {path to pyproject.toml}
we can reformat python code as PEP 8 suggests. (e.g. black .)

In this PR, I included line-length as 100[2].

[1] https://black.readthedocs.io/en/stable/
[2]
    https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=bdc48fa11e46f867ea4d75fa59ee87a7f48be144
Signed-off-by: Kang Minchul <tegongkang@gmail.com>