### PR TITLE
dwarf: Fix args reading error in -fpatchable-function-entry binaries

### DIFF
--- a/arch/aarch64/mcount-arch.h
+++ b/arch/aarch64/mcount-arch.h
@@ -38,6 +38,8 @@ struct mcount_disasm_engine;
 struct mcount_dynamic_info;
 struct mcount_disasm_info;
 
+#define NOP_INSN_SIZE   4
+
 int disasm_check_insns(struct mcount_disasm_engine *disasm,
 		       struct mcount_dynamic_info *mdi,
 		       struct mcount_disasm_info *info);

--- a/arch/arm/mcount-arch.h
+++ b/arch/arm/mcount-arch.h
@@ -32,4 +32,6 @@ unsigned long * mcount_arch_parent_location(struct symtabs *symtabs,
 #define ARCH_PLT0_SIZE  20
 #define ARCH_PLTHOOK_ADDR_OFFSET  0
 
+#define NOP_INSN_SIZE   4
+
 #endif /* MCOUNT_ARCH_H */

--- a/arch/i386/mcount-arch.h
+++ b/arch/i386/mcount-arch.h
@@ -32,5 +32,6 @@ unsigned long * mcount_arch_parent_location(struct symtabs *symtabs,
 #define ARCH_CAN_RESTORE_PLTHOOK   1
 
 #define CALL_INSN_SIZE 5
+#define NOP_INSN_SIZE  1
 
 #endif /* __MCOUNT_ARCH_H__ */

--- a/arch/x86_64/mcount-arch.h
+++ b/arch/x86_64/mcount-arch.h
@@ -56,6 +56,7 @@ struct sym;
 #define MOV_INSN_SIZE  10  /* move 8-byte immediate to reg */
 #define ENDBR_INSN_SIZE 4
 #define CET_JMP_INSN_SIZE 7  /* indirect jump + prefix */
+#define NOP_INSN_SIZE   1
 
 int disasm_check_insns(struct mcount_disasm_engine *disasm,
 		       struct mcount_dynamic_info *mdi,


### PR DESCRIPTION
Let's say there is a simple program 'shared_ptr.cc' as follows.
```cpp
  $ cat shared_ptr.cc
  #include <memory>

  int main()
  {
          std::shared_ptr<int> p(new int);
  }
```
If we compile this program with -fpatchable-function-entry, uftrace
record with arguments gets failed as follows.
```
  $ g++ -fpatchable-function-entry=5 -g -o shared_ptr.fpatchable shared_ptr.cc

  $ uftrace --no-libcall -a -P. shared_ptr.fpatchable
  fstack: /home/honggyu/work/uftrace/utils/fstack.c:1595:read_task_ustack
   ERROR: record missing argument info for std::shared_ptr::shared_ptr
```
This problem happens because dwarf_getsrc_die returns NULL with the
start address of functions and it's assigned to Dwarf_Line *line.
```
  line = dwarf_getsrc_die(&cudie, dwarf_addr);
```
-fpatchable-function-entry=5 adds 5 NOP instructions at the function
prologue and sym->addr has the address of the first NOP instruction.
However, we don't have dwarf info at the first NOP instruction.

For example, we can't find the debug info at the following function.
```asm
  0000000000400ebc <std::_Sp_counted_ptr<int*, (__gnu_cxx::_Lock_policy)2>::_M_get_deleter(std::type_info const&)>:
    400ebc:       90                      nop
    400ebd:       90                      nop
    400ebe:       90                      nop
    400ebf:       90                      nop
    400ec0:       90                      nop
    400ec1:       55                      push   %rbp
    400ec2:       48 89 e5                mov    %rsp,%rbp
    400ec5:       48 89 7d f8             mov    %rdi,-0x8(%rbp)
    400ec9:       48 89 75 f0             mov    %rsi,-0x10(%rbp)
    400ecd:       b8 00 00 00 00          mov    $0x0,%eax
    400ed2:       5d                      pop    %rbp
    400ed3:       c3                      retq
    400ed4:       66 2e 0f 1f 84 00 00    nopw   %cs:0x0(%rax,%rax,1)
    400edb:       00 00 00
    400ede:       66 90                   xchg   %ax,%ax
```
The same problem can be shown with addr2line and it can't find the
source location info as follows.
```
  $ addr2line -e shared_ptr.fpatchable 0x400ebc
  ??:?
```
The debug info can be found from the first actual instruction.
```
  $ addr2line -e shared_ptr.fpatchable 0x400ec1
  /usr/include/c++/9/bits/shared_ptr_base.h:384
```
To avoid this problem, we should adjust dwarf_addr to the first actual
instruction by skipping NOP instructions.

Fixed: #1387
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>