### PR TITLE
tests: Fix test regression due to trailing whitespace

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -563,6 +563,10 @@ class TestBase:
         result_expect = self.sort(self.result)
         result_tested = self.sort(result_origin)  # for python3
 
+        # strip trailing whitespace for each line.
+        result_expect = '\n'.join([line.rstrip() for line in result_expect.split('\n')])
+        result_tested = '\n'.join([line.rstrip() for line in result_tested.split('\n')])
+
         ret = p.wait()
         if ret < 0:
             if timed_out:


### PR DESCRIPTION
The following patch trimed the trailing whitespace in the expected test
strings.

  b93c4152 uftrace: Introduce pre-commit and apply the changes

However, uftrace sometimes produces output with trailing whitespace so
some tests especially in graph command were failed due to this change.
```
  181 graph_full          : NG NG NG NG NG NG NG NG NG NG
  187 graph_field         : NG NG NG NG NG NG NG NG NG NG
  188 graph_field_none    : NG NG NG NG NG NG NG NG NG NG
  218 no_libcall_graph    : NG NG NG NG NG NG NG NG NG NG
```
This patch applies trailing whitespace strip for both expected and test
result strings for correct comparison.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>