### PR TITLE
uftrace: Better default message for uftrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,23 @@ The uftrace command has following subcommands:
 You can use `-h`, `-?` or `--help` option to see available commands and options.
 
     $ uftrace
-    Usage: uftrace [OPTION...]
-                [record|replay|live|report|info|dump|recv|graph|script|tui] [<program>]
-    Try `uftrace --help' or `uftrace --usage' for more information.
+    uftrace -- function (graph) tracer for userspace
+
+     usage: uftrace [COMMAND] [OPTION...] [<program>]
+
+     COMMAND:
+       record          Run a program and saves the trace data
+       replay          Show program execution in the trace data
+       report          Show performance statistics in the trace data
+       live            Do record and replay in a row (default)
+       info            Show system and program info in the trace data
+       dump            Show low-level trace data
+       recv            Save the trace data from network
+       graph           Show function call graph in the trace data
+       script          Run a script for recorded trace data
+       tui             Show text user interface for graph and report
+
+    Try `uftrace --help' or `man uftrace [COMMAND]' for more information.
 
 If omitted, it defaults to the `live` command which is almost same as running
 record and replay subcommand in a row (but does not record the trace info

--- a/doc/ko/README.md
+++ b/doc/ko/README.md
@@ -74,9 +74,23 @@ uftrace 명령어는 다음과 같은 하위 명령어들로 구성된다.
 사용 가능한 명령어와 옵션을 보기 위해 `-h`, `-?` 혹은 `--help` 옵션을 사용할 수 있다.
 
     $ uftrace
-    Usage: uftrace [OPTION...]
-                [record|replay|live|report|info|dump|recv|graph|script|tui] [<program>]
-    Try `uftrace --help' or `uftrace --usage' for more information.
+    uftrace -- function (graph) tracer for userspace
+
+     usage: uftrace [COMMAND] [OPTION...] [<program>]
+
+     COMMAND:
+       record          Run a program and saves the trace data
+       replay          Show program execution in the trace data
+       report          Show performance statistics in the trace data
+       live            Do record and replay in a row (default)
+       info            Show system and program info in the trace data
+       dump            Show low-level trace data
+       recv            Save the trace data from network
+       graph           Show function call graph in the trace data
+       script          Run a script for recorded trace data
+       tui             Show text user interface for graph and report
+
+    Try `uftrace --help' or `man uftrace [COMMAND]' for more information.
 
 만일 하위 명령어를 생략한다면, 기본적으로 record 와 replay 를 차례로 적용한 것과 동일한
 `live` 명령어를 수행한다. (하지만 추적 정보를 파일로 저장하지 않는다)

--- a/uftrace.c
+++ b/uftrace.c
@@ -108,11 +108,21 @@ enum options {
 };
 
 __used static const char uftrace_usage[] =
-"uftrace -- function (graph) tracer for userspace\n"
+" uftrace -- function (graph) tracer for userspace\n"
 "\n"
-"Usage: uftrace [COMMAND] [OPTION...] [<program>]\n"
+" usage: uftrace [COMMAND] [OPTION...] [<program>]\n"
 "\n"
-" COMMAND: record|replay|live|report|graph|info|dump|recv|script|tui\n"
+" COMMAND:\n"
+"   record          Run a program and saves the trace data\n"
+"   replay          Show program execution in the trace data\n"
+"   report          Show performance statistics in the trace data\n"
+"   live            Do record and replay in a row (default)\n"
+"   info            Show system and program info in the trace data\n"
+"   dump            Show low-level trace data\n"
+"   recv            Save the trace data from network\n"
+"   graph           Show function call graph in the trace data\n"
+"   script          Run a script for recorded trace data\n"
+"   tui             Show text user interface for graph and report\n"
 "\n";
 
 __used static const char uftrace_help[] =
@@ -216,6 +226,12 @@ __used static const char uftrace_help[] =
 "  -h, --help                 Give this help list\n"
 "      --usage                Give a short usage message\n"
 "  -V, --version              Print program version\n"
+"\n"
+" Try `man uftrace [COMMAND]' for more information.\n"
+"\n";
+
+__used static const char uftrace_footer[] =
+" Try `uftrace --help' or `man uftrace [COMMAND]' for more information.\n"
 "\n";
 
 static const char uftrace_shopts[] =
@@ -1306,6 +1322,7 @@ int main(int argc, char *argv[])
 
 	if (argc == 1) {
 		pr_out(uftrace_usage);
+		pr_out(uftrace_footer);
 		return 0;
 	}
 
@@ -1314,6 +1331,7 @@ int main(int argc, char *argv[])
 		return 0;
 	case -2:
 		pr_out(uftrace_usage);
+		pr_out(uftrace_footer);
 		return 0;
 	case -3:
 		if (opts.use_pager)
@@ -1333,6 +1351,7 @@ int main(int argc, char *argv[])
 		case UFTRACE_MODE_LIVE:
 		case UFTRACE_MODE_INVALID:
 			pr_out(uftrace_usage);
+			pr_out(uftrace_footer);
 			return 1;
 		}
 	}


### PR DESCRIPTION
Currently, when uftrace is used solely,
there are no explanations for COMMANDS like below:
```
  COMMAND: record|replay|live|report|graph|info|dump|recv|script|tui
```
But I think it's better to put explanation for each commands like perf, git, etc
for users who don't know uftrace well.
```
  ubuntu@ubuntu:~$ perf

   usage: perf [--version] [--help] [OPTIONS] COMMAND [ARGS]

   The most commonly used perf commands are:
     annotate        Read perf.data (created by perf record) and display annotated code
     archive         Create archive with object files with build-ids found in perf.data file
     bench           General framework for benchmark suites
     buildid-cache   Manage build-id cache.
     buildid-list    List the buildids in a perf.data file
     ...
```
So this commit adds better explanation for commands when uftrace is used solely.

Closes: #1348

Signed-off-by: Kang Minchul <tegongkang@gmail.com>