### PR TITLE
tests: Show stderr message in verbose mode test

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -537,7 +537,12 @@ class TestBase:
         test_cmd = self.runcmd()
         self.pr_debug("test command: %s" % test_cmd)
 
-        p = sp.Popen(test_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
+        if self.debug:
+            # In verbose mode, stderr is printed as is without redirection.
+            # This will inform error messages to users when something goes wrong.
+            p = sp.Popen(test_cmd, shell=True, stdout=sp.PIPE)
+        else:
+            p = sp.Popen(test_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
 
         class Timeout(Exception):
             pass


### PR DESCRIPTION
Currently, stderr of target test programs are swallowd by runtest.py,
but it'd be much better if it can be printed in verbose mode test.

Before:
```
  $ ./runtest.py -vdi -O0 251
  Start 1 tests with 1 worker
  Test case                 fi
  ------------------------: O0
    ...
  251 exception4          : SG
```
After:
```
  $ ./runtest.py -vi -O0 251
  Start 1 tests with 1 worker
  Test case                 fi
  ------------------------: O0
    ...
  terminate called after throwing an instance of 'std::runtime_error'
    what():  XXX error
  WARN: process crashed by signal 6: Aborted (si_code: 0)
  WARN:  if this happens only with uftrace, please consider -e/--estimate-return option.

  WARN: Backtrace from uftrace v0.11-58-g376d ( aarch64 dwarf python luajit tui perf sched dynamic )
  WARN: =====================================
  WARN: [2] (XXX::XXX[ffffba97c9e4] <= plthook_return[ffffba9b7618])
  WARN: [1] (XXX::XXX[aaaae5f80b60] <= main[aaaae5f80d64])
  WARN: [0] (main[aaaae5f80d14] <= <ffffba5b723c>[ffffba5b723c])
  WARN: child terminated by signal: 6: Aborted
  251 exception4          : SG
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>