### PR TITLE
fix undefined behavior.

### DIFF
--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -254,9 +254,9 @@ int read_events_file(struct uftrace_data *handle)
 		unsigned evt_id;
 		struct uftrace_event *ev;
 
-		if (!strncmp(line, "EVENT", 5)) {
-			sscanf(line + 7, "%u %[^:]:%s",
-			       &evt_id, provider, event);
+		if (!strncmp(line, "EVENT", 5) &&
+		     sscanf(line + 7, "%u %[^:]:%s",
+			    &evt_id, provider, event) == 3) {
 
 			ev = xmalloc(sizeof(*ev));
 			ev->id = evt_id;


### PR DESCRIPTION
utils: fix undefined behavior.

In your code you don't initialize evt_id, provider and event, don't check the result of running sscanf.
therefore, in the event of an incorrect call to sscanf, function read_events_file may fill in the data with random data.

Signed-off-by: ihsinme <ihsinme@gmail.com>