### PR TITLE
scripts: Add uftrace_event handling in dump.{py,lua} and fix dump.lua

### DIFF
--- a/scripts/dump.lua
+++ b/scripts/dump.lua
@@ -52,6 +52,17 @@ function uftrace_exit(ctx)
     end
 end
 
+function uftrace_event(ctx)
+    local _tid        = ctx['tid']
+    local _time       = ctx['timestamp']
+    local _address    = ctx["address"]
+    local _name       = ctx["name"]
+
+    local unit = math.exp(10, 9)
+    print(string.format('%d.%d %6d: [event] %s(%x)',
+            _time / unit, mod(_time, unit), _tid, _name, _address))
+end
+
 function uftrace_end()
     print('\nuftrace_end()')
 end

--- a/scripts/dump.lua
+++ b/scripts/dump.lua
@@ -1,10 +1,6 @@
 -- uftrace-option: --auto-args --nest-libcall
 -- UFTRACE_FUNCS = [ "foo", "bar" ]
 
-function mod(lhs, rhs)
-    return lhs - (math.floor(lhs / rhs) * rhs)
-end
-
 function uftrace_begin(ctx)
     print('uftrace_begin(ctx)')
     print(string.format('  record  : %s', ctx['record']))
@@ -23,9 +19,9 @@ function uftrace_entry(ctx)
     local _address    = ctx['address']
     local _name       = ctx['name']
 
-    local unit = math.exp(10, 9)
+    local unit = 1000000000
     print(string.format('%d.%d %6d: [entry] %s(%x) depth: %d',
-            _time / unit, mod(_time, unit), _tid, _name, _address, _depth))
+            _time / unit, _time % unit, _tid, _name, _address, _depth))
 
     if ctx['args'] ~= nil then
         for i, arg in ipairs(ctx['args']) do
@@ -42,9 +38,9 @@ function uftrace_exit(ctx)
     local _address    = ctx["address"]
     local _name       = ctx["name"]
 
-    local unit = math.exp(10, 9)
+    local unit = 1000000000
     print(string.format('%d.%d %6d: [exit ] %s(%x) depth: %d',
-            _time / unit, mod(_time, unit), _tid, _name, _address, _depth))
+            _time / unit, _time % unit, _tid, _name, _address, _depth))
 
     if ctx['retval'] ~= nil then
         local ret = ctx['retval']
@@ -58,9 +54,9 @@ function uftrace_event(ctx)
     local _address    = ctx["address"]
     local _name       = ctx["name"]
 
-    local unit = math.exp(10, 9)
+    local unit = 1000000000
     print(string.format('%d.%d %6d: [event] %s(%x)',
-            _time / unit, mod(_time, unit), _tid, _name, _address))
+            _time / unit, _time % unit, _tid, _name, _address))
 end
 
 function uftrace_end()

--- a/scripts/dump.py
+++ b/scripts/dump.py
@@ -54,6 +54,17 @@ def uftrace_exit(ctx):
         ret = ctx["retval"]
         print("  retval  %s: %s" % (type(ret), ret))
 
+# uftrace_event is executed for each event.
+def uftrace_event(ctx):
+    _tid        = ctx["tid"]
+    _time       = ctx["timestamp"]
+    _address    = ctx["address"]
+    _name       = ctx["name"]
+
+    unit = 10 ** 9
+    print("%d.%d %6d: [event] %s(%x)" %
+            (_time / unit, _time % unit, _tid, _name, _address))
+
 # uftrace_end is optional, so can be omitted.
 def uftrace_end():
     print("\nuftrace_end()")


### PR DESCRIPTION
This PR adds uftrace_event handling in dump.py and dump.lua as follows.

      $ gcc -pg -o t-sleep tests/s-sleep.c
      $ uftrace record --no-libcall t-sleep
      $ uftrace script -S scripts/dump.py
      uftrace_begin(ctx)
        record  : False
        version : v0.11-63-g6eba47 ( x86_64 dwarf python luajit tui perf sched dynamic )
        cmds    :

      9826991.615165883  17706: [entry] main(400850) depth: 0
      9826991.615166494  17706: [entry] foo(40082a) depth: 1
      9826991.615166805  17706: [entry] mem_alloc(4007db) depth: 2
      9826991.615167952  17706: [exit ] mem_alloc(4007db) depth: 2
      9826991.615169119  17706: [entry] bar(400810) depth: 2
      9826991.615185663  17706: [event] linux:sched-out(30d42)
      9826991.617290083  17706: [event] linux:sched-in(30d41)
      9826991.617296237  17706: [exit ] bar(400810) depth: 2
      9826991.617298178  17706: [entry] mem_free(4007f4) depth: 2
      9826991.617301510  17706: [exit ] mem_free(4007f4) depth: 2
      9826991.617301821  17706: [exit ] foo(40082a) depth: 1
      9826991.617302177  17706: [exit ] main(400850) depth: 0

      uftrace_end()

It also fixes a timestamp print error in `dump.lua` script.
In dump.lua script, timestamp print logic is incorrect so the timestamp
output looks very different from dump.py output as follows.

      $ uftrace script -S scripts/dump.py | grep event
      9826512.975114342  17094: [event] linux:sched-out(30d42)
      9826512.977219263  17094: [event] linux:sched-in(30d41)

      $ uftrace script -S scripts/dump.lua | grep event
      446122998880.7426  17094: [event] linux:sched-out(30d42)
      446122998975.19834  17094: [event] linux:sched-in(30d41)

This PR also fixes the timestamp logic and the output now looks same as
dump.py output as follows.

      $ uftrace script -S scripts/dump.lua | grep event
      9826512.975114342  17094: [event] linux:sched-out(30d42)
      9826512.977219264  17094: [event] linux:sched-in(30d41)

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>