### PR TITLE
uftrace: correct minor spelling errors

### DIFF
--- a/libmcount/wrap.c
+++ b/libmcount/wrap.c
@@ -389,7 +389,7 @@ __visible_default void * __cxa_begin_catch(void *exception)
 
 		mcount_rstack_reset_exception(mtdp, frame_addr);
 		mtdp->in_exception = false;
-		pr_dbg2("%s: exception catched begin on [%d]\n",
+		pr_dbg2("%s: exception caught begin on [%d]\n",
 			__func__, mtdp->idx);
 	}
 
@@ -401,7 +401,7 @@ __visible_default void __cxa_end_catch(void)
 	if (unlikely(real_cxa_end_catch == NULL))
 		mcount_hook_functions();
 
-	pr_dbg2("%s: exception catched end\n", __func__);
+	pr_dbg2("%s: exception caught end\n", __func__);
 	real_cxa_end_catch();
 }
 

--- a/misc/version.sh
+++ b/misc/version.sh
@@ -26,7 +26,7 @@ if test -d .git -a -n "$(git --version 2>/dev/null)"; then
 fi
 
 if test -z "${GIT_VERSION}" -a -n "${FILE_VERSION}"; then
-    # do not update file version if git version is not avaiable
+    # do not update file version if git version is not available
     exit 0
 fi
 

--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -406,7 +406,7 @@ static void add_pattern_event(struct list_head *events,
 	filename = get_tracing_file("available_events");
 	fp = fopen(filename, "r");
 	if (fp == NULL)
-		pr_err("failed to open 'tracing/available_event' file");
+		pr_err("failed to open 'tracing/available_events' file");
 
 	while (fgets(buf, sizeof(buf), fp) != NULL) {
 		/* it's ok to have a trailing '\n' */
@@ -875,7 +875,7 @@ void list_kernel_events(void)
 	filename = get_tracing_file("available_events");
 	fp = fopen(filename, "r");
 	if (fp == NULL) {
-		pr_dbg("failed to open 'tracing/avaiable_events");
+		pr_dbg("failed to open 'tracing/available_events");
 		return;
 	}
 


### PR DESCRIPTION
as found by the debian automated-checking tool Lintian. None of these
matter particularly, but it's a patch we apply to the Debian packaging,
so I'll pass it along.

Signed-off-by: paul cannon <pik@debian.org>