### PR TITLE
arch/arm: fix build (under some circumstances)

### DIFF
--- a/arch/arm/mcount.S
+++ b/arch/arm/mcount.S
@@ -97,12 +97,14 @@ ENTRY(mcount_return)
 	push 	{r0-r3, lr, pc}  /* ensure 8-byte alignment */
 	mov	r0, sp
 #ifdef HAVE_ARM_HARDFP
+	.fpu vfpv2
 	vpush	{d0-d1}
 #endif
 
 	bl 	mcount_exit
 
 #if HAVE_ARM_HARDFP
+	.fpu vfpv2
 	vpop	{d0-d1}
 #endif
 	/* update return address (pc) in the stack */

--- a/arch/arm/plthook.S
+++ b/arch/arm/plthook.S
@@ -57,12 +57,14 @@ ENTRY(plthook_return)
 	push {r0-r3, lr, pc}  /* ensure 8-byte alignment */
 	mov r0, sp
 #ifdef HAVE_ARM_HARDFP
+	.fpu vfpv2
 	vpush {d0-d1}
 #endif
 
 	bl plthook_exit
 
 #ifdef HAVE_ARM_HARDFP
+	.fpu vfpv2
 	vpop {d0-d1}
 #endif
 	/* update return address (pc) in the stack */


### PR DESCRIPTION
This patch, supplied by Nobuhiro Iwamatsu <iwamatsu@debian.org>, allows
the uftrace deb to build cleanly on the "armhf" arch (that's the Debian
name for arm-linux-gnueabihf).

The errors as encountered by the build daemon can be seen in the log at:

  https://buildd.debian.org/status/fetch.php?pkg=uftrace&arch=armhf&ver=0.11-3&stamp=1647358997&raw=0

Here is a snippet of that output:

    gcc -D_GNU_SOURCE -ffile-prefix-map=/<<PKGBUILDDIR>>=. -Wdate-time
            -D_FORTIFY_SOURCE=2 -iquote /<<PKGBUILDDIR>> -iquote /<<PKGBUILDDIR>> \
            -iquote /<<PKGBUILDDIR>>/arch/arm -Wdeclaration-after-statement -W
            -Wall -Wno-unused-parameter -Wno-missing-field-initializers -O2 -g \
                    -DDEBUG_MODE=0 -DHAVE_CXA_DEMANGLE -DHAVE_LIBPYTHON3 \
            -I/usr/include/python3.9  -DLIBPYTHON_VERSION=3.9 -DHAVE_PERF_CLOCKID \
            -DHAVE_PERF_CTXSW -DHAVE_ARM_HARDFP -DHAVE_LIBNCURSES -D_DEFAULT_SOURCE \
            -D_XOPEN_SOURCE=600  -DHAVE_LIBELF -DHAVE_LIBDW -DHAVE_LIBCAPSTONE \
            -I/usr/include/capstone    -fPIC -fvisibility=hidden \
            -fno-omit-frame-pointer -c -o /<<PKGBUILDDIR>>/arch/arm/mcount.op \
            /<<PKGBUILDDIR>>/arch/arm/mcount.S
    /<<PKGBUILDDIR>>/arch/arm/mcount.S: Assembler messages:
    /<<PKGBUILDDIR>>/arch/arm/mcount.S:100: Error: selected processor does not support `vpush {d0-d1}' in ARM mode
    /<<PKGBUILDDIR>>/arch/arm/mcount.S:106: Error: selected processor does not support `vpop {d0-d1}' in ARM mode
    make[2]: *** [Makefile:25: /<<PKGBUILDDIR>>/arch/arm/mcount.op] Error 1
    make[1]: *** [Makefile:275: /<<PKGBUILDDIR>>/arch/arm/mcount-entry.op] Error 2

This patch tells the assembler that it can assume that the host has an
FPU of at least VFPv2, since that is the least FPU which has support for
vpush and vpop (as I understand it).

Now, on my own armhf box (an ARMv6 with VFPv2 running Raspbian), this
patch is not necessary. Everything builds without the .fpu directive.
There's some piece of the toolchain that I don't understand well that's
doing some magic to determine what sort of fpu it thinks the host has.
All I can tell is that there are at least _some_ circumstances where the
.fpu vfpv2 directive is necessary before vpush/vpop.

If you would prefer, we can probably also make this happen using the
right -mfpu= option to gcc.

Signed-off-by: paul cannon <pik@debian.org>