### PR TITLE
build: Replace -executable to -perm -u=x,g=x,o=x

### DIFF
--- a/check-deps/Makefile
+++ b/check-deps/Makefile
@@ -63,6 +63,9 @@ $(CHKDIR)/check-tstamp: PHONY
 	@if [ `id -u` -eq 0 ]; then chmod 666 $@; fi
 
 check-clean:
-	@$(RM) $(shell find $(CHKDIR) -type f -executable 2> /dev/null) $(CHKDIR)/check-tstamp $(CHKDIR)/*.o
+	# This is to find and remove all the executable files.
+	# In overlayfs, entire files are matched with -executable option,
+	# so -perm option is used instead.
+	@$(RM) $(shell find $(CHKDIR) -type f -perm -u=x,g=x,o=x 2> /dev/null) $(CHKDIR)/check-tstamp $(CHKDIR)/*.o
 
 .PHONY: PHONY;


### PR DESCRIPTION
If uftrace directory is under overlay file system, -executable option in
find doesn't work as expected and it gives the entire files.  It makes
'make check-clean' remove all the files under check-deps.

This patch replaces -executable to -perm -u=x,g=x,o=x to avoid such
problem in check-deps/Makefile.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>