### PR TITLE
clock: Fix clock_source setup logic to handle perf events

### DIFF
--- a/cmds/record.c
+++ b/cmds/record.c
@@ -1810,6 +1810,7 @@ static void setup_writers(struct writer_data *wd, struct opts *opts)
 		opts->nr_thread = wd->nr_cpu;
 
 	if (has_perf_event) {
+		setup_clock_id(opts->clock);
 		if (setup_perf_record(perf, wd->nr_cpu, wd->pid,
 				      opts->dirname, has_sched_event) < 0)
 			has_perf_event = false;

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -197,8 +197,6 @@ static inline void mcount_watch_setup(struct mcount_thread_data *mtdp) {}
 static inline void mcount_watch_release(struct mcount_thread_data *mtdp) {}
 #endif /* DISABLE_MCOUNT_FILTER */
 
-extern clockid_t clock_source;
-
 static inline uint64_t mcount_gettime(void)
 {
 	struct timespec ts;

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -92,8 +92,6 @@ unsigned long mcount_return_fn;
 /* do not hook return address and inject EXIT record between functions */
 bool mcount_estimate_return;
 
-clockid_t clock_source = CLOCK_MONOTONIC;
-
 __weak void dynamic_return(void) { }
 
 #ifdef DISABLE_MCOUNT_FILTER
@@ -1760,15 +1758,6 @@ static void mcount_script_init(enum uftrace_pattern_type patt_type)
 	strv_free(&info.cmds);
 }
 
-static const struct {
-	const char *name;
-	clockid_t clock_id;
-} trace_clocks[] = {
-	{ "mono",	CLOCK_MONOTONIC		},
-	{ "mono_raw",	CLOCK_MONOTONIC_RAW	},
-	{ "boot",	CLOCK_BOOTTIME		},
-};
-
 static __used void mcount_startup(void)
 {
 	char *pipefd_str;
@@ -1921,16 +1910,8 @@ static __used void mcount_startup(void)
 		mcount_setup_plthook(mcount_exename, nest_libcall);
 	}
 
-	if (clock_str) {
-		size_t i;
-
-		for (i = 0; i < ARRAY_SIZE(trace_clocks); i++) {
-			if (!strcmp(clock_str, trace_clocks[i].name)) {
-				clock_source = trace_clocks[i].clock_id;
-				break;
-			}
-		}
-	}
+	if (clock_str)
+		setup_clock_id(clock_str);
 
 	pthread_atfork(atfork_prepare_handler, NULL, atfork_child_handler);
 

--- a/uftrace.c
+++ b/uftrace.c
@@ -1322,6 +1322,7 @@ int main(int argc, char *argv[])
 		.event_skip_out = true,
 		.patt_type      = PATT_REGEX,
 		.show_args      = true,
+		.clock		= "mono",
 	};
 	int ret = -1;
 	char *pager = NULL;

--- a/utils/perf.c
+++ b/utils/perf.c
@@ -39,7 +39,7 @@ static int open_perf_event(int pid, int cpu, int use_ctxsw)
 		.task			= 1,
 		.comm			= 1,
 		.use_clockid		= 1,
-		.clockid		= CLOCK_MONOTONIC,
+		.clockid		= clock_source,
 #ifdef HAVE_PERF_CTXSW
 		.context_switch		= use_ctxsw,
 #endif

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -379,6 +379,29 @@ char *read_exename(void)
 	return exename;
 }
 
+clockid_t clock_source = CLOCK_MONOTONIC;
+
+static const struct {
+	const char *name;
+	clockid_t clock_id;
+} trace_clocks[] = {
+	{ "mono",	CLOCK_MONOTONIC		},
+	{ "mono_raw",	CLOCK_MONOTONIC_RAW	},
+	{ "boot",	CLOCK_BOOTTIME		},
+};
+
+void setup_clock_id(const char *clock_str)
+{
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(trace_clocks); i++) {
+		if (!strcmp(clock_str, trace_clocks[i].name)) {
+			clock_source = trace_clocks[i].clock_id;
+			break;
+		}
+	}
+}
+
 bool check_time_range(struct uftrace_time_range *range, uint64_t timestamp)
 {
 	/* maybe it's called before first timestamp set */

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -18,6 +18,7 @@
 #include <ctype.h>
 #include <limits.h>
 #include <signal.h>
+#include <time.h>
 
 #include "compiler.h"
 
@@ -336,6 +337,9 @@ int create_directory(const char *dirname);
 int remove_directory(const char *dirname);
 int chown_directory(const char *dirname);
 char *read_exename(void);
+
+extern clockid_t clock_source;
+void setup_clock_id(const char *clock_str);
 
 void print_time_unit(uint64_t delta_nsec);
 void print_diff_percent(uint64_t base_nsec, uint64_t delta_nsec);


### PR DESCRIPTION
The --clock option currently doesn't change the clock id of perf events
and this makes the replay output incorrect when clock id is changed.

This patch applies clock id change to perf event as well and moves
clock_source from libmcount/mcount.c to utils/utils.c.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>