### PR TITLE
symbol: Fix incorrect symbol file loading

### DIFF
--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -1034,7 +1034,7 @@ static void load_module_symbol(struct symtabs *symtabs, struct uftrace_module *m
 			if (check_symbol_file(symfile, buf, sizeof(buf),
 					      build_id, sizeof(build_id)) > 0 &&
 			    ((strcmp(buf, m->name) && !(flags & SYMTAB_FL_SYMS_DIR)) ||
-			     (build_id[0] && strcmp(build_id, m->build_id)))) {
+			     (build_id[0] && m->build_id[0] && strcmp(build_id, m->build_id)))) {
 				char *new_file;
 
 				new_file = make_new_symbol_filename(symfile,


### PR DESCRIPTION
We also need to check if m->build_id[0] is not NULL just like we did for
build_id[0].

When m->build_id[0] is empty, it fails loading symbol files.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>