### PR TITLE
tests: Fix a regression in 248 dynamic_dlopen

### DIFF
--- a/tests/t248_dynamic_dlopen.py
+++ b/tests/t248_dynamic_dlopen.py
@@ -6,20 +6,22 @@ class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'dlopen', """
 # DURATION     TID     FUNCTION
-           [108977] | main() {
-187.389 us [108977] |   dlopen();
-  0.754 us [108977] |   dlsym();
-           [108977] |   lib_a() {
-           [108977] |     lib_b() {
-  1.083 us [108977] |       lib_c();
-  1.331 us [108977] |     } /* lib_b */
-  1.614 us [108977] |   } /* lib_a */
-  9.988 us [108977] |   dlclose();
-174.777 us [108977] |   dlopen();
-  0.764 us [108977] |   dlsym();
-  0.765 us [108977] |   foo();
-108.059 us [108977] |   dlclose();
-488.088 us [108977] | } /* main */
+            [ 29979] | main() {
+ 401.827 us [ 29979] |   dlopen();
+   1.339 us [ 29979] |   dlsym();
+            [ 29979] |   lib_a() {
+            [ 29979] |     lib_b() {
+   1.509 us [ 29979] |       lib_c();
+   1.993 us [ 29979] |     } /* lib_b */
+   2.468 us [ 29979] |   } /* lib_a */
+  14.949 us [ 29979] |   dlclose();
+ 346.494 us [ 29979] |   dlopen();
+   0.925 us [ 29979] |   dlsym();
+            [ 29979] |   foo() {
+   0.163 us [ 29979] |     AAA::bar();
+   1.706 us [ 29979] |   } /* foo */
+  11.246 us [ 29979] |   dlclose();
+ 788.643 us [ 29979] | } /* main */
 """)
 
     def prerun(self, timeout):


### PR DESCRIPTION
The test 248 dynamic_dlopen fails since the following patch.

  0096b3f3 dynamic: Do not skip weak symbol functions for dynamic tracing

It's because AAA:bar() is a weak symbol so it wasn't shown before, but
this patch makes it appear.
```
  $ nm -C libfoo.so
        ...
  0000000000000659 W AAA::bar(int)
```
This patch fixes the test by adding AAA:bar() in the expected test
result.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>