### PR TITLE
travis: Run system tests in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 - python3 -m pip install pre-commit
 - pre-commit install
 
-script: pre-commit run -s HEAD~1 -o HEAD --show-diff-on-failure && ./configure && make ASAN=1 && make ASAN=1 unittest
+script: pre-commit run -s HEAD~1 -o HEAD --show-diff-on-failure && ./configure && make ASAN=1 && make ASAN=1 unittest && (cd tests && ./runtest.py -O2 > /dev/null && cat failed-tests.txt)
 
 env:
   global:


### PR DESCRIPTION
It'd be more helpful to run our system tests in travis.

But there are some known test failures so we show the failed tests but
doesn't raise a red flag in the CI test result even if some tests fails.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>