### PR TITLE
event: Fix memory leaks by adding finish_events_file()

### DIFF
--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -9,6 +9,7 @@
 #include <sys/stat.h>
 
 #include "uftrace.h"
+#include "utils/event.h"
 #include "utils/utils.h"
 #include "utils/fstack.h"
 #include "utils/filter.h"
@@ -217,60 +218,6 @@ out:
 		errno = EINVAL;
 
 	return ret;
-}
-
-/**
- * read_events_file - read 'events.txt' file from data directory
- * @dirname: name of the data directory
- *
- * This function read the events file in the @dirname and build event
- * information (for userspace).
- *
- * It returns 0 for success, -1 for error.
- */
-int read_events_file(struct uftrace_data *handle)
-{
-	FILE *fp;
-	char *fname = NULL;
-	char *line = NULL;
-	size_t sz = 0;
-
-	xasprintf(&fname, "%s/%s", handle->dirname, "events.txt");
-
-	fp = fopen(fname, "r");
-	if (fp == NULL) {
-		/* it might hit no events, so no file is ok */
-		if (errno == ENOENT)
-			errno = 0;
-
-		free(fname);
-		return -errno;
-	}
-
-	pr_dbg("reading %s file\n", fname);
-	while (getline(&line, &sz, fp) >= 0) {
-		char provider[512];
-		char event[512];
-		unsigned evt_id;
-		struct uftrace_event *ev;
-
-		if (!strncmp(line, "EVENT", 5) &&
-		     sscanf(line + 7, "%u %[^:]:%s",
-			    &evt_id, provider, event) == 3) {
-
-			ev = xmalloc(sizeof(*ev));
-			ev->id = evt_id;
-			ev->provider = xstrdup(provider);
-			ev->event = xstrdup(event);
-
-			list_add_tail(&ev->list, &handle->events);
-		}
-	}
-
-	free(line);
-	fclose(fp);
-	free(fname);
-	return 0;
 }
 
 static void snprint_timestamp(char *buf, size_t sz, uint64_t timestamp)

--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -605,6 +605,8 @@ void __close_data_file(struct opts *opts, struct uftrace_data *handle,
 		free(handle->kernel);
 	}
 
+	finish_events_file(handle);
+
 	if (has_perf_data(handle))
 		finish_perf_data(handle);
 

--- a/utils/event.c
+++ b/utils/event.c
@@ -241,6 +241,22 @@ char * event_get_data_str(unsigned evt_id, void *data, bool verbose)
 }
 
 /**
+ * finish_events_file - cleanup memory for events in the given handle
+ * @handle: uftrace_data data structure
+ */
+void finish_events_file(struct uftrace_data *handle)
+{
+	struct uftrace_event *ev, *tmp;
+
+	list_for_each_entry_safe(ev, tmp, &handle->events, list) {
+		list_del(&ev->list);
+		free(ev->provider);
+		free(ev->event);
+		free(ev);
+	}
+}
+
+/**
  * read_events_file - read 'events.txt' file from data directory
  * @handle: uftrace_data data structure
  *

--- a/utils/event.h
+++ b/utils/event.h
@@ -35,4 +35,6 @@ struct uftrace_pmu_branch {
 char * event_get_name(struct uftrace_data *handle, unsigned evt_id);
 char * event_get_data_str(unsigned evt_id, void *data, bool verbose);
 
+int read_events_file(struct uftrace_data *handle);
+
 #endif  /* UFTRACE_EVENT_H */

--- a/utils/event.h
+++ b/utils/event.h
@@ -35,6 +35,7 @@ struct uftrace_pmu_branch {
 char * event_get_name(struct uftrace_data *handle, unsigned evt_id);
 char * event_get_data_str(unsigned evt_id, void *data, bool verbose);
 
+void finish_events_file(struct uftrace_data *handle);
 int read_events_file(struct uftrace_data *handle);
 
 #endif  /* UFTRACE_EVENT_H */


### PR DESCRIPTION
This PR fixes memory leaks when handling events.txt read.
```
  $ make ASAN=1
  $ cd tests
```
Before:
```
  $ ./runtest.py -vdp -O0 147
      ...
  SUMMARY: AddressSanitizer: 54 byte(s) leaked in 3 allocation(s).
  t147_event_sdt: -pg -O0 returns 1

  147 event_sdt           : NZ
```
After:
```
  $ ./runtest.py -vdp -O0 147
      ...
  147 event_sdt           : OK
```
Fixed: #1427
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>