### PR TITLE
uftrace: Fix memory leak in parse_option

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -1233,6 +1233,7 @@ static void free_opts(struct opts *opts)
 	free(opts->patch);
 	free(opts->caller);
 	free(opts->watch);
+	free(opts->hide);
 	free_parsed_cmdline(opts->run_cmd);
 }
 


### PR DESCRIPTION
This PR fixes memory leak in t252, which happens
when parse_option is called.

Before:
```
  $ ./runtest.py -vdp -O0 252
      ...
  SUMMARY: AddressSanitizer: 2 byte(s) leaked in 1 allocation(s).
  t252_filter_H: -pg -O0 returns 1

  252 filter_H            : NZ

```
After:
```
  $ ./runtest.py -vdp -O0 252
      ...
  252 filter_H            : OK

```
Fixed: #1429

Signed-off-by: Kang Minchul <tegongkang@gmail.com>