### PR TITLE
arch: Fix missing renaming in arm and i386

### DIFF
--- a/arch/arm/mcount-arch.h
+++ b/arch/arm/mcount-arch.h
@@ -22,10 +22,10 @@ struct mcount_regs {
 struct mcount_arch_context {
 };
 
-struct symtabs;
+struct uftrace_sym_info;
 
 #define FIX_PARENT_LOC
-unsigned long * mcount_arch_parent_location(struct symtabs *symtabs,
+unsigned long * mcount_arch_parent_location(struct uftrace_sym_info *symtabs,
 					    unsigned long *parent_loc,
 					    unsigned long child_ip);
 

--- a/arch/arm/mcount-support.c
+++ b/arch/arm/mcount-support.c
@@ -231,7 +231,7 @@ static void analyze_mcount_instructions(unsigned short *insn, struct lr_offset *
 }
 
 /* This code is only meaningful on THUMB2 mode: @loc = $sp + 4 */
-unsigned long *mcount_arch_parent_location(struct symtabs *symtabs,
+unsigned long *mcount_arch_parent_location(struct uftrace_sym_info *symtabs,
 					   unsigned long *parent_loc,
 					   unsigned long child_ip)
 {

--- a/arch/i386/mcount-arch.h
+++ b/arch/i386/mcount-arch.h
@@ -23,7 +23,7 @@ struct mcount_arch_context {
 };
 
 #define FIX_PARENT_LOC
-unsigned long * mcount_arch_parent_location(struct symtabs *symtabs,
+unsigned long * mcount_arch_parent_location(struct uftrace_sym_info *symtabs,
 					    unsigned long *parent_loc,
 					    unsigned long child_ip);
 #define ARCH_PLT0_SIZE  16

--- a/arch/i386/mcount-support.c
+++ b/arch/i386/mcount-support.c
@@ -194,7 +194,7 @@ void mcount_restore_arch_context(struct mcount_arch_context *ctx)
 	we will find it, and we will replace it.
 	GOOD LUCK!
 */
-unsigned long *mcount_arch_parent_location(struct symtabs *symtabs,
+unsigned long *mcount_arch_parent_location(struct uftrace_sym_info *symtabs,
                                             unsigned long *parent_loc,
                                             unsigned long child_ip)
 {


### PR DESCRIPTION
This patch is to fix missing renaming in arm and i386.
The original renaming change was introduced in the following commit.

  1b16f4ed uftrace: Rename 'symtabs' to 'uftrace_sym_info'

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>