### PR TITLE
A few fixes and enhancement for i386 testing

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -107,6 +107,8 @@ class TestBase:
         self.option = ''
         self.exearg = 't-' + name
         self.test_feature()
+        if Elf.get_elf_machine(self.uftrace_cmd) == 'i386':
+            self.default_cflags.append('-m32')
 
     def set_compiler(self, compiler):
         if compiler == 'gcc':

--- a/tests/t269_arg_no_args_replay.py
+++ b/tests/t269_arg_no_args_replay.py
@@ -29,8 +29,8 @@ class TestCase(TestBase):
         return TestBase.build(self, name, cflags, ldflags)
 
     def prerun(self, timeout):
-        record_cmd = '%s record -d %s -A ^str_@arg1/s,arg2/s -R ^str_@retval/s %s' \
-                        % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s -A ^str_@arg1/s,arg2/s -R ^str_@retval/s %s %s' \
+                        % (TestBase.uftrace_cmd, TDIR, TestBase.default_opt, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t270_arg_no_args_dump.py
+++ b/tests/t270_arg_no_args_dump.py
@@ -44,8 +44,8 @@ reading 72944.dat
         return TestBase.build(self, name, cflags, ldflags)
 
     def prerun(self, timeout):
-        record_cmd = '%s record -d %s -A ^str_@arg1/s,arg2/s -R ^str_@retval/s %s' \
-                        % (TestBase.uftrace_cmd, TDIR, 't-' + self.name)
+        record_cmd = '%s record -d %s -A ^str_@arg1/s,arg2/s -R ^str_@retval/s %s %s' \
+                        % (TestBase.uftrace_cmd, TDIR, TestBase.default_opt, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 


### PR DESCRIPTION
This PR includes the following changes.
- afe48159 tests: Fix possibly incorrect libmcount.so loading
- 57b6b34e tests: Add -m32 option when the architecture is i386
- 31047961 tests: Add class Elf and move related code inside of runtest.py