### PR TITLE
travis: Upgrade travis to Ubuntu 22.04 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ compiler:
   - gcc
   - clang
 
-# Ubuntu 18.04 LTS
-dist: bionic
+# Ubuntu 22.04 LTS
+dist: jammy
 
 sudo: required
 


### PR DESCRIPTION
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>