### PR TITLE
misc: Add an exception for distros that doesn't use /etc/os-release

### DIFF
--- a/misc/install-deps.sh
+++ b/misc/install-deps.sh
@@ -9,6 +9,12 @@ fi
 
 OPT="${@}"
 
+if [ ! -f /etc/os-release ]; then
+    echo "Your distribution is not supported, so please install pacakges manually."
+    echo
+    exit
+fi
+
 distro=$(grep "^ID=" /etc/os-release | cut -d\= -f2 | sed -e 's/"//g')
 
 case $distro in
@@ -34,5 +40,6 @@ case $distro in
         apk $OPT add luajit-dev || true
         apk $OPT add capstone-dev || true ;;
     *) # we can add more install command for each distros.
-        echo "\"$distro\" is not supported distro, so please install packages manually." ;;
+        echo "\"$distro\" is not supported distro, so please install packages manually."
+        echo ;;
 esac


### PR DESCRIPTION
Although many linux distributions use /etc/os-release,
there are some systems that does not use that for OS identification.
(especially for some traditional non-systemd linux distros or macOS)

When these kinds on distros run /misc/install-deps.sh,
message is printed like below:
```
  $ sudo ./install-deps.sh
  grep: /etc/os-release: No such file or directory
  "" is not supported distro, so please install packages manually.
```
So this commit adds an exception for those does not use
/etc/os-release.

Signed-off-by: Kang Minchul <tegongkang@gmail.com>