### PR TITLE
utils: casting return value of aspritf to void.

### DIFF
--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -663,13 +663,13 @@ static int create_data(struct uftrace_opts *opts)
 	write_dlopen_info(opts->dirname, &dlopen_msg, "libnothing.so");
 
 	/* create_session() requires a map file even if it's empty */
-	asprintf(&filename, "%s/sid-%.*s.map",
+	(void)asprintf(&filename, "%s/sid-%.*s.map",
 		 opts->dirname, SESSION_ID_LEN, TEST_SESSION_ID);
 	creat(filename, 0644);
 	free(filename);
 
 	/* open_data_file() requires at least one non-empty data file */
-	asprintf(&filename, "%s/%d.dat", opts->dirname, task_msg.pid);
+	(void)asprintf(&filename, "%s/%d.dat", opts->dirname, task_msg.pid);
 	fp = fopen(filename, "w");
 	fprintf(fp, "%s\n", "empty file");
 	fclose(fp);


### PR DESCRIPTION
Fixed: #1453

I amended the commit to make my changes clear and followed the guidelines more correctly.

Fixed the issue by casting the return of asprintf to void to avoid unused variable warnings. Based on the expectation that the bytes returned from asprintf are unnecessary for the program's functionality.

Signed-off-by: Sultan AlRashed [sultan.m.rashed@gmail.com](mailto:sultan.m.rashed@gmail.com)