### PR TITLE
doc: Add pre-commit installation command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,13 @@ with the help of [pre-commit](https://pre-commit.com) and
 [clang-format](https://clang.llvm.org/docs/ClangFormat.html) so that
 our source code has a consistent coding style at all times.
 
-You can install pre-commit as follows.
+You need to install pre-commit package but please note that python version 3.7
+or higher is required.  The installation can be done as follows.
+
+    $ python3 -m pip install pre-commit
+
+Then you can simply install a pre-commit hook inside the uftrace source
+directory as follows.
 
     $ pre-commit install
     pre-commit installed at .git/hooks/pre-commit


### PR DESCRIPTION
pre-commit is installed via pip[1].
If this CONTRIBUTING.md doesn't guide how to install the package,
future contributors cannot know how to download and run the command below.

  $ pre-commit install

So this commit adds pre-commit package installation command in
CONTRIBUTING.md

[1] https://pre-commit.com/#installation

Signed-off-by: Kang Minchul <tegongkang@gmail.com>