### PR TITLE
libmcount: Include capstone header in dynamic.h

### DIFF
--- a/libmcount/dynamic.h
+++ b/libmcount/dynamic.h
@@ -3,6 +3,10 @@
 
 #include <link.h>
 
+#ifdef HAVE_LIBCAPSTONE
+#include <capstone/capstone.h>
+#endif
+
 #include "utils/symbol.h"
 
 #define PAGE_SIZE 4096


### PR DESCRIPTION
After sorting the includes using .clang-format like below,
```
  diff --git a/.clang-format b/.clang-format
  index fb412706..2b293a1d 12234
  --- a/.clang-format
  +++ b/.clang-format
  @@ -125,7 +125,7 @@ PenaltyReturnTypeOnItsOwnLine: 60

   PointerAlignment: Right
   ReflowComments: false
  -SortIncludes: false
  +SortIncludes: true
   SortUsingDeclarations: false
   SpaceAfterCStyleCast: false
   SpaceAfterTemplateKeyword: true
```
this error comes out during make.
```
  minchul@minchul:~/workspace/uftrace$ make
    GEN      version.h
    CC       uftrace.o
    CC       cmds/dump.o
    CC       cmds/graph.o
    CC       cmds/info.o
    CC       cmds/live.o
    ...
    LINK     uftrace
    CC FPIC  libmcount/dynamic.op
  In file included from /home/minchul/workspace/uftrace/libmcount/dynamic.c:24:
  /home/minchul/workspace/uftrace/libmcount/dynamic.h:58:9: error: unknown type name ‘csh’
     58 |         csh engine;
        |         ^~~
  make: *** [Makefile:245: /home/minchul/workspace/uftrace/libmcount/dynamic.op] Error 1
```
So this commit includes capstone/capstone.h in libmcount/dynamic.h
in order to remove the error even when the includes are sorted.

Signed-off-by: Kang Minchul <tegongkang@gmail.com>