### PR TITLE
misc: Add Amazon Linux distro in install-deps.sh

### DIFF
--- a/misc/install-deps.sh
+++ b/misc/install-deps.sh
@@ -26,7 +26,7 @@ case $distro in
         dnf install $OPT pandoc elfutils-devel python3-devel ncurses-devel pkgconf-pkg-config
         dnf install $OPT luajit-devel || true
         dnf install $OPT capstone-devel || true ;;
-    "rhel" | "centos")
+    "rhel" | "centos" | "amzn")
         rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
         yum install $OPT pandoc elfutils-devel python3-devel ncurses-devel pkgconfig
         yum install $OPT luajit-devel || true


### PR DESCRIPTION
Although Amazon Linux uses yum as package manager[1],
current /misc/install-deps.sh cannot install packages because
ID of /etc/os-release is "amzn".
```
  $ cat /etc/os-release
  NAME="Amazon Linux"
  VERSION="2"
  ID="amzn"
  ID_LIKE="centos rhel fedora"
  VERSION_ID="2"
  PRETTY_NAME="Amazon Linux 2"
  ANSI_COLOR="0;33"
  CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
  HOME_URL="https://amazonlinux.com/"

  $ sudo ./install-deps.sh
  "amzn" is not supported distro, so please install packages manually.
```
So this commit adds Amazon Linux in /misc/install-deps.sh
so that Amazon Linux users can install uftrace dependency packages instantly.

[1] https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-software.html

Signed-off-by: Kang Minchul <tegongkang@gmail.com>