### PR TITLE
utils: detect tracefs or debugfs at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/demangle.c $(srcdir)/utils/utils.c
 LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/script.c $(srcdir)/utils/script-python.c $(srcdir)/utils/script-luajit.c
 LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/auto-args.c $(srcdir)/utils/dwarf.c
 LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/hashmap.c $(srcdir)/utils/argspec.c
+LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/tracefs.c
 LIBMCOUNT_UTILS_SRCS += $(wildcard $(srcdir)/utils/symbol*.c)
 LIBMCOUNT_UTILS_OBJS := $(patsubst $(srcdir)/utils/%.c,$(objdir)/libmcount/%.op,$(LIBMCOUNT_UTILS_SRCS))
 

--- a/libmcount/misc.c
+++ b/libmcount/misc.c
@@ -13,8 +13,6 @@
 #include "utils/tracefs.h"
 #include "utils/utils.h"
 
-static char *TRACING_DIR = NULL;
-
 /* old kernel never updates pid filter for a forked child */
 void update_kernel_tid(int tid)
 {
@@ -23,16 +21,13 @@ void update_kernel_tid(int tid)
 	int fd;
 	ssize_t len;
 
-	if (!TRACING_DIR && !find_tracing_dir(&TRACING_DIR))
-		return;
-
 	if (!kernel_pid_update)
 		return;
 
 	/* update pid filter for function tracing */
-	xasprintf(&filename, "%s/set_ftrace_pid", TRACING_DIR);
+	filename = get_tracing_file("set_ftrace_pid");
 	fd = open(filename, O_WRONLY | O_APPEND);
-	free(filename);
+	put_tracing_file(filename);
 
 	if (fd < 0) {
 		pr_dbg("open kernel ftrace pid filter failed\n");
@@ -47,9 +42,9 @@ void update_kernel_tid(int tid)
 	close(fd);
 
 	/* update pid filter for event tracing */
-	xasprintf(&filename, "%s/set_event_pid", TRACING_DIR);
+	filename = get_tracing_file("set_event_pid");
 	fd = open(filename, O_WRONLY | O_APPEND);
-	free(filename);
+	put_tracing_file(filename);
 	if (fd < 0) {
 		pr_dbg("open kernel event pid filter failed\n");
 		return;

--- a/libmcount/misc.c
+++ b/libmcount/misc.c
@@ -10,16 +10,21 @@
 
 #include "libmcount/internal.h"
 #include "libmcount/mcount.h"
+#include "utils/tracefs.h"
 #include "utils/utils.h"
+
+static char *TRACING_DIR = NULL;
 
 /* old kernel never updates pid filter for a forked child */
 void update_kernel_tid(int tid)
 {
-	static const char TRACING_DIR[] = "/sys/kernel/debug/tracing";
 	char *filename = NULL;
 	char buf[8];
 	int fd;
 	ssize_t len;
+
+	if (!TRACING_DIR && !find_tracing_dir(&TRACING_DIR))
+		return;
 
 	if (!kernel_pid_update)
 		return;

--- a/libmcount/misc.c
+++ b/libmcount/misc.c
@@ -16,46 +16,20 @@
 /* old kernel never updates pid filter for a forked child */
 void update_kernel_tid(int tid)
 {
-	char *filename = NULL;
 	char buf[8];
-	int fd;
-	ssize_t len;
 
 	if (!kernel_pid_update)
 		return;
 
-	/* update pid filter for function tracing */
-	filename = get_tracing_file("set_ftrace_pid");
-	fd = open(filename, O_WRONLY | O_APPEND);
-	put_tracing_file(filename);
-
-	if (fd < 0) {
-		pr_dbg("open kernel ftrace pid filter failed\n");
-		return;
-	}
-
 	snprintf(buf, sizeof(buf), "%d", tid);
-	len = strlen(buf);
-	if (write(fd, buf, len) != len)
-		pr_dbg("update kernel ftrace pid filter failed\n");
 
-	close(fd);
+	/* update pid filter for function tracing */
+	if (append_tracing_file("set_ftrace_pid", buf) < 0)
+		pr_dbg("write to kernel ftrace pid filter failed\n");
 
 	/* update pid filter for event tracing */
-	filename = get_tracing_file("set_event_pid");
-	fd = open(filename, O_WRONLY | O_APPEND);
-	put_tracing_file(filename);
-	if (fd < 0) {
-		pr_dbg("open kernel event pid filter failed\n");
-		return;
-	}
-
-	snprintf(buf, sizeof(buf), "%d", tid);
-	len = strlen(buf);
-	if (write(fd, buf, len) != len)
-		pr_dbg("update kernel event pid filter failed\n");
-
-	close(fd);
+	if (append_tracing_file("set_event_pid", buf) < 0)
+		pr_dbg("write to kernel ftrace pid filter failed\n");
 }
 
 const char *mcount_session_name(void)

--- a/utils/tracefs.c
+++ b/utils/tracefs.c
@@ -98,6 +98,20 @@ int open_tracing_file(const char *name, int flags)
 	return fd;
 }
 
+ssize_t read_tracing_file(const char *name, char *buf, size_t len)
+{
+	ssize_t ret;
+	int fd = open_tracing_file(name, O_RDONLY);
+
+	if (fd < 0)
+		return -1;
+
+	ret = read(fd, buf, len);
+	close(fd);
+
+	return ret;
+}
+
 int __write_tracing_file(int fd, const char *name, const char *val, bool append,
 			 bool correct_sys_prefix)
 {

--- a/utils/tracefs.c
+++ b/utils/tracefs.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "utils/tracefs.h"
+#include "utils/utils.h"
+
+#define PROC_MOUNTINFO "/proc/self/mountinfo"
+
+bool find_tracing_dir(char **trace_dir)
+{
+	FILE *fp;
+	char *line = NULL, fs_type[NAME_MAX], mount_point[PATH_MAX];
+	static char debugfs_suffix[] = "tracing";
+	bool debugfs_found = false;
+	size_t len;
+
+	if (*trace_dir)
+		return false;
+
+	fp = fopen(PROC_MOUNTINFO, "r");
+	if (fp == NULL)
+		return false;
+
+	while (getline(&line, &len, fp) > 0) {
+		/*
+		 * /proc/<pid>/mountinfo format:
+		 * 36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 .... ....
+		 * (1)(2)(3)   (4)   (5)      (6)      (7)   (8) (9) (10) (11)
+		 *                mount_point                  fs_type
+		 *
+		 * (9) is the file system type, (5) is the mount point relative
+		 * to self's root directory.
+		 */
+		sscanf(line, "%*i %*i %*u:%*u %*s %s %*s %*s - %s %*s %*s\n", mount_point, fs_type);
+
+		if (!strcmp(fs_type, "tracefs")) {
+			/* discard previously kept debugfs tracing dir */
+			if (*trace_dir)
+				free(*trace_dir);
+			xasprintf(trace_dir, "%s", mount_point);
+			pr_dbg2("Found tracefs at %s\n", mount_point);
+			pr_dbg2("Use %s as TRACING_DIR\n", *trace_dir);
+			return true;
+		}
+
+		if (!strcmp(fs_type, "debugfs")) {
+			xasprintf(trace_dir, "%s/%s", mount_point, debugfs_suffix);
+			pr_dbg2("Found debugfs at %s\n", mount_point);
+			pr_dbg2("Keep searching for tracefs...\n");
+			debugfs_found = true;
+		}
+	}
+
+	/* we couldn't find a tracefs, but found a debugfs... */
+	if (debugfs_found) {
+		pr_dbg2("Use %s as TRACING_DIR\n", *trace_dir);
+		return true;
+	}
+
+	pr_dbg2("No tracefs or debugfs found..!\n");
+	return false;
+}

--- a/utils/tracefs.c
+++ b/utils/tracefs.c
@@ -1,3 +1,4 @@
+#include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -6,7 +7,9 @@
 
 #define PROC_MOUNTINFO "/proc/self/mountinfo"
 
-bool find_tracing_dir(char **trace_dir)
+static char *TRACING_DIR = NULL;
+
+static bool find_tracing_dir(void)
 {
 	FILE *fp;
 	char *line = NULL, fs_type[NAME_MAX], mount_point[PATH_MAX];
@@ -14,7 +17,7 @@ bool find_tracing_dir(char **trace_dir)
 	bool debugfs_found = false;
 	size_t len;
 
-	if (*trace_dir)
+	if (TRACING_DIR)
 		return false;
 
 	fp = fopen(PROC_MOUNTINFO, "r");
@@ -35,16 +38,16 @@ bool find_tracing_dir(char **trace_dir)
 
 		if (!strcmp(fs_type, "tracefs")) {
 			/* discard previously kept debugfs tracing dir */
-			if (*trace_dir)
-				free(*trace_dir);
-			xasprintf(trace_dir, "%s", mount_point);
+			if (TRACING_DIR)
+				free(TRACING_DIR);
+			xasprintf(&TRACING_DIR, "%s", mount_point);
 			pr_dbg2("Found tracefs at %s\n", mount_point);
-			pr_dbg2("Use %s as TRACING_DIR\n", *trace_dir);
+			pr_dbg2("Use %s as TRACING_DIR\n", TRACING_DIR);
 			return true;
 		}
 
 		if (!strcmp(fs_type, "debugfs")) {
-			xasprintf(trace_dir, "%s/%s", mount_point, debugfs_suffix);
+			xasprintf(&TRACING_DIR, "%s/%s", mount_point, debugfs_suffix);
 			pr_dbg2("Found debugfs at %s\n", mount_point);
 			pr_dbg2("Keep searching for tracefs...\n");
 			debugfs_found = true;
@@ -53,10 +56,139 @@ bool find_tracing_dir(char **trace_dir)
 
 	/* we couldn't find a tracefs, but found a debugfs... */
 	if (debugfs_found) {
-		pr_dbg2("Use %s as TRACING_DIR\n", *trace_dir);
+		pr_dbg2("Use %s as TRACING_DIR\n", TRACING_DIR);
 		return true;
 	}
 
 	pr_dbg2("No tracefs or debugfs found..!\n");
 	return false;
+}
+
+char *get_tracing_file(const char *name)
+{
+	char *file = NULL;
+
+	if (!TRACING_DIR && !find_tracing_dir())
+		return NULL;
+
+	xasprintf(&file, "%s/%s", TRACING_DIR, name);
+	return file;
+}
+
+void put_tracing_file(char *file)
+{
+	free(file);
+}
+
+int open_tracing_file(const char *name, int flags)
+{
+	char *file;
+	int fd;
+	file = get_tracing_file(name);
+	if (!file) {
+		pr_dbg("cannot get tracing file: %s: %m\n", name);
+		return -1;
+	}
+
+	fd = open(file, flags);
+	if (fd < 0)
+		pr_dbg("cannot open tracing file: %s: %m\n", name);
+
+	put_tracing_file(file);
+	return fd;
+}
+
+int __write_tracing_file(int fd, const char *name, const char *val, bool append,
+			 bool correct_sys_prefix)
+{
+	int ret = -1;
+	ssize_t size = strlen(val);
+
+	if (correct_sys_prefix) {
+		char *newval = (char *)val;
+
+		if (!strncmp(val, "sys_", 4))
+			newval[0] = newval[2] = 'S';
+		else if (!strncmp(val, "compat_sys_", 11))
+			newval[7] = newval[9] = 'S';
+		else
+			correct_sys_prefix = false;
+	}
+
+	pr_dbg2("%s '%s' to tracing/%s\n", append ? "appending" : "writing", val, name);
+
+	if (write(fd, val, size) == size)
+		ret = 0;
+
+	if (correct_sys_prefix) {
+		char *newval = (char *)val;
+
+		if (!strncmp(val, "SyS_", 4))
+			newval[0] = newval[2] = 's';
+		else if (!strncmp(val, "compat_SyS_", 11))
+			newval[7] = newval[9] = 's';
+
+		/* write a whitespace to distinguish the previous pattern */
+		if (write(fd, " ", 1) < 0)
+			ret = -1;
+
+		pr_dbg2("%s '%s' to tracing/%s\n", append ? "appending" : "writing", val, name);
+
+		if (write(fd, val, size) == size)
+			ret = 0;
+	}
+
+	if (ret < 0)
+		pr_dbg("write '%s' to tracing/%s failed: %m\n", val, name);
+
+	return ret;
+}
+
+int write_tracing_file(const char *name, const char *val)
+{
+	int ret;
+	int fd = open_tracing_file(name, O_WRONLY | O_TRUNC);
+
+	if (fd < 0)
+		return -1;
+
+	ret = __write_tracing_file(fd, name, val, false, false);
+
+	close(fd);
+	return ret;
+}
+
+int append_tracing_file(const char *name, const char *val)
+{
+	int ret;
+	int fd = open_tracing_file(name, O_WRONLY | O_APPEND);
+
+	if (fd < 0)
+		return -1;
+
+	ret = __write_tracing_file(fd, name, val, true, false);
+
+	close(fd);
+	return ret;
+}
+
+int set_tracing_pid(int pid)
+{
+	char buf[16];
+
+	snprintf(buf, sizeof(buf), "%d", pid);
+	if (append_tracing_file("set_ftrace_pid", buf) < 0)
+		return -1;
+
+	/* ignore error on old kernel */
+	append_tracing_file("set_event_pid", buf);
+	return 0;
+}
+
+int set_tracing_clock(char *clock_str)
+{
+	/* set to default clock source if not given */
+	if (clock_str == NULL)
+		clock_str = "mono";
+	return write_tracing_file("trace_clock", clock_str);
 }

--- a/utils/tracefs.h
+++ b/utils/tracefs.h
@@ -1,0 +1,8 @@
+#ifndef UFTRACE_TRACEFS_H
+#define UFTRACE_TRACEFS_H
+
+#include <stdbool.h>
+
+bool find_tracing_dir(char **tracing_dir);
+
+#endif /* UFTRACE_TRACEFS_H */

--- a/utils/tracefs.h
+++ b/utils/tracefs.h
@@ -2,7 +2,24 @@
 #define UFTRACE_TRACEFS_H
 
 #include <stdbool.h>
+#include <stddef.h>
+#include <unistd.h>
 
-bool find_tracing_dir(char **tracing_dir);
+char *get_tracing_file(const char *name);
+
+void put_tracing_file(char *file);
+
+int open_tracing_file(const char *name, int flags);
+
+int write_tracing_file(const char *name, const char *val);
+
+int __write_tracing_file(int fd, const char *name, const char *val, bool append,
+			 bool correct_sys_prefix);
+
+int append_tracing_file(const char *name, const char *val);
+
+int set_tracing_pid(int pid);
+
+int set_tracing_clock(char *clock_str);
 
 #endif /* UFTRACE_TRACEFS_H */

--- a/utils/tracefs.h
+++ b/utils/tracefs.h
@@ -11,6 +11,8 @@ void put_tracing_file(char *file);
 
 int open_tracing_file(const char *name, int flags);
 
+ssize_t read_tracing_file(const char *name, char *buf, size_t len);
+
 int write_tracing_file(const char *name, const char *val);
 
 int __write_tracing_file(int fd, const char *name, const char *val, bool append,


### PR DESCRIPTION
Currently, uftrace interacts with kernel tracing system through
a fixed TRACING_DIR; /sys/kernel/debug/tracing, therefore fails
to trace kernel when a tracefs is mounted at a different location.

This commit introduces runtime detection tracefs or debugfs from
/proc/self/mountinfo (which is newer than /proc</self>/mounts).

Fixes #797 

Signed-off-by: Seonghyun Park <shp4rk@gmail.com>