### PR TITLE
uftrace: fix a memory leak in a exename of a opts struct

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -1219,6 +1219,7 @@ static void free_opts(struct uftrace_opts *opts)
 	free(opts->caller);
 	free(opts->watch);
 	free(opts->hide);
+	free(opts->exename);
 	free_parsed_cmdline(opts->run_cmd);
 }
 


### PR DESCRIPTION
After used the exename of opts stucture, it should be freed.
But there is missing a free function after used it,
so a free function is added.

Fixed: #1428