### PR TITLE
trivial: Remove duplicated #include directive

### DIFF
--- a/utils/report.c
+++ b/utils/report.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include "uftrace.h"
 #include "utils/report.h"


### PR DESCRIPTION
Remove redundant `#include` in utils/report.c

There were a few other files with duplicated `#include` but I thought those should be kept. I'll list them below just for the record.

utils/kernel.c
- <sys/stat.h> L15, L1832
> The first is always included while the second is used for unit testing. Since the use case is different, being explicit seems better.

cmds/tui.c
- "uftrace.h" L14, L3033
- "utils/utils.h" L16, L3034
> The directives are specified once for `ifdef HAVE_LIBNCURSES` and once for `else`. Having dependencies contained for each condition would be better for future development in case the conditions become more complex.

misc/prototypes.h
- <sys/stat.h> L188, L496
> constant / function declarations are grouped by category, so keeping the directive serves as documentation for where the declarations originate from.