### PR TITLE
misc: Ignore vscode/clangd files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ check-deps/*
 FLAGS
 version.h
 .config
+.cache
+.clangd/
+.vscode
 .build/
 GPATH
 GRTAGS
@@ -32,6 +35,7 @@ GTAGS
 TAGS
 tags
 cscope.*
+compile_commands.json
 *.pyc
 *.sw[opn]
 *.patch


### PR DESCRIPTION
Ignore vscode config directory (.vscode), compilation db
(compile_commands.json) and clangd config/index (.clangd/ and
.cache).

Signed-off-by: Seonghyun Park <shp4rk@gmail.com>