### PR TITLE
Revert "uftrace: fix a memory leak in a exename of a opts struct"

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -1219,7 +1219,6 @@ static void free_opts(struct uftrace_opts *opts)
 	free(opts->caller);
 	free(opts->watch);
 	free(opts->hide);
-	free(opts->exename);
 	free_parsed_cmdline(opts->run_cmd);
 }
 


### PR DESCRIPTION
This reverts commit e0f2fe1a9ed2a606f8039a6be28939289123083c.

The above patch freed opts->exename but it mostly wasn't malloced memory
so it shows the following error when recording.
```
  $ uftrace record a.out
  free(): invalid pointer
  Aborted
```
The following asan message shows the problem.
```
  $ uftrace record a.out
  =================================================================
  ==37601==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x7ffd1f2c18e6 in thread T0
      #0 0x7f117be958af in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x10b8af)
      #1 0x40fc41 in free_opts /home/honggyu/work/uftrace/uftrace.c:1222
      #2 0x4121ae in main /home/honggyu/work/uftrace/uftrace.c:1462
      #3 0x7f1179edb0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
      #4 0x40648d in _start (/home/honkim01/usr/bin/uftrace+0x40648d)

  Address 0x7ffd1f2c18e6 is located in stack of thread T0 at offset 4646 in frame
      #0 0x410a41 in main /home/honggyu/work/uftrace/uftrace.c:1290

    This frame has 3 object(s):
      [32, 36) 'argc' (line 1289)
      [48, 56) 'argv' (line 1289)
      [80, 448) 'opts' (line 1291) <== Memory access at offset 4646 overflows this variable
  HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
        (longjmp and C++ exceptions *are* supported)
  SUMMARY: AddressSanitizer: bad-free (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x10b8af) in __interceptor_free
  ==37601==ABORTING
```
We should revert the patch until we correctly handle whether
opts->exename is malloced or not.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>