### PR TITLE
utils: Fix warnings in data-file.c 

### DIFF
--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -646,12 +646,14 @@ static int create_data(struct uftrace_opts *opts)
 	write_dlopen_info(opts->dirname, &dlopen_msg, "libnothing.so");
 
 	/* create_session() requires a map file even if it's empty */
-	asprintf(&filename, "%s/sid-%.*s.map", opts->dirname, SESSION_ID_LEN, TEST_SESSION_ID);
+	TEST_GE(asprintf(&filename, "%s/sid-%.*s.map", opts->dirname, SESSION_ID_LEN,
+			 TEST_SESSION_ID),
+		0);
 	creat(filename, 0644);
 	free(filename);
 
 	/* open_data_file() requires at least one non-empty data file */
-	asprintf(&filename, "%s/%d.dat", opts->dirname, task_msg.pid);
+	TEST_GE(asprintf(&filename, "%s/%d.dat", opts->dirname, task_msg.pid), 0);
 	fp = fopen(filename, "w");
 	fprintf(fp, "%s\n", "empty file");
 	fclose(fp);


### PR DESCRIPTION
This commit fixes some warning messages
when the uftrace is built with unittests.

Signed-off-by: Kang Minchul <tegongkang@gmail.com>