### PR TITLE
tests : Fix applying zero offset to null pointer in unittest 16, 17

### DIFF
--- a/utils/dwarf.c
+++ b/utils/dwarf.c
@@ -2409,8 +2409,10 @@ static int check_test_debug_info(struct uftrace_dbg_info *dinfo1, struct uftrace
 		TEST_STREQ(save_entry->spec, load_entry->spec);
 		TEST_EQ(save_entry->offset, load_entry->offset);
 
-		save_entry = rb_entry(rb_next(&save_entry->node), struct debug_entry, node);
-		load_entry = rb_entry(rb_next(&load_entry->node), struct debug_entry, node);
+		node = rb_next(&save_entry->node);
+		save_entry = node ? rb_entry(node, struct debug_entry, node) : NULL;
+		node = rb_next(&load_entry->node);
+		load_entry = node ? rb_entry(node, struct debug_entry, node) : NULL;
 	}
 	TEST_EQ(save_entry == NULL, load_entry == NULL);
 


### PR DESCRIPTION
rb_entry's first argument 'rb_next(&save_entry->node)' is used as the pointer to the member in container_of.
If it is NULL, it does arithmetic on the null pointer in container_of's code below.
	(type *)((char *)__mptr - offsetof(type, member));

In this part, offsetof(struct debug_entry, node) is 0. So it outputs the error as "applying zero offset to null pointer"
This change is to add null checking to fix it.

Fixed: #1441

Signed-off-by: Jia Ha <wendyisdream1004@gmail.com>