### PR TITLE
misc: update description about libunwind support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,7 +85,7 @@ It will show the prefix directory and detected features like:
     ...     perf_event: [ on  ] - perf (PMU) event support
     ...       schedule: [ on  ] - scheduler event support
     ...       capstone: [ on  ] - full dynamic tracing support
-    ...      libunwind: [ OFF ] - libunwind support
+    ...      libunwind: [ OFF ] - stacktrace support (optional for debugging)
 
 Then you can run `make` to build the source.
 

--- a/configure
+++ b/configure
@@ -260,7 +260,7 @@ print_feature "cxa_demangle" "cxa_demangle" "full demangler support with libstdc
 print_feature "perf_event" "perf_clockid" "perf (PMU) event support"
 print_feature "schedule" "perf_context_switch" "scheduler event support"
 print_feature "capstone" "have_libcapstone" "full dynamic tracing support"
-print_feature "libunwind" "have_libunwind" "libunwind support"
+print_feature "libunwind" "have_libunwind" "stacktrace support (optional for debugging)"
 
 cat >$output <<EOF
 # this file is generated automatically


### PR DESCRIPTION
On building uftrace from the scratch, `./configure` shows dependent
library install status. `misc/install-deps.sh` will automatically
install those libraries with each distribution's package manager.

But, current `misc/install-deps.sh` doesn't install libunwind.
This is especially optional package for debugging. (though other
packages are also optional packages.) Some users may want to build
uftrace with full feature support. So add `--full` option to install
all libraries which checked by `./configure`.
Additionally, add usage message to show about `--full` options.

Also, change description about `libunwind`. It supports backtracing
information, which is optional for debugging.

Reported-by: Lee Dong Wook <sh95119@gmail.com>
Signed-off-by: JaeSang Yoo <jsyoo5b@gmail.com>