### PR TITLE
dump: Do not print perf-cpuXX and kernel-cpuXX if empty

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -1318,6 +1318,12 @@ static void do_dump_file(struct uftrace_dump_ops *ops, struct uftrace_opts *opts
 		struct uftrace_kernel_reader *kernel = handle->kernel;
 		struct uftrace_record *frs = &kernel->rstacks[i];
 		struct uftrace_session *fsess = handle->sessions.first;
+		struct stat statbuf;
+
+		if (fstat(kernel->fds[i], &statbuf) < 0)
+			continue;
+		if (statbuf.st_size == 0)
+			continue;
 
 		call_if_nonull(ops->cpu_start, ops, kernel, i);
 
@@ -1358,6 +1364,12 @@ perf:
 
 	for (i = 0; i < handle->nr_perf; i++) {
 		struct uftrace_perf_reader *perf = &handle->perf[i];
+		struct stat statbuf;
+
+		if (fstat(fileno(perf->fp), &statbuf) < 0)
+			continue;
+		if (statbuf.st_size == 0)
+			continue;
 
 		call_if_nonull(ops->perf_start, ops, perf, i);
 


### PR DESCRIPTION
If there are many cores in the system, most of the cpus stays empty when
recording perf and kernel data.

If the files are empty, do not print "reading {perf,kernel}-cpuXX.dat"
messages in uftrace dump output.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>