### PR TITLE
pre-commit: Add codespell hook in pre-commit and fix typos

### DIFF
--- a/.codespell_ignore
+++ b/.codespell_ignore
@@ -1,0 +1,5 @@
+pevent
+creat
+mmaped
+ot
+te

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,9 @@ repos:
     rev: v14.0.6
     hooks:
     -   id: clang-format
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+    -   id: codespell
+        args: ['-I', '.codespell_ignore']
+        exclude: "libtraceevent/.*"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -62,7 +62,7 @@ BUILD
 =====
 
 To build uftrace, you need to install basic software development tools first -
-like gcc and make.  And you also need to install dependent softwares. Please
+like gcc and make.  And you also need to install dependent packages. Please
 see DEPENDENCY section for more details.
 
 Once you have installed the required software(s), you need to run `configure` to set

--- a/arch/aarch64/mcount-dynamic.c
+++ b/arch/aarch64/mcount-dynamic.c
@@ -134,7 +134,7 @@ void mcount_arch_find_module(struct mcount_dynamic_info *mdi, struct uftrace_sym
 		if (sym->type != ST_LOCAL_FUNC && sym->type != ST_GLOBAL_FUNC)
 			continue;
 
-		/* dont' check special functions */
+		/* don't check special functions */
 		if (sym->name[0] == '_')
 			continue;
 

--- a/arch/i386/mcount-dynamic.c
+++ b/arch/i386/mcount-dynamic.c
@@ -67,7 +67,7 @@ void mcount_arch_find_module(struct mcount_dynamic_info *mdi, struct uftrace_sym
 		if (sym->type != ST_LOCAL_FUNC && sym->type != ST_GLOBAL_FUNC)
 			continue;
 
-		/* dont' check special functions */
+		/* don't check special functions */
 		if (sym->name[0] == '_')
 			continue;
 

--- a/arch/x86_64/dynamic.S
+++ b/arch/x86_64/dynamic.S
@@ -146,7 +146,7 @@ ENTRY(dynamic_return)
 	/* restore original stack pointer */
 	movq   (%rsp), %rsp
 
-	/* restore orignal return address in parent */
+	/* restore original return address in parent */
 	movq   %rax,   88(%rsp)
 
 	movq    0(%rsp), %rax

--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -204,7 +204,7 @@ void mcount_arch_find_module(struct mcount_dynamic_info *mdi, struct uftrace_sym
 		if (sym->type != ST_LOCAL_FUNC && sym->type != ST_GLOBAL_FUNC)
 			continue;
 
-		/* dont' check special functions */
+		/* don't check special functions */
 		if (sym->name[0] == '_')
 			continue;
 
@@ -727,7 +727,7 @@ void mcount_arch_patch_branch(struct mcount_disasm_info *info, struct mcount_ori
 			pr_err("target is not in reach");
 		}
 
-		/* patch jcc displacement to target correspending entry in the table */
+		/* patch jcc displacement to target corresponding entry in the table */
 		info->insns[jcc_index + 1] = disp;
 
 		entry_offset += ARCH_BRANCH_ENTRY_SIZE;

--- a/arch/x86_64/mcount-insn.c
+++ b/arch/x86_64/mcount-insn.c
@@ -83,7 +83,7 @@ static int x86_reg_index(int capstone_reg)
  * This function relocates jcc8 and jcc32 instructions by replacing them with a jcc8
  * that has a null offset. The offset will be patched later when the code is saved
  * in the of line execution buffer. The new jcc8 will bounce (if condition is met)
- * on a trampoline that jumps to the target of the orginal instruction.
+ * on a trampoline that jumps to the target of the original instruction.
  *
  * The relocation of jmp8 and jmp32 is achieved by replacing them with an absolute
  * indirect jump to the target.
@@ -545,7 +545,7 @@ static bool check_unsupported(struct mcount_disasm_engine *disasm, cs_insn *insn
 			if (info->addr > target || target >= info->addr + info->sym->size) {
 				/* also mark the target function as invalid */
 				if (!mcount_add_badsym(mdi, insn->address, target)) {
-					/* it was actuall ok (like tail call) */
+					/* it was actually ok (like tail call) */
 					return true;
 				}
 

--- a/arch/x86_64/mcount.S
+++ b/arch/x86_64/mcount.S
@@ -84,7 +84,7 @@ END(mcount)
 /*
  * Now, we are just returned from the child, RSP points to the right above the
  * stack address containing the return address (now it is mcount_return), but we
- * should restore the orignal address and the RSP to return.
+ * should restore the original address and the RSP to return.
  */
 ENTRY(mcount_return)
 	.cfi_startproc
@@ -112,7 +112,7 @@ ENTRY(mcount_return)
 	/* restore original stack pointer */
 	movq    0(%rsp), %rsp
 
-	/* restore orignal return address in parent */
+	/* restore original return address in parent */
 	movq    %rax, 40(%rsp)
 
 	movq    0(%rsp), %rax

--- a/check-deps/Makefile
+++ b/check-deps/Makefile
@@ -22,7 +22,7 @@ CHECK_LIST += cc_has_minline_all_stringops
 CHECK_CFLAGS  = $(CFLAGS)  $(CFLAGS_$@) -Werror
 CHECK_LDFLAGS = $(LDFLAGS) $(LDFLAGS_$@)
 
-# libpython3 provides an embed verison of pkg-config file since python3.8
+# libpython3 provides an embed version of pkg-config file since python3.8
 ifeq ($(shell pkg-config python3-embed --exists 2> /dev/null; echo $$?), 0)
   EMBED := -embed
 endif

--- a/check-deps/Makefile.check
+++ b/check-deps/Makefile.check
@@ -16,7 +16,7 @@ ifneq ($(wildcard $(objdir)/check-deps/cc_has_mno_sse2),)
 endif
 
 ifneq ($(wildcard $(srcdir)/check-deps/have_libpython3),)
-  # libpython3 provides an embed verison of pkg-config file since python3.8
+  # libpython3 provides an embed version of pkg-config file since python3.8
   ifeq ($(shell pkg-config python3-embed --exists 2> /dev/null; echo $$?), 0)
     EMBED := -embed
   endif

--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -661,7 +661,7 @@ void get_argspec_string(struct uftrace_task_reader *task, char *args, size_t len
 		else if (spec->fmt == ARG_FMT_STRUCT) {
 			if (spec->type_name) {
 				/*
-				 * gcc puts "<lambda" to annoymous lambda
+				 * gcc puts "<lambda" to anonymous lambda
 				 * but let's ignore to make it same as clang.
 				 */
 				if (strcmp(spec->type_name, "<lambda")) {

--- a/gdb/uftrace/utils.py
+++ b/gdb/uftrace/utils.py
@@ -70,9 +70,9 @@ Note that TYPE and ELEMENT have to be quoted as strings."""
 ContainerOf()
 
 
-def gdb_eval_or_none(expresssion):
+def gdb_eval_or_none(expression):
     try:
-        return gdb.parse_and_eval(expresssion)
+        return gdb.parse_and_eval(expression)
     except:
         return None
 

--- a/misc/install-deps.sh
+++ b/misc/install-deps.sh
@@ -10,7 +10,7 @@ fi
 OPT="${@}"
 
 if [ ! -f /etc/os-release ]; then
-    echo "Your distribution is not supported, so please install pacakges manually."
+    echo "Your distribution is not supported, so please install packages manually."
     echo
     exit
 fi

--- a/tests/arch/arm/a.c
+++ b/tests/arch/arm/a.c
@@ -1,4 +1,4 @@
-static volatile int acount;
+static volatile int account;
 
 extern volatile int tcount;
 extern void t1(void);
@@ -7,17 +7,17 @@ extern void t2(void);
 static void __attribute__((noinline)) a1(void)
 {
 	t1();
-	acount++;
+	account++;
 }
 
 void __attribute__((noinline)) a2(void)
 {
 	t2();
-	acount++;
+	account++;
 }
 
 int main(void)
 {
 	a1();
-	return acount + tcount;
+	return account + tcount;
 }

--- a/tests/s-thread-exec.c
+++ b/tests/s-thread-exec.c
@@ -11,10 +11,10 @@ void *thread_func(void *arg)
 
 int main(void)
 {
-	pthread_t thid;
+	pthread_t thrd_id;
 
-	pthread_create(&thid, NULL, thread_func, "t-abc");
-	pthread_join(thid, NULL);
+	pthread_create(&thrd_id, NULL, thread_func, "t-abc");
+	pthread_join(thrd_id, NULL);
 
 	return 0;
 }

--- a/tests/s-thread-name.c
+++ b/tests/s-thread-name.c
@@ -41,15 +41,15 @@ static void *thread_fourth(void *arg)
 int main(void)
 {
 	int i;
-	pthread_t thid[4];
+	pthread_t thrd_id[4];
 
-	pthread_create(&thid[0], NULL, thread_first, NULL);
-	pthread_create(&thid[1], NULL, thread_second, NULL);
-	pthread_create(&thid[2], NULL, thread_third, NULL);
-	pthread_create(&thid[3], NULL, thread_fourth, NULL);
+	pthread_create(&thrd_id[0], NULL, thread_first, NULL);
+	pthread_create(&thrd_id[1], NULL, thread_second, NULL);
+	pthread_create(&thrd_id[2], NULL, thread_third, NULL);
+	pthread_create(&thrd_id[3], NULL, thread_fourth, NULL);
 
 	for (i = 0; i < 4; i++)
-		pthread_join(thid[i], NULL);
+		pthread_join(thrd_id[i], NULL);
 
 	return 0;
 }

--- a/utils/auto-args.c
+++ b/utils/auto-args.c
@@ -568,7 +568,7 @@ char *get_enum_string(struct rb_root *root, char *name, int val)
  * This function parses @enum_str and add it to @root so that it can be
  * used for argument/return later.  The syntax of enum is same as C
  * (except for the 'enum' keyword) but it only accepts a simple integer
- * contant or other enum constant in RHS.
+ * constant or other enum constant in RHS.
  *
  * For example, following string should be accepted:
  *

--- a/utils/demangle.c
+++ b/utils/demangle.c
@@ -1368,7 +1368,7 @@ static int dd_operator_name(struct demangle_data *dd)
 		}
 	}
 	if (c0 == 'v' && isdigit(c1)) {
-		/* vender extended operator */
+		/* vendor extended operator */
 		dd->type++;
 		dd_source_name(dd);
 		dd->type--;

--- a/utils/dwarf.c
+++ b/utils/dwarf.c
@@ -282,7 +282,7 @@ static int setup_dwarf_info(const char *filename, struct uftrace_dbg_info *dinfo
 
 	/*
 	 * symbol table already uses relative address but non-PIE
-	 * executble needs to use absolute address for DWARF info.
+	 * executable needs to use absolute address for DWARF info.
 	 * Also as filter entry uses absolute address, it needs to
 	 * keep the offset to recover relative address back.
 	 */

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -683,7 +683,7 @@ void fstack_exit(struct uftrace_task_reader *task)
  * @task   - tracee task
  * @fstack - function tracing stack
  *
- * This funciton updates current display depth according to @type and
+ * This function updates current display depth according to @type and
  * flags of @fstack, and return a new depth.
  */
 int fstack_update(int type, struct uftrace_task_reader *task, struct uftrace_fstack *fstack)

--- a/utils/graph.c
+++ b/utils/graph.c
@@ -147,7 +147,7 @@ static int add_graph_exit(struct uftrace_task_graph *tg)
 			return 1;
 
 		/*
-		 * LOST only occures in kernel, so clear tg->lost
+		 * LOST only occurs in kernel, so clear tg->lost
 		 * when return to userspace
 		 */
 		tg->lost = false;

--- a/utils/perf.c
+++ b/utils/perf.c
@@ -244,7 +244,7 @@ out:
 #endif /* HAVE_PERF_CLOCKID */
 
 /**
- * setup_perf_data - preapre reading perf event data
+ * setup_perf_data - prepare reading perf event data
  * @handle - uftrace data file handle
  *
  * This function prepares to read perf event data from perf-cpu*.dat

--- a/utils/regs.c
+++ b/utils/regs.c
@@ -143,7 +143,7 @@ static const size_t arch_reg_sizes[] = {
 	ARRAY_SIZE(uft_i386_reg_table),
 };
 
-/* number of integer reigsters */
+/* number of integer registers */
 static const int arch_reg_int_sizes[] = {
 	0, 6, 4, 8, 2,
 };

--- a/utils/session.c
+++ b/utils/session.c
@@ -339,7 +339,7 @@ struct uftrace_session *get_session_from_sid(struct uftrace_session_link *sessio
  * @sess: pointer to a current session
  * @timestamp: timestamp at the dlopen call
  * @base_addr: load address of text segment of the library
- * @libname: name of the librarry
+ * @libname: name of the library
  *
  * This functions adds the info of a library which was loaded by dlopen.
  * Instead of creating a new session, it just adds the library information
@@ -412,7 +412,7 @@ void delete_session(struct uftrace_session *sess)
 }
 
 /**
- * delete_sessions - free all resouces in the @sessions
+ * delete_sessions - free all resources in the @sessions
  * @sessions: session link to manage sessions and tasks
  *
  * This function removes all session-related data structure in
@@ -466,7 +466,7 @@ static void add_session_ref(struct uftrace_task *task, struct uftrace_session *s
  *
  * This function searches the sessions tree using @task and @timestamp.
  * The most recent session that has a smaller than the @timestamp will
- * be returned.  If it didn't find a session tries to search sesssion
+ * be returned.  If it didn't find a session tries to search session
  * list of parent or thread-leader.
  */
 struct uftrace_session *find_task_session(struct uftrace_session_link *sessions,

--- a/utils/symbol.h
+++ b/utils/symbol.h
@@ -120,7 +120,7 @@ struct uftrace_sym_info {
 	uint64_t kernel_base;
 	/* map for the main executable (cached) */
 	struct uftrace_mmap *exec_map;
-	/* list of memory maping info for executable and libraries */
+	/* list of memory mapping info for executable and libraries */
 	struct uftrace_mmap *maps;
 };
 

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -600,7 +600,7 @@ char *strjoin(char *left, char *right, const char *delim)
  * @str:   input string
  * @delim: delimiter to split the string
  *
- * This function build a string vector using @str splitted by @delim.
+ * This function builds a string vector using @str split by @delim.
  */
 void strv_split(struct strv *strv, const char *str, const char *delim)
 {


### PR DESCRIPTION
codespell is a useful tool to detect typos so this patch adds it as a
pre-commit hook by default.

This codespell pre-commit hook found many typos and this patch also
fixes those typos.
```
  $ pre-commit run -a
      ...
  codespell................................................................Failed
  - hook id: codespell
  - exit code: 65

  tests/s-thread-name.c:44: thid ==> this
      ...
  gdb/uftrace/utils.py:73: expresssion ==> expression
  gdb/uftrace/utils.py:75: expresssion ==> expression
  utils/symbol.h:123: maping ==> mapping
  check-deps/Makefile.check:19: verison ==> version
  utils/session.c:342: librarry ==> library
  utils/session.c:415: resouces ==> resources
  utils/session.c:469: sesssion ==> session
  utils/dwarf.c:285: executble ==> executable
  utils/fstack.c:686: funciton ==> function
  arch/aarch64/mcount-dynamic.c:137: dont' ==> don't
  misc/install-deps.sh:13: pacakges ==> packages
  INSTALL.md:65: softwares ==> software
  utils/perf.c:247: preapre ==> prepare
  tests/s-thread-exec.c:14: thid ==> this
      ...
  arch/x86_64/mcount-dynamic.c:207: dont' ==> don't
  arch/x86_64/mcount-dynamic.c:730: correspending ==> corresponding
  utils/demangle.c:1371: vender ==> vendor
  check-deps/Makefile:25: verison ==> version
  arch/i386/mcount-dynamic.c:70: dont' ==> don't
  utils/utils.c:603: splitted ==> split
  arch/x86_64/mcount-insn.c:86: orginal ==> original
  arch/x86_64/mcount-insn.c:548: actuall ==> actually, actual
  arch/x86_64/mcount.S:87: orignal ==> original
  arch/x86_64/mcount.S:115: orignal ==> original
  utils/auto-args.c:571: contant ==> constant, content
  tests/arch/arm/a.c:1: acount ==> account
      ...
  cmds/replay.c:664: annoymous ==> anonymous
  utils/regs.c:146: reigsters ==> registers
  arch/x86_64/dynamic.S:149: orignal ==> original
  utils/graph.c:150: occures ==> occurs
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>