### PR TITLE
unittest: Fix a asan crash in argspec_parse_struct

### DIFF
--- a/utils/argspec.c
+++ b/utils/argspec.c
@@ -267,7 +267,7 @@ TEST_CASE(argspec_parse_struct)
 
 	/* parse_argspec might change the string, copy it */
 	str = strdup("arg3/t16:mystruct%RDI+RSI");
-	pr_dbg("parsing a struct passed by value: %s\n");
+	pr_dbg("parsing a struct passed by value: %s\n", str);
 
 	spec = parse_argspec(str, &setting);
 	TEST_NE(spec, NULL);


### PR DESCRIPTION
This patch is to fix the following error in unittest.
```
  $ make ASAN=1 unittest
  $ ./tests/unittest -v argspec_parse_struct
  SUMMARY: AddressSanitizer: SEGV (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x1245a1)
  ==55110==ABORTING
  [001] argspec_parse_struct          : FAIL
```
It's because pr_dbg requires to read a string with %s, but we didn't
provide an argument.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>