### PR TITLE
graph: Add the option to show function call graph as mermaid diagram

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -1172,13 +1172,15 @@ static struct uftrace_graph graphviz_graph = {
 static void dump_graphviz_header(struct uftrace_dump_ops *ops, struct uftrace_data *handle,
 				 struct uftrace_opts *opts)
 {
+	char *exename = basename(handle->info.exename);
+	graphviz_graph.root.name = exename;
 	pr_out("# version\":\"uftrace %s\"\n", UFTRACE_VERSION);
 
 	if (handle->hdr.info_mask & CMDLINE)
 		pr_out("# command_line \"%s\"\n", handle->info.cmdline);
 
 	pr_out("\ndigraph ");
-	pr_out("\"%s\"", basename(handle->info.exename));
+	pr_out("\"%s\"", exename);
 	pr_out(" { \n");
 
 	graph_init_callbacks(NULL, NULL, NULL, ops);

--- a/doc/uftrace-dump.md
+++ b/doc/uftrace-dump.md
@@ -31,6 +31,9 @@ DUMP OPTIONS
 \--graphviz
 :   Show DOT style output used by the graphviz toolkit.
 
+\--mermaid
+:   Show graph as mermaid flowchart diagram. It can be rendered in the browser.
+
 \--debug
 :   Show hex dump of data as well
 

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -442,6 +442,28 @@ class TestBase:
                 result.append("%s %s" % (ln['ph'], ln['name']))
         return '\n'.join(result)
 
+    def mermaid_sort(self, output, ignore_children=False):
+        """ This function post-processes output of the test to be compared .
+            It ignores blank and comment (#) lines and remaining functions.  """
+        result = []
+        start_mermaid = False
+
+        for ln in output.split('\n'):
+            if ln.find('<div class=\"mermaid\">') >= 0:
+                start_mermaid = True
+                continue
+            if start_mermaid == False:
+                continue
+            if ln.find('</div>') >= 0:
+                break
+
+            m = re.match( r'\s+(?P<start_id>\d+)\[\"(?P<start_name>\S+)\"\]\s+-->\|(?P<call_num>\d+)\|\s+(?P<end_id>\d+)\[\"(?P<end_name>\S+)\"\];', ln)
+            if m:
+                result.append("%s_%s %s> %s_%s" % (m.group('start_id'), m.group('start_name'), m.group('call_num'), m.group('end_id'), m.group('end_name')))
+            else:
+                continue
+        return '\n'.join(result)
+
     def sort(self, output, ignore_children=False):
         if not hasattr(TestBase, self.sort_method + '_sort'):
             print('cannot find the sort function: %s' % self.sort_method)

--- a/tests/t272_dump_mermaid.py
+++ b/tests/t272_dump_mermaid.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'abc', """
+<html>
+<body>
+<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+<script>
+  var config = {
+  startOnLoad: true,
+  maxTextSize: 99999999,
+  flowchart: { useMaxWidth: false }
+  };
+  mermaid.initialize(config);
+</script>
+<h2>Function Call Graph for <span style="color:blue">t-abc</span></h2>
+<div class="mermaid">
+flowchart TB
+  0["t-abc"] -->|1| 1["main"];
+  1["main"] -->|1| 2["a"];
+  2["a"] -->|1| 3["b"];
+  3["b"] -->|1| 4["c"];
+</div>
+</body>
+</html>
+""", sort='mermaid')
+
+    def prepare(self):
+        self.subcmd = 'record'
+        return self.runcmd()
+
+    def setup(self):
+        self.subcmd = 'dump'
+        self.option = '-F main -D 4 --mermaid'

--- a/uftrace.c
+++ b/uftrace.c
@@ -100,6 +100,7 @@ enum uftrace_short_options {
 	OPT_clock,
 	OPT_usage,
 	OPT_libmcount_path,
+	OPT_mermaid,
 };
 
 /* clang-format off */
@@ -285,6 +286,7 @@ static const struct option uftrace_options[] = {
 	NO_ARG(chrome, OPT_chrome_trace),
 	NO_ARG(graphviz, OPT_graphviz),
 	NO_ARG(flame-graph, OPT_flame_graph),
+	NO_ARG(mermaid, OPT_mermaid),
 	REQ_ARG(sample-time, OPT_sample_time),
 	REQ_ARG(diff, OPT_diff),
 	REQ_ARG(format, OPT_format),
@@ -998,6 +1000,10 @@ static int parse_option(struct uftrace_opts *opts, int key, char *arg)
 			arg = "mono";
 		}
 		opts->clock = arg;
+		break;
+
+	case OPT_mermaid:
+		opts->mermaid = true;
 		break;
 
 	default:

--- a/uftrace.h
+++ b/uftrace.h
@@ -300,6 +300,7 @@ struct uftrace_opts {
 	bool graphviz;
 	bool srcline;
 	bool estimate_return;
+	bool mermaid;
 	struct uftrace_time_range range;
 	enum uftrace_pattern_type patt_type;
 };

--- a/utils/graph.c
+++ b/utils/graph.c
@@ -62,6 +62,7 @@ static int add_graph_entry(struct uftrace_task_graph *tg, char *name, size_t nod
 	struct uftrace_graph_node *node = NULL;
 	struct uftrace_graph_node *curr = tg->node;
 	struct uftrace_fstack *fstack;
+	static uint32_t next_id = 1;
 
 	if (tg->lost)
 		return 1; /* ignore kernel functions after LOST */
@@ -87,6 +88,7 @@ static int add_graph_entry(struct uftrace_task_graph *tg, char *name, size_t nod
 
 		node = xzalloc(node_size);
 
+		node->id = next_id++;
 		node->addr = fstack->addr;
 		node->name = xstrdup(name ?: "none");
 		INIT_LIST_HEAD(&node->head);
@@ -205,6 +207,7 @@ static int add_graph_event(struct uftrace_task_graph *tg, size_t node_size)
 	return -1;
 }
 
+/* graph_add_node is not thread-safe due to static id of uftrace_graph_node */
 int graph_add_node(struct uftrace_task_graph *tg, int type, char *name, size_t node_size,
 		   struct uftrace_dbg_loc *loc)
 {

--- a/utils/graph.h
+++ b/utils/graph.h
@@ -16,6 +16,7 @@ struct uftrace_graph_node {
 	int nr_calls;
 	uint64_t time;
 	uint64_t child_time;
+	uint32_t id;
 	struct list_head head;
 	struct list_head list;
 	struct uftrace_graph_node *parent;


### PR DESCRIPTION
This option shows the function call graph as a mermaid flowchart
for visualization.

- mermaid page : https://mermaid-js.github.io/mermaid/

The usage for this option is add --mermaid in graph command.

The result can be rendered in the browser so it is formatted as HTML.
The mermaid syntax itself can be rendered in other services
including a mermaid plugin like github or draw.io.

The function name cannot be used as a node id because some suffix
like 'end', 'self' is indicated to special usage in mermaid.
So 'id' is added to identify the node to 'struct uftrace_graph_node'.

Signed-off-by: Jia Ha <wendyisdream1004@gmail.com>