### PR TITLE
utils: Archive old record data (WIP)

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -2,3 +2,5 @@
 __pycache__/
 unittest
 failed-tests.txt
+failed-tests.txt.old
+test_*/


### PR DESCRIPTION
Currently, only the previous record data is saved (uftrace.data.old) and any older data are discarded.
This complicates debugging `runtest.py` since most record data are lost even with `-k` option.

This commit changes how old data is archived so that the last `n` record data are saved (where `n` is configurable).
Currently that number is hardcoded to 10 (`utils/util.c` #L364) because I have yet to implement an interface with `struct uftrace_opts`.

Current method of archiving appends `.old` to the directory name, but this change will append `.old#` where `#` is the smallest positive index that has not yet been taken. When the limit `n` is exceeded, the smaller indices are discarded and the remaining are renamed such that their index is shifted to lie within the range [1, n].

tests/.gitignore was also updated to exclude `failed-tests.txt.old` and `test_*` which get created from running `runtest.py -k`

Signed-off-by: JongHyeon Hwang <jhh.20@icloud.com>