### PR TITLE
tests: Properly check the number of workers for use_pool

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -822,9 +822,6 @@ if __name__ == "__main__":
 
     arg = parse_argument()
 
-    # Arg is checked before being bounded to be explicitly toggleable
-    use_pool = arg.worker > 1
-
     if arg.case == 'all':
         testcases = glob.glob('t???_*.py')
     else:
@@ -835,6 +832,9 @@ if __name__ == "__main__":
             if len(testcases) == 0:
                 print("cannot find testcase for : %s" % arg.case)
                 sys.exit(0)
+
+    # Use multiprocessing pool if the number of workers is greater than 1.
+    use_pool = arg.worker > 1
 
     opts = ' '.join(sorted(['O' + o for o in arg.opts]))
 


### PR DESCRIPTION
Since the number of workers is bounded to the number of testcases, the
decision to use pool has to be delayed after the bound check.

Before:

      $ ./runtest.py 001
      Start 1 tests with 1 worker
      Test case                 pg             finstrument-fu
      ------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
      001 basic               : OK OK OK OK OK OK OK OK OK OK

After:

      $ ./runtest.py 001
      Start 1 tests without worker pool
      Test case                 pg             finstrument-fu
      ------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os
      001 basic               : OK OK OK OK OK OK OK OK OK OK

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>