### PR TITLE
utils: Fix build problems when building with --without-libelf option

### DIFF
--- a/utils/symbol-rawelf.h
+++ b/utils/symbol-rawelf.h
@@ -2,6 +2,7 @@
 #define UFTRACE_SYMBOL_RAWELF_H
 
 #include <elf.h>
+#include <stdbool.h>
 
 #ifdef __LP64__
 #define ELF_SIZE 64


### PR DESCRIPTION
Fix #1524 issue.

### Current
```
$ ./configure --without-libelf
uftrace detected system features:
...         prefix: /usr/local
...         libelf: [ OFF ] - more flexible ELF data handling
...          libdw: [ OFF ] - DWARF debug info support
...      libpython: [ on  ] - python scripting support
...      libluajit: [ on  ] - luajit scripting support
...    libncursesw: [ on  ] - TUI support
...   cxa_demangle: [ on  ] - full demangler support with libstdc++
...     perf_event: [ on  ] - perf (PMU) event support
...       schedule: [ on  ] - scheduler event support
...       capstone: [ on  ] - full dynamic tracing support
...      libunwind: [ on  ] - stacktrace support (optional for debugging)
$ make -j4
  CC       cmds/recv.o
  CC       cmds/report.o
  CC       cmds/live.o
  GEN      version.h
  CC       cmds/replay.o
  CC       cmds/tui.o
  CC       cmds/dump.o
  CC       cmds/graph.o
  CC       cmds/info.o
  CC       cmds/record.o
  CC       utils/session.o
  CC       utils/rbtree.o
  CC       utils/perf.o
  CC       utils/hashmap.o
  CC       utils/tracefs.o
  CC       utils/auto-args.o
  CC       utils/report.o
  CC       utils/data-file.o
  CC       utils/pager.o
  CC       utils/regs.o
  CC       utils/dwarf.o
  CC       utils/symbol-rawelf.o
In file included from /home/user/uftrace/utils/symbol-rawelf.c:13:
/home/user/uftrace/utils/symbol-rawelf.h:43:2: error: unknown type name ‘bool’
   43 |  bool has_shdr;
      |  ^~~~
  CC       utils/script-luajit.o
make: *** [Makefile:299: /home/user/uftrace/utils/symbol-rawelf.o] Error 1
make: *** Waiting for unfinished jobs....
```

### After changes
```
$ make -j4
  CC       utils/symbol-rawelf.o
  CC       utils/utils.o
...
  LINK     misc/dbginfo
  LINK     uftrace
```