### PR TITLE
tests: Fix NameError in build function

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -171,7 +171,7 @@ class TestBase:
 
     def build(self, name, cflags='', ldflags=''):
         if self.lang not in TestBase.supported_lang:
-            pr_debug("%s: unsupported language: %s" % (name, self.lang))
+            self.pr_debug("%s: unsupported language: %s" % (name, self.lang))
             return TestBase.TEST_UNSUPP_LANG
 
         lang = TestBase.supported_lang[self.lang]


### PR DESCRIPTION
Fix "NameError: name 'pr_debug' is not defined" error.

### Edit the code to reproduce the problem
```
diff --git a/tests/t012_demangle.py b/tests/t012_demangle.py
index 2686c333..e0822eea 100644
--- a/tests/t012_demangle.py
+++ b/tests/t012_demangle.py
@@ -4,7 +4,7 @@ from runtest import TestBase

 class TestCase(TestBase):
     def __init__(self):
-        TestBase.__init__(self, 'demangle', lang='C++', result="""
+        TestBase.__init__(self, 'demangle', lang='Go', result="""
 # DURATION    TID     FUNCTION
             [31433] | ABC::foo() {
             [31433] |   __static_initialization_and_destruction_0() {
```

### Current
```
$ ./runtest.py -vdp -O0 012
Start 1 tests without worker pool
Test case                 pg
------------------------: O0
Traceback (most recent call last):
  File "./runtest.py", line 905, in <module>
    results = run_single_case(name, flags, opts.split(), arg)
  File "./runtest.py", line 702, in run_single_case
    ret = tc.build(tc.name, cflags)
  File "/home/user/uftrace/tests/runtest.py", line 174, in build
    pr_debug("%s: unsupported language: %s" % (name, self.lang))
NameError: name 'pr_debug' is not defined
```

### After changes
```
$ ./runtest.py -vdp -O0 012
Start 1 tests without worker pool
Test case                 pg
------------------------: O0
demangle: unsupported language: Go
012 demangle            : LA
```