### PR TITLE
tests: Fix IndexError by checking report length

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -350,7 +350,7 @@ class TestBase:
                     continue
             except:
                 pass
-            result.append('%s %s' % (line[4], line[5]))
+            result.append('%s %s' % (line[-2], line[-1]))
 
         return '\n'.join(result)
 


### PR DESCRIPTION
Similar to issue #1509, sometimes TC 125 raised an IndexError with an abnormal output.
IndexError interferes with test normality, so I try to solve it with this PR.

- test normality even when abnormal results are output
- remove the code that checks for empty lines
- remove try...catch code with length check
- resolve pylint: No exception type (W0702:bare-except)

### Additional debugging code and abnormal results
- Missing self time value

```
$ git diff
diff --git a/tests/runtest.py b/tests/runtest.py
index dfe39dfd..991443c5 100755
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -334,6 +334,7 @@ class TestBase:
         """ This function post-processes output of the test to be compared .
             It ignores blank and comment (#) lines and remaining functions.  """
         result = []
+        print (output)
         for ln in output.split('\n'):
             if ln.strip() == '':
                 continue

$ ./runtest.py -vdp -O0 125
Start 1 tests without worker pool
Test case                 pg
------------------------: O0
build command: gcc -o t-abc -fno-inline -fno-builtin -fno-ipa-cp -fno-omit-frame-pointer -D_FORTIFY_SOURCE=0  -pg -O0  s-abc.c
prerun command: /home/user/uftrace/uftrace record --no-pager --no-event --libmcount-path=/home/user/uftrace  t-abc
prerun command: /home/user/uftrace/uftrace replay --no-pager --no-event --libmcount-path=/home/user/uftrace -f time -F main t-abc
test command: /home/user/uftrace/uftrace report --no-pager --no-event --libmcount-path=/home/user/uftrace -F main -r ~920.260799000 t-abc

  Total time   Self time       Calls  Function
  ==========  ==========  ==========  ====================================
    2.160 us    0.172 us           1  main
    1.988 us    0.126 us           1  a
    1.862 us    0.375 us           1  b
    1.487 us    0.747 us           1  c
    0.740 us    0.740 us           1  getpid

  Total time   Self time       Calls  Function
  ==========  ==========  ==========  ====================
    1.200 us    0.100 us           1  main
    1.100 us    0.100 us           1  a
    1.000 us                       1  b
    1.000 us    0.400 us           1  c
    0.600 us    0.600 us           1  getpid

Traceback (most recent call last):
  File "./runtest.py", line 906, in <module>
    results = run_single_case(name, flags, opts.split(), arg)
  File "./runtest.py", line 707, in run_single_case
    ret, dif = tc.run(case, cflags, arg.diff, timeout)
  File "/home/user/uftrace/tests/runtest.py", line 579, in run
    result_tested = self.sort(result_origin)  # for python3
  File "/home/user/uftrace/tests/runtest.py", line 452, in sort
    return func(self, output, ignore_children)
  File "/home/user/uftrace/tests/runtest.py", line 354, in report_sort
    result.append('%s %s' % (line[4], line[5]))
IndexError: list index out of range
```

### After changes
```
$ ./runtest.py -vdp -O0 125
Start 1 tests without worker pool
Test case                 pg
------------------------: O0
build command: gcc -o t-abc -fno-inline -fno-builtin -fno-ipa-cp -fno-omit-frame-pointer -D_FORTIFY_SOURCE=0  -pg -O0  s-abc.c
prerun command: /home/user/uftrace/uftrace record --no-pager --no-event --libmcount-path=/home/user/uftrace  t-abc
prerun command: /home/user/uftrace/uftrace replay --no-pager --no-event --libmcount-path=/home/user/uftrace -f time -F main t-abc
test command: /home/user/uftrace/uftrace report --no-pager --no-event --libmcount-path=/home/user/uftrace -F main -r ~1319.892205200 t-abc

  Total time   Self time       Calls  Function
  ==========  ==========  ==========  ====================================
    2.160 us    0.172 us           1  main
    1.988 us    0.126 us           1  a
    1.862 us    0.375 us           1  b
    1.487 us    0.747 us           1  c
    0.740 us    0.740 us           1  getpid

  Total time   Self time       Calls  Function
  ==========  ==========  ==========  ====================
    2.000 us    0.200 us           1  main
    1.800 us    0.200 us           1  a
    1.600 us                       1  b
    1.600 us    1.000 us           1  c
    0.600 us    0.600 us           1  getpid

=========== original ===========
  Total time   Self time       Calls  Function
  ==========  ==========  ==========  ====================
    2.000 us    0.200 us           1  main
    1.800 us    0.200 us           1  a
    1.600 us                       1  b
    1.600 us    1.000 us           1  c
    0.600 us    0.600 us           1  getpid

===========  result  ===========
1 main
1 a
1 c
1 getpid
=========== expected ===========
1 main
1 a
1 b
1 c
1 getpid

  Total time   Self time       Calls  Function
  ==========  ==========  ==========  ====================================
    2.160 us    0.172 us           1  main
    1.988 us    0.126 us           1  a
    1.862 us    0.375 us           1  b
    1.487 us    0.747 us           1  c
    0.740 us    0.740 us           1  getpid

t125_report_range: diff result of -pg -O0
--- expect      2022-08-15 22:04:29.653448200 +0900
+++ result      2022-08-15 22:04:29.653448200 +0900
@@ -2,3 +2,2 @@
 1 a
-1 b
 1 c

125 report_range        : NG
```