### PR TITLE
Introduce an agent in libmcount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/demangle.c $(srcdir)/utils/utils.c
 LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/script.c $(srcdir)/utils/script-python.c $(srcdir)/utils/script-luajit.c
 LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/auto-args.c $(srcdir)/utils/dwarf.c
 LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/hashmap.c $(srcdir)/utils/argspec.c
-LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/tracefs.c
+LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/tracefs.c $(srcdir)/utils/socket.c
 LIBMCOUNT_UTILS_SRCS += $(wildcard $(srcdir)/utils/symbol*.c)
 LIBMCOUNT_UTILS_OBJS := $(patsubst $(srcdir)/utils/%.c,$(objdir)/libmcount/%.op,$(LIBMCOUNT_UTILS_SRCS))
 

--- a/cmds/record.c
+++ b/cmds/record.c
@@ -71,7 +71,7 @@ static bool can_use_fast_libmcount(struct uftrace_opts *opts)
 	if (getenv("UFTRACE_FILTER") || getenv("UFTRACE_TRIGGER") || getenv("UFTRACE_ARGUMENT") ||
 	    getenv("UFTRACE_RETVAL") || getenv("UFTRACE_PATCH") || getenv("UFTRACE_SCRIPT") ||
 	    getenv("UFTRACE_AUTO_ARGS") || getenv("UFTRACE_WATCH") || getenv("UFTRACE_CALLER") ||
-	    getenv("UFTRACE_SIGNAL"))
+	    getenv("UFTRACE_SIGNAL") || getenv("UFTRACE_AGENT"))
 		return false;
 	return true;
 }
@@ -322,6 +322,9 @@ static void setup_child_environ(struct uftrace_opts *opts, int argc, char *argv[
 
 	if (opts->with_syms)
 		setenv("UFTRACE_SYMBOL_DIR", opts->with_syms, 1);
+
+	if (opts->agent)
+		setenv("UFTRACE_AGENT", "1", 1);
 
 	if (argc > 0) {
 		char *args = NULL;

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/uio.h>
+#include <sys/un.h>
 #include <unistd.h>
 
 /* This should be defined before #include "utils.h" */
@@ -26,6 +27,7 @@
 #include "mcount-arch.h"
 #include "utils/filter.h"
 #include "utils/script.h"
+#include "utils/socket.h"
 #include "utils/symbol.h"
 #include "utils/utils.h"
 #include "version.h"
@@ -91,6 +93,12 @@ unsigned long mcount_return_fn;
 
 /* do not hook return address and inject EXIT record between functions */
 bool mcount_estimate_return;
+
+/* agent thread */
+static pthread_t agent;
+
+/* state flag for the agent */
+static bool agent_run = false;
 
 __weak void dynamic_return(void)
 {
@@ -1716,6 +1724,139 @@ static void mcount_script_init(enum uftrace_pattern_type patt_type)
 	strv_free(&info.cmds);
 }
 
+static int agent_init(struct sockaddr_un *addr)
+{
+	int sfd;
+
+	if (mkdir(MCOUNT_AGENT_SOCKET_DIR, 0775) == -1) {
+		if (errno != EEXIST) {
+			pr_dbg("error creating run directory %s\n", MCOUNT_AGENT_SOCKET_DIR);
+			return -1;
+		}
+	}
+
+	sfd = socket_create(addr, getpid());
+	if (sfd == -1)
+		return sfd;
+
+	if (access(addr->sun_path, F_OK) == 0) {
+		pr_dbg("agent socket file already exists\n");
+		goto error;
+	}
+
+	if (socket_listen(sfd, addr) == -1)
+		goto error;
+
+	return sfd;
+
+error:
+	close(sfd);
+	return -1;
+}
+
+static void agent_fini(struct sockaddr_un *addr, int sfd)
+{
+	if (sfd != -1)
+		close(sfd);
+
+	socket_unlink(addr);
+}
+
+/* Agent routine, applying instructions from the CLI. */
+void *agent_apply_commands(void *arg)
+{
+	int sfd, cfd; /* socket fd, connection fd */
+	bool close_connection;
+	enum uftrace_dopt dopt;
+	struct sockaddr_un addr;
+
+	sfd = agent_init(&addr);
+	if (sfd == -1) {
+		pr_warn("agent cannot start\n");
+		return NULL;
+	}
+	agent_run = true;
+	pr_dbg("agent started on socket %s\n", addr.sun_path);
+
+	while (agent_run) {
+		cfd = socket_accept(sfd);
+		if (cfd == -1) {
+			pr_warn("error accepting socket connection\n");
+			continue;
+		}
+		pr_dbg2("agent connection open\n");
+
+		close_connection = false;
+		while (!close_connection) {
+			if (read(cfd, &dopt, sizeof(enum uftrace_dopt)) == -1) {
+				pr_warn("error reading option\n", errno);
+				break;
+			}
+
+			switch (dopt) {
+			case UFTRACE_DOPT_CLOSE:
+				close_connection = true;
+				break;
+
+			default:
+				close_connection = true;
+				pr_warn("option not recognized: %d\n", dopt);
+			}
+		}
+		if (close(cfd) == -1)
+			pr_dbg2("cannot close socket connection\n");
+		else
+			pr_dbg2("agent connection closed\n");
+	}
+
+	agent_fini(&addr, sfd);
+	pr_dbg("agent exited\n");
+	return 0;
+}
+
+static void agent_spawn()
+{
+	errno = pthread_create(&agent, NULL, &agent_apply_commands, NULL);
+	if (errno != 0)
+		pr_warn("cannot start agent: %s\n", strerror((errno)));
+}
+
+/* Check if the agent is up. If so, set its run flag to false, open and close
+ * connection . */
+static void agent_kill()
+{
+	int sfd;
+	struct sockaddr_un addr;
+
+	if (!agent_run)
+		return;
+
+	agent_run = false;
+
+	sfd = socket_create(&addr, getpid());
+	if (sfd == -1)
+		goto error;
+
+	if (socket_connect(sfd, &addr) == -1) {
+		if (errno != ENOENT) /* The agent may have ended and deleted the socket */
+			goto error;
+	}
+
+	if (socket_send_option(sfd, UFTRACE_DOPT_CLOSE, NULL, 0) == -1) {
+		pr_dbg("cannot stop agent loop\n");
+		goto error;
+	}
+
+	close(sfd);
+
+	if (pthread_join(agent, NULL) != 0)
+		pr_dbg("agent left in unknown state\n");
+	return;
+
+error:
+	pthread_cancel(agent);
+}
+
 static __used void mcount_startup(void)
 {
 	char *pipefd_str;
@@ -1871,6 +2012,7 @@ static __used void mcount_startup(void)
 	if (clock_str)
 		setup_clock_id(clock_str);
 
+	agent_spawn();
 	pthread_atfork(atfork_prepare_handler, NULL, atfork_child_handler);
 
 	mcount_hook_functions();
@@ -1888,6 +2030,7 @@ static __used void mcount_startup(void)
 
 static void mcount_cleanup(void)
 {
+	agent_kill();
 	mcount_finish();
 	destroy_dynsym_indexes();
 	mcount_dynamic_finish();

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -1796,6 +1796,8 @@ void *agent_apply_commands(void *arg)
 			switch (dopt) {
 			case UFTRACE_DOPT_CLOSE:
 				close_connection = true;
+				if (agent_run)
+					socket_send_option(cfd, UFTRACE_DOPT_CLOSE, NULL, 0);
 				break;
 
 			default:

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -2012,7 +2012,9 @@ static __used void mcount_startup(void)
 	if (clock_str)
 		setup_clock_id(clock_str);
 
-	agent_spawn();
+	if (getenv("UFTRACE_AGENT"))
+		agent_spawn();
+
 	pthread_atfork(atfork_prepare_handler, NULL, atfork_child_handler);
 
 	mcount_hook_functions();

--- a/tests/s-agent.c
+++ b/tests/s-agent.c
@@ -1,0 +1,11 @@
+/*
+ *  This is a test to see if the agent is running and responsive.
+ */
+
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+	getchar();
+	return 0;
+}

--- a/tests/t273_agent_basic.py
+++ b/tests/t273_agent_basic.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+import subprocess as sp
+from time import sleep
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'agent', """
+# DURATION     TID     FUNCTION
+            [ 22621] | main() {
+  43.742 ms [ 22621] |   getchar();
+  43.759 ms [ 22621] | } /* main */
+""")
+
+    def prerun(self, timeout):
+        self.subcmd = 'record'
+        self.option = '--keep-pid -g'
+        self.exearg = 't-' + self.name
+        record_cmd  = self.runcmd()
+        self.pr_debug("prerun command: " + record_cmd)
+        record_p = sp.Popen(record_cmd.split(), stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE)
+
+        sleep(.05)              # time for the agent to start
+        self.subcmd = 'live'
+        self.option = '-p %d' % record_p.pid
+        self.exearg = ''
+        client_cmd = self.runcmd()
+        self.pr_debug('prerun command: ' + client_cmd)
+        client_ret = sp.call(client_cmd.split())
+
+        record_p.communicate(b"^D") # target waits for a char to end
+        record_p.wait()
+
+        if client_ret != 0:
+            return TestBase.TEST_NONZERO_RETURN
+        return TestBase.TEST_SUCCESS
+
+    def setup(self):
+        self.subcmd = 'replay'
+        self.option = ''
+        self.exearg = ''

--- a/uftrace.c
+++ b/uftrace.c
@@ -190,6 +190,7 @@ __used static const char uftrace_help[] =
 "      --num-thread=NUM       Create NUM recorder threads\n"
 "  -N, --notrace=FUNC         Don't trace those FUNCs\n"
 "      --opt-file=FILE        Read command-line options from FILE\n"
+"  -p  --pid=PID              PID of an interactive mcount instance\n"
 "      --port=PORT            Use PORT for network connection (default: "
 	stringify(UFTRACE_RECV_PORT) ")\n"
 "  -P, --patch=FUNC           Apply dynamic patching for FUNCs\n"
@@ -234,7 +235,7 @@ __used static const char uftrace_footer[] =
 "\n";
 
 static const char uftrace_shopts[] =
-	"+aA:b:C:d:D:eE:f:F:ghH:kK:lN:P:r:R:s:S:t:T:U:vVW:Z:";
+	"+aA:b:C:d:D:eE:f:F:ghH:kK:lN:p:P:r:R:s:S:t:T:U:vVW:Z:";
 
 #define REQ_ARG(name, shopt) { #name, required_argument, 0, shopt }
 #define NO_ARG(name, shopt)  { #name, no_argument, 0, shopt }
@@ -330,6 +331,7 @@ static const struct option uftrace_options[] = {
 	NO_ARG(estimate-return, 'e'),
 	REQ_ARG(with-syms, OPT_with_syms),
 	NO_ARG(agent, 'g'),
+	REQ_ARG(pid, 'p'),
 	{ 0 }
 };
 /* clang-format on */
@@ -704,6 +706,11 @@ static int parse_option(struct uftrace_opts *opts, int key, char *arg)
 
 	case 'h':
 		return -3;
+
+	case 'p':
+		opts->pid = strtol(arg, NULL, 0);
+		opts->exename = "";
+		break;
 
 	case OPT_libmcount_path:
 		opts->lib_path = arg;

--- a/uftrace.c
+++ b/uftrace.c
@@ -156,6 +156,7 @@ __used static const char uftrace_help[] =
 "      --format=FORMAT        Use FORMAT for output: normal, html (default: normal)\n"
 "  -f, --output-fields=FIELD  Show FIELDs in the replay or graph output\n"
 "  -F, --filter=FUNC          Only trace those FUNCs\n"
+"  -g  --agent                Start an agent in mcount to listen to commands\n"
 "      --graphviz             Dump recorded data in DOT format\n"
 "  -H, --hide=FUNC            Hide FUNCs from trace\n"
 "      --host=HOST            Send trace data to HOST instead of write to file\n"
@@ -233,7 +234,7 @@ __used static const char uftrace_footer[] =
 "\n";
 
 static const char uftrace_shopts[] =
-	"+aA:b:C:d:D:eE:f:F:hH:kK:lN:P:r:R:s:S:t:T:U:vVW:Z:";
+	"+aA:b:C:d:D:eE:f:F:ghH:kK:lN:P:r:R:s:S:t:T:U:vVW:Z:";
 
 #define REQ_ARG(name, shopt) { #name, required_argument, 0, shopt }
 #define NO_ARG(name, shopt)  { #name, no_argument, 0, shopt }
@@ -328,6 +329,7 @@ static const struct option uftrace_options[] = {
 	NO_ARG(version, 'V'),
 	NO_ARG(estimate-return, 'e'),
 	REQ_ARG(with-syms, OPT_with_syms),
+	NO_ARG(agent, 'g'),
 	{ 0 }
 };
 /* clang-format on */
@@ -695,6 +697,10 @@ static int parse_option(struct uftrace_opts *opts, int key, char *arg)
 	case 'V':
 		pr_out("%s\n", uftrace_version);
 		return -1;
+
+	case 'g':
+		opts->agent = true;
+		break;
 
 	case 'h':
 		return -3;

--- a/uftrace.h
+++ b/uftrace.h
@@ -301,6 +301,7 @@ struct uftrace_opts {
 	bool srcline;
 	bool estimate_return;
 	bool mermaid;
+	bool agent;
 	struct uftrace_time_range range;
 	enum uftrace_pattern_type patt_type;
 };

--- a/uftrace.h
+++ b/uftrace.h
@@ -412,6 +412,11 @@ enum uftrace_msg_type {
 	UFTRACE_MSG_SEND_END,
 };
 
+/* Dynamic options sent by the client to the agent */
+enum uftrace_dopt {
+	UFTRACE_DOPT_CLOSE, /* Close the connection with the client */
+};
+
 /* msg format for communicating by pipe */
 struct uftrace_msg {
 	unsigned short magic; /* UFTRACE_MSG_MAGIC */

--- a/uftrace.h
+++ b/uftrace.h
@@ -258,6 +258,7 @@ struct uftrace_opts {
 	int nr_thread;
 	int rt_prio;
 	int size_filter;
+	int pid;
 	unsigned long bufsize;
 	unsigned long kernel_bufsize;
 	uint64_t threshold;

--- a/utils/socket.c
+++ b/utils/socket.c
@@ -1,0 +1,76 @@
+#include <errno.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include "uftrace.h"
+#include "utils/socket.h"
+#include "utils/utils.h"
+
+/* unlink socket file if it exists */
+void socket_unlink(struct sockaddr_un *addr)
+{
+	if (unlink(addr->sun_path) == -1) {
+		if (errno != ENOENT) {
+			pr_dbg("cannot unlink %s\n", addr->sun_path);
+		}
+	}
+}
+
+/* Create socket for communication between the client and the agent */
+int socket_create(struct sockaddr_un *addr, pid_t pid)
+{
+	int fd;
+	char *channel = NULL;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (fd == -1) {
+		pr_warn("socket creation failed: %s\n", strerror(errno));
+		return fd;
+	}
+	memset(addr, 0, sizeof(struct sockaddr_un));
+	xasprintf(&channel, "%s/%d.socket", MCOUNT_AGENT_SOCKET_DIR, pid);
+	addr->sun_family = AF_UNIX;
+	strncpy(addr->sun_path, channel, sizeof(addr->sun_path) - 1);
+	free(channel);
+	return fd;
+}
+
+/* Setup socket on agent side so it can accept client connection */
+int socket_listen(int fd, struct sockaddr_un *addr)
+{
+	if (bind(fd, (struct sockaddr *)addr, sizeof(struct sockaddr_un)) == -1) {
+		pr_warn("cannot bind to socket %s: %s\n", addr->sun_path, strerror(errno));
+		close(fd);
+		return -1;
+	}
+	if (listen(fd, 1) == -1) {
+		pr_warn("cannot listen to socket %s\n", addr->sun_path);
+		close(fd);
+		return -1;
+	}
+	return 0;
+}
+
+/* Send a single option to the agent through its socket */
+int socket_send_option(int fd, enum uftrace_dopt opt, void *value, size_t size)
+{
+	if (!write(fd, &opt, sizeof(enum uftrace_dopt)))
+		return -1;
+	if (value)
+		return write(fd, value, size);
+	return 0;
+}
+
+int socket_connect(int fd, struct sockaddr_un *addr)
+{
+	if (connect(fd, (struct sockaddr *)addr, sizeof(struct sockaddr_un)) == -1) {
+		pr_warn("cannot connect to socket '%s': %s\n", addr->sun_path, strerror(errno));
+		return -1;
+	}
+	return 0;
+}
+
+int socket_accept(int fd)
+{
+	return accept(fd, NULL, NULL);
+}

--- a/utils/socket.h
+++ b/utils/socket.h
@@ -1,0 +1,17 @@
+#ifndef UFTRACE_SOCKET_H
+#define UFTRACE_SOCKET_H
+
+#include <sys/socket.h>
+
+#define MCOUNT_AGENT_SOCKET_DIR "/tmp/uftrace"
+
+enum uftrace_dopt;
+
+void socket_unlink(struct sockaddr_un *addr);
+int socket_create(struct sockaddr_un *addr, pid_t pid);
+int socket_listen(int fd, struct sockaddr_un *addr);
+int socket_connect(int fd, struct sockaddr_un *addr);
+int socket_accept(int fd);
+int socket_send_option(int fd, enum uftrace_dopt opt, void *value, size_t size);
+
+#endif // UFTRACE_SOCKET_H


### PR DESCRIPTION
Hi,

This is a rework of PR #1269 from DORSAL. I moved the code to a new repository and made modifications according to old discussions. Sorry for the inconvenience.

This PR is the first step to interact with uftrace targets at runtime. It separates the CLI from the libmcount runtime, by spawning a daemon in libmcount, that is controlled by an separate and independent uftrace instance.

I introduce two new associated parameters:
- `--daemon`/`-m` to spawn the daemon in the target (off by default)
- `--pid`/`-p`to set uftrace to "client mode" and forward its parameters to a running target

Note that the daemon code is compiled conditionally in libmcount. It can be disabled using the `--without-daemon` flag in the configure script.

Follow-up steps:
- implement parameter tweaking at runtime (e.g. filters, depth) - PR to come
- implement dynamic patching and unpatching (from #1274)

Please let me know what you think about it!