### PR TITLE
uftrace: Make headers independently buildable

### DIFF
--- a/libmcount/dynamic.h
+++ b/libmcount/dynamic.h
@@ -2,6 +2,7 @@
 #define UFTRACE_MCOUNT_DYNAMIC_H
 
 #include <link.h>
+#include <stdlib.h>
 
 #ifdef HAVE_LIBCAPSTONE
 #include <capstone/capstone.h>

--- a/tests/unittest.c
+++ b/tests/unittest.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <fcntl.h>
 #include <link.h>
 #include <stdbool.h>

--- a/utils/event.h
+++ b/utils/event.h
@@ -2,6 +2,7 @@
 #define UFTRACE_EVENT_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 struct uftrace_data;
 

--- a/utils/kernel.h
+++ b/utils/kernel.h
@@ -2,6 +2,8 @@
 #define UFTRACE_KERNEL_H
 
 #include "libtraceevent/event-parse.h"
+#include "uftrace.h"
+#include "utils/list.h"
 #include "utils/utils.h"
 
 #define KERNEL_NOP_TRACER "nop"

--- a/utils/perf.h
+++ b/utils/perf.h
@@ -4,6 +4,7 @@
 #include <linux/perf_event.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #define PERF_MMAP_SIZE (132 * 1024) /* 32 + 1 pages */
 #define PERF_WATERMARK (8 * 1024) /* 2 pages */

--- a/utils/symbol-rawelf.h
+++ b/utils/symbol-rawelf.h
@@ -3,6 +3,7 @@
 
 #include <elf.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #ifdef __LP64__
 #define ELF_SIZE 64


### PR DESCRIPTION
This patch makes headers independently buildable with the following
command.

      $ find -name "*\.h" | grep -v prototypes.h | grep -v libtraceevent | xargs gcc -I. -I./arch/x86_64

It shows a single warning because of missing _GNU_SOURCE, but it's
manually defined in the current Makefile so it's not an issue.

Fixed: #1546
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>