### PR TITLE
tests: Fix "_GNU_SOURCE" redefined warning in unittest

### DIFF
--- a/tests/unittest.c
+++ b/tests/unittest.c
@@ -1,4 +1,3 @@
-#define _GNU_SOURCE
 #include <fcntl.h>
 #include <link.h>
 #include <stdbool.h>


### PR DESCRIPTION
This patch is to fix the following warning when compiling unittest.
```
  $ make unittest -j32
    LINK     unittest
  unittest.c:1: warning: "_GNU_SOURCE" redefined
      1 | #define _GNU_SOURCE
        |
  <command-line>: note: this is the location of the previous definition
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>