### PR TITLE
tests: Fix int conversion issue where zeros were discarded

### DIFF
--- a/tests/t222_external_data.py
+++ b/tests/t222_external_data.py
@@ -50,7 +50,7 @@ class TestCase(TestBase):
             nsec = int(t[point+1:point+10])
 
             # add the external data right after the first line
-            msg = '%s.%d %s\n' % (t[:point], nsec + 1, 'user message')
+            msg = '%s.%09d %s\n' % (t[:point], nsec + 1, 'user message')
 
             data_file = open(os.path.join('uftrace.data', 'extern.dat'), 'w')
             data_file.write(msg)


### PR DESCRIPTION
This is a fix for the test case found in #1509.

There was a issue where if there was a zero after the decimal point
like 8490.080467500, the zero was deleted when converting to int.

```
  $ uftrace replay -f +time
              [  9250]     8490.080467500 | main() {
              [  9250]     8490.080467800 |   a() {
              [  9250]     8490.080467800 |     b() {
              [  9250]     8490.080467900 |       c() {
     1.200 us [  9250]     8490.080468700 |         getpid();
     2.700 us [  9250]     8490.080470600 |       } /* c */
     2.900 us [  9250]     8490.080470700 |     } /* b */
     3.000 us [  9250]     8490.080470800 |   } /* a */
     3.400 us [  9250]     8490.080470900 | } /* main */
```

After the fix, it converts to 8490.080467501 instead of 8490.80467501.

### Current
```
$ cat uftrace.data/extern.dat 
8490.80467501 user message
```

### After changes
```
$ cat uftrace.data/extern.dat 
8490.080467501 user message
```

### Test result
```
$ ./runtest.py -dik 222
Start 1 tests without worker pool
Compiler                  gcc
Test case                 finstrument-fu
------------------------: O0 O1 O2 O3 Os
222 external_data       : OK OK OK OK OK

$ ./runtest.py -dik 222
Start 1 tests without worker pool
Compiler                  gcc
Test case                 finstrument-fu
------------------------: O0 O1 O2 O3 Os
222 external_data       : OK OK OK OK OK

$ ./runtest.py -dik 222
Start 1 tests without worker pool
Compiler                  gcc
Test case                 finstrument-fu
------------------------: O0 O1 O2 O3 Os
222 external_data       : OK OK OK OK OK

$ ./runtest.py -dik 222
Start 1 tests without worker pool
Compiler                  gcc
Test case                 finstrument-fu
------------------------: O0 O1 O2 O3 Os
222 external_data       : OK OK OK OK OK

$ ./runtest.py -dik 222
Start 1 tests without worker pool
Compiler                  gcc
Test case                 finstrument-fu
------------------------: O0 O1 O2 O3 Os
222 external_data       : OK OK OK OK OK
```