### PR TITLE
tests: Fix random failures in diff tests

### DIFF
--- a/tests/s-diff.c
+++ b/tests/s-diff.c
@@ -1,18 +1,15 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-int bar(int do_sleep)
+int bar()
 {
-	if (do_sleep)
-		usleep(100);
+	usleep(100);
 }
 
-int foo(int do_sleep)
+int foo()
 {
-	if (do_sleep)
-		usleep(1000);
-
-	bar(do_sleep);
+	usleep(1000);
+	bar();
 }
 
 int main(int argc, char *argv[])
@@ -22,9 +19,12 @@ int main(int argc, char *argv[])
 	if (argc > 1)
 		do_sleep = atoi(argv[1]);
 
-	if (do_sleep)
+	if (do_sleep) {
 		usleep(10);
+		foo();
+		bar();
+	}
+	foo();
 
-	foo(do_sleep);
 	return 0;
 }

--- a/tests/t025_report_s_call.py
+++ b/tests/t025_report_s_call.py
@@ -5,15 +5,15 @@ from runtest import TestBase
 class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'sort', """
-  Total time   Self time  Nr. called  Function
-  ==========  ==========  ==========  ====================================
-   36.388 us   36.388 us           6  loop
-   37.525 us    1.137 us           2  foo
-    1.078 ms    1.078 ms           1  usleep
-    1.152 ms   71.683 us           1  main
-   70.176 us   70.176 us           1  __monstartup   # ignore this
-    1.080 ms    1.813 us           1  bar
-    1.200 us    1.200 us           1  __cxa_atexit   # and this too
+  Total time   Self time       Calls  Function
+  ==========  ==========  ==========  ====================
+  187.817 us  187.817 us           6  loop
+  189.598 us    1.781 us           2  foo
+    0.657 us    0.657 us           1  __cxa_atexit
+    1.323 us    1.323 us           1  __monstartup
+   10.265 ms  157.616 us           1  bar
+   10.921 ms  466.298 us           1  main
+   10.107 ms   10.107 ms           1  usleep
 """, sort='report')
 
     def prepare(self):
@@ -22,4 +22,4 @@ class TestCase(TestBase):
 
     def setup(self):
         self.subcmd = 'report'
-        self.option = '-s call,self'
+        self.option = '-s call,func'

--- a/tests/t158_report_diff_policy1.py
+++ b/tests/t158_report_diff_policy1.py
@@ -15,13 +15,13 @@ class TestCase(TestBase):
 #  [0] base: xxx   (from uftrace record -d xxx -F main tests/t-diff 0 )
 #  [1] diff: yyy   (from uftrace record -d yyy -F main tests/t-diff 1 )
 #
-    Total time    Self time        Calls   Function
-  ============   ==========   ==========   ====================
-     +1.296 ms    +0.312 us           +0   main
-     +1.292 ms    +1.292 ms           +3   usleep
-     +1.225 ms    +2.609 us           +0   foo
-   +158.450 us    +1.305 us           +0   bar
-     -0.066 us    -0.066 us           +0   atoi
+    Total time     Self time         Calls   Function
+   ===========   ===========   ===========   ====================
+     -1.495 ms     -1.495 ms            +4   usleep
+   -320.169 us     -1.968 us            +2   bar
+     -1.270 ms     -2.370 us            +1   foo
+     +0.359 us     +0.359 us            +0   atoi
+     -1.499 ms     -0.157 us            +0   main
 """)
 
     def prerun(self, timeout):
@@ -42,7 +42,7 @@ class TestCase(TestBase):
 
     def setup(self):
         self.subcmd = 'report'
-        self.option = '--diff-policy compact,no-percent,abs'  # new default
+        self.option = '--diff-policy compact,no-percent,abs -s call'  # new default
         self.exearg = '-d %s --diff %s' % (XDIR, YDIR)
 
     def sort(self, output):

--- a/tests/t159_report_diff_policy2.py
+++ b/tests/t159_report_diff_policy2.py
@@ -15,13 +15,13 @@ class TestCase(TestBase):
 #  [0] base: xxx   (from uftrace record -d yyy -F main tests/t-diff 1 )
 #  [1] diff: yyy   (from uftrace record -d xxx -F main tests/t-diff 0 )
 #
-                    Total time (diff)                      Self time (diff)                       Calls (diff)   Function
-  ===================================   ===================================   ================================   ================================================
-    1.075 us    1.048 us    -0.027 us     1.075 us    1.048 us    -0.027 us            1          1         +0   atoi
-  158.971 us    0.118 us  -158.853 us     1.437 us    0.118 us    -1.319 us            1          1         +0   bar
-    1.235 ms    0.645 us    -1.235 ms     3.276 us    0.527 us    -2.749 us            1          1         +0   foo
-    1.309 ms    3.975 us    -1.305 ms     2.601 us    2.282 us    -0.319 us            1          1         +0   main
-    1.300 ms           -    -1.300 ms     1.300 ms           -    -1.300 ms            3          0         -3   usleep
+                     Total time (diff)                      Self time (diff)                       Calls (diff)   Function
+   ===================================   ===================================   ================================   ====================
+     0.965 us    0.942 us    +0.023 us     0.965 us    0.942 us    +0.023 us            1          1         +0   atoi
+     2.735 ms    1.219 ms    +1.516 ms     3.370 us    1.528 us    +1.842 us            1          1         +0   main
+     2.501 ms    1.216 ms    +1.284 ms     4.159 us    0.950 us    +3.209 us            2          1         -1   foo
+   481.377 us  156.153 us  +325.224 us     3.160 us    0.557 us    +2.603 us            3          1         -2   bar
+     2.724 ms    1.215 ms    +1.509 ms     2.724 ms    1.215 ms    +1.509 ms            6          2         -4   usleep
 """)
 
     def prerun(self, timeout):
@@ -42,7 +42,7 @@ class TestCase(TestBase):
 
     def setup(self):
         self.subcmd = 'report'
-        self.option = '--diff-policy full,no-abs -s call,total'
+        self.option = '--diff-policy full,no-abs -s call,func'
         self.exearg = '-d %s --diff %s' % (YDIR, XDIR)
 
     def sort(self, output):

--- a/tests/t160_report_diff_policy3.py
+++ b/tests/t160_report_diff_policy3.py
@@ -15,13 +15,13 @@ class TestCase(TestBase):
 #  [0] base: xxx   (from uftrace record -d xxx -F main tests/t-diff 0 )
 #  [1] diff: yyy   (from uftrace record -d yyy -F main tests/t-diff 1 )
 #
-  Total time    Self time        Calls   Function
-  ==========   ==========   ==========   ====================
-      -5.40%       -5.40%           +0   atoi
-    +999.99%     +875.84%           +0   bar
-    +999.99%     +498.85%           +0   foo
-    +999.99%      +10.47%           +0   main
-    +999.99%     +999.99%           +3   usleep
+    Total time     Self time         Calls   Function
+   ===========   ===========   ===========   ====================
+        +2.99%        +2.99%            +0   atoi
+      +195.87%      +104.40%            +2   bar
+       +95.74%       +16.14%            +1   foo
+      +113.47%       +88.88%            +0   main
+      +113.96%      +113.96%            +4   usleep
 """)
 
     def prerun(self, timeout):

--- a/tests/t177_report_diff_policy4.py
+++ b/tests/t177_report_diff_policy4.py
@@ -15,13 +15,13 @@ class TestCase(TestBase):
 #  [0] base: xxx   (from uftrace record -d xxx -F main tests/t-diff 0 )
 #  [1] diff: yyy   (from uftrace record -d yyy -F main tests/t-diff 1 )
 #
-   Total time     Self time         Calls   Function
-  ===========   ===========   ===========   ====================
-    +0.027 us     +0.027 us            +0   atoi
-  +158.853 us     +1.319 us            +0   bar
-    +1.235 ms     +2.749 us            +0   foo
-    +1.305 ms     +0.319 us            +0   main
-    +1.300 ms     +1.300 ms            +3   usleep
+    Total time     Self time         Calls   Function
+   ===========   ===========   ===========   ====================
+     -0.092 us     -0.092 us            +0   atoi
+   -315.716 us     -2.259 us            +2   bar
+     -1.318 ms     -3.505 us            +1   foo
+     -1.548 ms     -1.632 us            +0   main
+     -1.540 ms     -1.540 ms            +4   usleep
 """)
 
     def prerun(self, timeout):

--- a/tests/t240_report_diff_field2.py
+++ b/tests/t240_report_diff_field2.py
@@ -15,13 +15,13 @@ class TestCase(TestBase):
 #  [0] base: xxx   (from uftrace record -d xxx -F main tests/t-diff 0 )
 #  [1] diff: yyy   (from uftrace record -d yyy -F main tests/t-diff 1 )
 #
-    Total time        Calls   Function
-  ============   ==========   ====================
-     +1.296 ms           +0   main
-     +1.292 ms           +3   usleep
-     +1.225 ms           +0   foo
-   +158.450 us           +0   bar
-     -0.066 us           +0   atoi
+    Total time         Calls   Function
+   ===========   ===========   ====================
+     -1.524 ms            +4   usleep
+   -326.342 us            +2   bar
+     -1.302 ms            +1   foo
+     -0.115 us            +0   atoi
+     -1.533 ms            +0   main
 """)
 
     def prerun(self, timeout):
@@ -42,7 +42,7 @@ class TestCase(TestBase):
 
     def setup(self):
         self.subcmd = 'report'
-        self.option = '-f total,call --diff-policy compact,no-percent,abs'  # new default
+        self.option = '-f total,call --diff-policy compact,no-percent,abs -s call'  # new default
         self.exearg = '-d %s --diff %s' % (XDIR, YDIR)
 
     def sort(self, output):

--- a/tests/t241_report_diff_field3.py
+++ b/tests/t241_report_diff_field3.py
@@ -15,13 +15,13 @@ class TestCase(TestBase):
 #  [0] base: xxx   (from uftrace record -d yyy -F main tests/t-diff 1 )
 #  [1] diff: yyy   (from uftrace record -d xxx -F main tests/t-diff 0 )
 #
-                    Total time (diff)                      Self time (diff)                       Calls (diff)   Function
-  ===================================   ===================================   ================================   ================================================
-    1.075 us    1.048 us    -0.027 us     1.075 us    1.048 us    -0.027 us            1          1         +0   atoi
-  158.971 us    0.118 us  -158.853 us     1.437 us    0.118 us    -1.319 us            1          1         +0   bar
-    1.235 ms    0.645 us    -1.235 ms     3.276 us    0.527 us    -2.749 us            1          1         +0   foo
-    1.309 ms    3.975 us    -1.305 ms     2.601 us    2.282 us    -0.319 us            1          1         +0   main
-    1.300 ms           -    -1.300 ms     1.300 ms           -    -1.300 ms            3          0         -3   usleep
+                     Total time (diff)                      Self time (diff)                       Calls (diff)   Function
+   ===================================   ===================================   ================================   ====================
+     1.012 us    1.017 us    -0.005 us     1.012 us    1.017 us    -0.005 us            1          1         +0   atoi
+     2.796 ms    1.268 ms    +1.528 ms     3.031 us    1.644 us    +1.387 us            1          1         +0   main
+     2.563 ms    1.265 ms    +1.297 ms     5.972 us    2.706 us    +3.266 us            2          1         -1   foo
+   484.028 us  157.853 us  +326.175 us     4.056 us    0.979 us    +3.077 us            3          1         -2   bar
+     2.782 ms    1.261 ms    +1.521 ms     2.782 ms    1.261 ms    +1.521 ms            6          2         -4   usleep
 """)
 
     def prerun(self, timeout):
@@ -42,7 +42,7 @@ class TestCase(TestBase):
 
     def setup(self):
         self.subcmd = 'report'
-        self.option = '-f total,self,call --diff-policy full,no-abs -s call,total'
+        self.option = '-f total,self,call --diff-policy full,no-abs -s call,func'
         self.exearg = '-d %s --diff %s' % (YDIR, XDIR)
 
     def sort(self, output):

--- a/tests/t242_report_diff_field4.py
+++ b/tests/t242_report_diff_field4.py
@@ -16,13 +16,13 @@ class TestCase(TestBase):
 #  [1] diff: yyy   (from uftrace record -d yyy -F main tests/t-diff 1 )
 #
 
-    Self time        Calls  Function
-  ===========  ===========  ====================
-      +22.05%           +0  atoi
-     +307.75%           +0  bar
-     +273.85%           +0  foo
-      +17.78%           +0  main
-         N/A            +3  usleep
+     Self time         Calls   Function
+   ===========   ===========   ====================
+        -1.71%            +0   atoi
+      +160.82%            +2   bar
+       +63.23%            +1   foo
+       +51.53%            +0   main
+      +120.44%            +4   usleep
 """)
 
     def prerun(self, timeout):

--- a/tests/t243_report_diff_field5.py
+++ b/tests/t243_report_diff_field5.py
@@ -15,13 +15,13 @@ class TestCase(TestBase):
 #  [0] base: xxx   (from uftrace record -d xxx -F main tests/t-diff 0 )
 #  [1] diff: yyy   (from uftrace record -d yyy -F main tests/t-diff 1 )
 #
-   Total time     Self time         Calls   Function
-  ===========   ===========   ===========   ====================
-    +0.027 us     +0.027 us            +0   atoi
-  +158.853 us     +1.319 us            +0   bar
-    +1.235 ms     +2.749 us            +0   foo
-    +1.305 ms     +0.319 us            +0   main
-    +1.300 ms     +1.300 ms            +3   usleep
+    Total time     Self time         Calls   Function
+   ===========   ===========   ===========   ====================
+     +0.089 us     +0.089 us            +0   atoi
+   -314.912 us     -1.346 us            +2   bar
+     -1.262 ms     -1.819 us            +1   foo
+     -1.490 ms     -1.005 us            +0   main
+     -1.486 ms     -1.486 ms            +4   usleep
 """)
 
     def prerun(self, timeout):


### PR DESCRIPTION
The current diff tests have a common tricky problem because we can't
guarantee the difference of execution time for two different executions.

Because of this problem, some diff tests randomly fails as follows.
```
  158 report_diff_policy1 : OK OK OK NG OK OK NG OK OK NG  OK OK OK OK OK OK OK OK OK OK
  159 report_diff_policy2 : OK OK OK OK OK OK OK OK OK OK  OK OK OK NG OK OK OK OK OK OK
  160 report_diff_policy3 : NG OK OK OK OK OK OK NG NG OK  OK OK OK OK OK OK OK OK OK OK
  240 report_diff_field2  : OK OK OK NG OK OK NG NG OK OK  NG OK OK OK NG OK OK NG NG OK
  241 report_diff_field3  : OK OK OK OK OK OK OK OK OK OK  OK OK OK OK OK OK OK OK NG OK
  242 report_diff_field4  : OK OK OK OK OK OK OK OK OK OK  OK NG OK OK OK OK OK OK OK OK
  243 report_diff_field5  : OK OK OK OK OK OK OK OK OK NG  OK NG OK OK OK OK OK OK OK OK
```
I have reproduced the problem in 158 and the report diff results shows
as follows in both pass and fail cases.

The pass case:
```
  $ uftrace report -d xxx/ --diff yyy
        ...
      Total time     Self time         Calls   Function
     ===========   ===========   ===========   ====================
       +1.348 ms     +0.147 us            +0   main
       +1.344 ms     +1.344 ms            +3   usleep
       +1.277 ms     +2.501 us            +0   foo
     +161.926 us     +1.410 us            +0   bar
       +0.022 us     +0.022 us            +0   atoi
```
The fail case:
```
  $ uftrace report -d xxx/ --diff yyy
        ...
      Total time     Self time         Calls   Function
     ===========   ===========   ===========   ====================
       +1.275 ms     +1.275 ms            +3   usleep
       +1.274 ms     -0.491 us            +0   main
       +1.208 ms     +0.031 us            +0   foo
     +153.580 us     +0.168 us            +0   bar
       -0.496 us     -0.496 us            +0   atoi
```
The fail case shows 'usleep' at the top and that means the total time
diff 'usleep' is greater than 'main', which is a different result.

Since we can't guarantee that the execution difference of two different
records, we should use a reliable field for sorting the result.

The same problem happens in many diff tests, so this patch fixes all
those problem.

It also changes s-diff.c source to make the test result more clearly
distinguished.

The following report test also shows the same problem so it's fixed
together.
```
  025 report_s_call       : OK OK OK OK OK OK OK OK NG OK  OK OK OK OK OK OK OK OK OK OK
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>