### PR TITLE
tui: Add field "size" in report mode

### DIFF
--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -170,11 +170,11 @@ static const char *graph_field_names[NUM_GRAPH_FIELD] = {
 	"ADDRESS",
 };
 
-#define NUM_REPORT_FIELD 9
+#define NUM_REPORT_FIELD 10
 
 static const char *report_field_names[NUM_REPORT_FIELD] = {
 	"TOTAL TIME", "TOTAL AVG", "TOTAL MIN", "TOTAL MAX", "SELF TIME",
-	"SELF AVG",   "SELF MIN",  "SELF MAX",	"CALL",
+	"SELF AVG",   "SELF MIN",  "SELF MAX",	"CALL",	     "SIZE",
 };
 
 static const char *field_help[] = {
@@ -191,8 +191,10 @@ enum tui_mode {
 	TUI_MODE_OTHER,
 };
 
-static char *report_sort_key[] = { OPT_SORT_KEYS, "total_avg", "total_min", "total_max", "self",
-				   "self_avg",	  "self_min",  "self_max",  "call" };
+static char *report_sort_key[] = {
+	OPT_SORT_KEYS, "total_avg", "total_min", "total_max", "self",
+	"self_avg",    "self_min",  "self_max",	 "call",      "size",
+};
 
 static char *selected_report_sort_key[NUM_REPORT_FIELD];
 
@@ -341,7 +343,7 @@ static void print_report_##_func(struct field_data *fd)                         
 }                                                                                                  \
 REPORT_FIELD_STRUCT(_id, _name, _func, _header, 11)
 
-#define REPORT_FIELD_CALL(_id, _name, _field, _func, _header)                                      \
+#define REPORT_FIELD_UINT(_id, _name, _field, _func, _header)                                      \
 static void print_report_##_func(struct field_data *fd)                                            \
 {                                                                                                  \
 	struct uftrace_report_node *node = fd->arg;                                                \
@@ -359,7 +361,8 @@ REPORT_FIELD_TIME(REPORT_F_SELF_TIME, self, self.sum, self, "SELF TIME");
 REPORT_FIELD_TIME(REPORT_F_SELF_TIME_AVG, self-avg, self.avg, self_avg, "SELF AVG");
 REPORT_FIELD_TIME(REPORT_F_SELF_TIME_MIN, self-min, self.min, self_min, "SELF MIN");
 REPORT_FIELD_TIME(REPORT_F_SELF_TIME_MAX, self-max, self.max, self_max, "SELF MAX");
-REPORT_FIELD_CALL(REPORT_F_CALL, call, call, call, "CALL");
+REPORT_FIELD_UINT(REPORT_F_CALL, call, call, call, "CALL");
+REPORT_FIELD_UINT(REPORT_F_SIZE, size, size, size, "SIZE");
 
 /* clang-format on */
 
@@ -367,6 +370,7 @@ static struct display_field *report_field_table[] = {
 	&report_field_total,	 &report_field_total_avg, &report_field_total_min,
 	&report_field_total_max, &report_field_self,	  &report_field_self_avg,
 	&report_field_self_min,	 &report_field_self_max,  &report_field_call,
+	&report_field_size,
 };
 
 static void setup_default_graph_field(struct list_head *fields, struct uftrace_opts *opts,
@@ -524,6 +528,7 @@ static int build_tui_node(struct uftrace_task_reader *task, struct uftrace_recor
 
 	if (rec->type == UFTRACE_ENTRY || rec->type == UFTRACE_EXIT) {
 		sym = task_find_sym_addr(&task->h->sessions, task, rec->time, addr);
+		task->func = sym;
 
 		/* skip it if --no-libcall is given */
 		if (!opts->libcall && sym && sym->type == ST_PLT_FUNC)

--- a/doc/ko/uftrace-tui.md
+++ b/doc/ko/uftrace-tui.md
@@ -26,7 +26,7 @@ TUI 옵션
     설정 가능한 값은 total, self, addr 이고, 기본 설정값은 `total`이다.
     그런데 이 옵션이 --report 옵션과 함께 사용된다면, 이 옵션은 report 필드를 나타낸다.
     설정 가능한 값은 total, total-avg, total-min, total-max, self, self-avg, self-min,
-    self-max, call이고, 기본 설정값은 'total,self,call'이다.
+    self-max, call, size 이고, 기본 설정값은 'total,self,call'이다.
     쉼표를 사용하여 여러 필드를 설정할 수 있고, 주어진 필드 이름이 "+"로 시작할 경우,
     기본 설정값에 추가하는 방식으로 필드를 설정할 수 있다.
     'none' 과 같은 특수 필드를 사용하면 모든 필드를 숨길 수 있다.
@@ -35,8 +35,8 @@ TUI 옵션
 -s *KEYS*[,*KEYS*,...], --sort=*KEYS*[,*KEYS*,...]
 :   주어진 키를 기반으로 함수들을 정렬한다.
     여러 키들을 적용할 경우, 키들을 쉼표(,)로 나누어 표현한다.  total (time), total-avg,
-    total-min, total-max, self (time), self-avg, self-min, self-max, call, func를 키로
-    이용할 수 있다.  이 옵션은 반드시 --report 옵션과 함께 사용해야 한다.
+    total-min, total-max, self (time), self-avg, self-min, self-max, call, func, size를
+    키로 이용할 수 있다.  이 옵션은 반드시 --report 옵션과 함께 사용해야 한다.
 
 공통 옵션
 =========

--- a/doc/uftrace-tui.md
+++ b/doc/uftrace-tui.md
@@ -27,7 +27,7 @@ TUI OPTIONS
     Possible values are total, self and addr.  The default value is 'total'.
     But if this option is used with --report option,
     this option indicates report fields.  Possible values are total, total-avg,
-    total-min, total-max, self, self-avg, self-min, self-max and call.
+    total-min, total-max, self, self-avg, self-min, self-max, call and size.
     The default value is 'total,self,call'.
     Multiple fields can be set by using comma.
     If given field name starts with "+", then it'll be appended to the default fields.
@@ -37,7 +37,7 @@ TUI OPTIONS
 -s *KEYS*[,*KEYS*,...], \--sort=*KEYS*[,*KEYS*,...]
 :   Sort functions by given KEYS. Multiple KEYS can be given, separated by comma (,).
     Possible keys are total (time), total-avg, total-min, total-max, self (time), self-avg,
-    self-min, self-max, call and func.
+    self-min, self-max, call, func and size.
     This option must be used with --report option.
 
 COMMON OPTIONS


### PR DESCRIPTION
I add size field in report mode because filter options in report command.
contain the field but report mode in `tui` command doesn't.

I referenced commit `b0544ca8` to add this field.

Here is available fields for report mode in `tui` command.
```
./uftrace tui -d ~/test/hello.data --report -f?
uftrace: Unknown field name '?'
uftrace:   Possible fields are: total total-avg total-min total-max self self-avg self-min self-max call size
```
I also rename the macro `REPORT_FIELD_CALL` to `REPORT_FIELD_UINT`,
because of code consistency for commit `a926a9cf`.

Signed-off-by: Joonho Seo <tjwnsgh1110@gmail.com>