### PR TITLE
misc: Fix error when 'ARG test=yes' in dockerfile of fedora

### DIFF
--- a/misc/docker/fedora/33/Dockerfile
+++ b/misc/docker/fedora/33/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:33
 ARG test
-RUN yum install -y git gcc make
+RUN yum install -y git gcc make libasan libubsan
 RUN mkdir -p /usr/src
 RUN git clone https://github.com/namhyung/uftrace /usr/src/uftrace
 RUN if [ "$test" = "yes" ] ; then \

--- a/misc/docker/fedora/34/Dockerfile
+++ b/misc/docker/fedora/34/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:34
 ARG test
-RUN yum install -y git gcc make
+RUN yum install -y git gcc make libasan libubsan
 RUN mkdir -p /usr/src
 RUN git clone https://github.com/namhyung/uftrace /usr/src/uftrace
 RUN if [ "$test" = "yes" ] ; then \


### PR DESCRIPTION
The current dockerfile of fedora 33 and 34 have a problem that installed gcc
not have libasan and libubsan, this is cause error as follows when 'ARG test=yes'

  /usr/bin/ld: cannot find /usr/lib64/libasan.so.6.0.0
  /usr/bin/ld: cannot find /usr/lib64/libubsan.so.1.0.0
  collect2: error: ld returned 1 exit status
  make: *** [Makefile:308: /usr/src/uftrace/uftrace] Error 1

so, i change 'yum install' command to install libasan and libubsan.

Signed-off-by: Yusun Choi <tanks2438@outlook.kr>