### PR TITLE
tests: Fix failed-tests.txt output alignment

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -773,8 +773,6 @@ def print_test_result(case, result, diffs, color, ftests, nr_compilers):
     normal = [TestBase.TEST_SUCCESS, TestBase.TEST_SUCCESS_FIXED, TestBase.TEST_SKIP]
     for r in result:
         if r not in normal:
-            output = case[1:4]
-            output += ' %-20s' % case[5:] + ': ' + ' '.join(plain_result) + '\n'
             ftests.write(output)
             ftests.flush()
             break


### PR DESCRIPTION
This patch fixes the following incorrect alignment in failed-tests.txt.
```
  $ cat failed-tests.txt
  Compiler                  gcc                            clang
  Test case                 pg             finstrument-fu  pg             finstrument-fu
  ------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os  O0 O1 O2 O3 Os O0 O1 O2 O3 Os
  203 arg_dwarf3          : OK OK NG NG NG SK SK SK SK SK OK OK OK OK OK SK SK SK SK SK
```
It also makes the failed-tests.txt output with color because there is
another way to print the plain output with '--color off' option.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>