### PR TITLE
scripts: Correct dump scripts timestamp representation

### DIFF
--- a/scripts/dump.lua
+++ b/scripts/dump.lua
@@ -20,7 +20,7 @@ function uftrace_entry(ctx)
     local _name       = ctx['name']
 
     local unit = 1000000000
-    print(string.format('%d.%d %6d: [entry] %s(%x) depth: %d',
+    print(string.format('%d.%09d %6d: [entry] %s(%x) depth: %d',
             _time / unit, _time % unit, _tid, _name, _address, _depth))
 
     if ctx['args'] ~= nil then
@@ -39,7 +39,7 @@ function uftrace_exit(ctx)
     local _name       = ctx["name"]
 
     local unit = 1000000000
-    print(string.format('%d.%d %6d: [exit ] %s(%x) depth: %d',
+    print(string.format('%d.%09d %6d: [exit ] %s(%x) depth: %d',
             _time / unit, _time % unit, _tid, _name, _address, _depth))
 
     if ctx['retval'] ~= nil then
@@ -55,7 +55,7 @@ function uftrace_event(ctx)
     local _name       = ctx["name"]
 
     local unit = 1000000000
-    print(string.format('%d.%d %6d: [event] %s(%x)',
+    print(string.format('%d.%09d %6d: [event] %s(%x)',
             _time / unit, _time % unit, _tid, _name, _address))
 end
 

--- a/scripts/dump.py
+++ b/scripts/dump.py
@@ -28,7 +28,7 @@ def uftrace_entry(ctx):
     _name       = ctx["name"]
 
     unit = 10 ** 9
-    print("%d.%d %6d: [entry] %s(%x) depth: %d" %
+    print("%d.%09d %6d: [entry] %s(%x) depth: %d" %
             (_time / unit, _time % unit, _tid, _name, _address, _depth))
 
     if "args" in ctx:
@@ -47,7 +47,7 @@ def uftrace_exit(ctx):
     _name       = ctx["name"]
 
     unit = 10 ** 9
-    print("%d.%d %6d: [exit ] %s(%x) depth: %d" %
+    print("%d.%09d %6d: [exit ] %s(%x) depth: %d" %
             (_time / unit, _time % unit, _tid, _name, _address, _depth))
 
     if "retval" in ctx:
@@ -62,7 +62,7 @@ def uftrace_event(ctx):
     _name       = ctx["name"]
 
     unit = 10 ** 9
-    print("%d.%d %6d: [event] %s(%x)" %
+    print("%d.%09d %6d: [event] %s(%x)" %
             (_time / unit, _time % unit, _tid, _name, _address))
 
 # uftrace_end is optional, so can be omitted.


### PR DESCRIPTION
As the timestamp represents in nanosecond unit, dump script wants to
show in second unit. But, in modular, the digits may not filled enough

ex.
  _time = 1001002003
  _time / unit == 1
  _time % unit == 1002003

expected:
  1.001002003

actual:
  1.1002003
  // may translated as 1s, 100ms, 200us, 300ns

So, need to change formatting text to start with leading zero, fixed
nine digits.

Signed-off-by: JaeSang Yoo <jsyoo5b@gmail.com>