### PR TITLE
dump: Add an interaction option to the mermaid result.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,9 @@ endif
 
 COMMON_CFLAGS += -W -Wall -Wno-unused-parameter -Wno-missing-field-initializers
 
+C_STR_TARGET = utils/mermaid.js utils/mermaid.html
+C_STR_EXTENSION = cstr
+
 #
 # Note that the plain CFLAGS and LDFLAGS can be changed
 # by config/Makefile later but *_*FLAGS can not.
@@ -281,7 +284,7 @@ $(UFTRACE_ARCH_OBJS): $(wildcard $(srcdir)/arch/$(ARCH)/*.[cS]) $(COMMON_DEPS)
 $(objdir)/libtraceevent/libtraceevent.a: $(wildcard $(srcdir)/libtraceevent/*.[ch]) $(objdir)/.config
 	@$(MAKE) -C $(srcdir)/libtraceevent BUILD_SRC=$(srcdir)/libtraceevent BUILD_OUTPUT=$(objdir)/libtraceevent CONFIG_FLAGS="$(TRACEEVENT_CFLAGS)"
 
-$(objdir)/uftrace.o: $(srcdir)/uftrace.c $(objdir)/version.h $(COMMON_DEPS)
+$(objdir)/uftrace.o: $(srcdir)/uftrace.c $(objdir)/version.h c-str-conversion $(COMMON_DEPS)
 	$(QUIET_CC)$(CC) $(UFTRACE_CFLAGS) -c -o $@ $<
 
 $(objdir)/misc/demangler.o: $(srcdir)/misc/demangler.c $(objdir)/version.h $(COMMON_DEPS)
@@ -383,6 +386,7 @@ clean:
 	$(Q)$(RM) $(objdir)/uftrace-*.tar.gz $(objdir)/version.h
 	$(Q)find -name "*\.gcda" -o -name "*\.gcno" | xargs $(RM)
 	$(Q)$(RM) coverage.info
+	$(Q)$(RM) $(objdir)/utils/*.$(C_STR_EXTENSION)
 	@$(MAKE) -sC $(srcdir)/arch/$(ARCH) clean
 	@$(MAKE) -sC $(srcdir)/tests ARCH=$(ARCH) clean
 	@$(MAKE) -sC $(docdir) clean
@@ -395,5 +399,10 @@ reset-coverage:
 ctags:
 	@find . -name "*\.[chS]" -o -path ./tests -prune -o -path ./check-deps -prune \
 		| xargs ctags --regex-asm='/^(GLOBAL|ENTRY|END)\(([^)]*)\).*/\2/'
+
+c-str-conversion:
+	@for i in ${C_STR_TARGET}; do \
+		sed -e 's#\\#\\\\#g;s#\"#\\"#g;s#$$#\\n\"#;s#^#\"#' $${i} > $${i}.$(C_STR_EXTENSION); \
+	done
 
 .PHONY: all config clean test dist doc ctags PHONY

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -449,7 +449,7 @@ class TestBase:
         start_mermaid = False
 
         for ln in output.split('\n'):
-            if ln.find('<div class=\"mermaid\">') >= 0:
+            if ln.find('<div class=\"mermaid\"') >= 0:
                 start_mermaid = True
                 continue
             if start_mermaid == False:
@@ -457,9 +457,11 @@ class TestBase:
             if ln.find('</div>') >= 0:
                 break
 
-            m = re.match( r'\s+(?P<start_id>\d+)\[\"(?P<start_name>\S+)\"\]\s+-->\|(?P<call_num>\d+)\|\s+(?P<end_id>\d+)\[\"(?P<end_name>\S+)\"\];', ln)
+            m = re.match( r'\s+(?P<start_depth>\d+)_(?P<start_id>\d+)\[\"(?P<start_name>\S+)\"\]\s+'
+                + '-->\|(?P<call_num>\d+)\|\s+(?P<end_depth>\d+)_(?P<end_id>\d+)\[\"(?P<end_name>\S+)\"\];', ln)
             if m:
-                result.append("%s_%s %s> %s_%s" % (m.group('start_id'), m.group('start_name'), m.group('call_num'), m.group('end_id'), m.group('end_name')))
+                result.append("%s_%s_%s %s> %s_%s_%s" % (m.group('start_depth'), m.group('start_id'), m.group('start_name'),
+                m.group('call_num'), m.group('end_depth'), m.group('end_id'), m.group('end_name')))
             else:
                 continue
         return '\n'.join(result)

--- a/tests/t272_dump_mermaid.py
+++ b/tests/t272_dump_mermaid.py
@@ -19,10 +19,10 @@ class TestCase(TestBase):
 <h2>Function Call Graph for <span style="color:blue">t-abc</span></h2>
 <div class="mermaid">
 flowchart TB
-  0["t-abc"] -->|1| 1["main"];
-  1["main"] -->|1| 2["a"];
-  2["a"] -->|1| 3["b"];
-  3["b"] -->|1| 4["c"];
+  0_0["t-abc"] -->|1| 1_1["main"];
+  1_1["main"] -->|1| 2_2["a"];
+  2_2["a"] -->|1| 3_3["b"];
+  3_3["b"] -->|1| 4_4["c"];
 </div>
 </body>
 </html>

--- a/utils/mermaid.html
+++ b/utils/mermaid.html
@@ -1,0 +1,57 @@
+<style>
+#options {
+  border-collapse: collapse;
+  width: 100%;
+}
+#options td, #options th {
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+#options tr:hover{ background-color : #fffff4; }
+#options th {
+  padding-top : 10px;
+  padding-bottom : 10px;
+  text-align : left;
+  background-color : #58becd;
+}
+.button {
+  padding: 8px 16px;
+  transition-duration: 0.4s;
+  border: none;
+  cursor: pointer;
+  border-radius: 6px;
+}
+.button:hover {
+  box-shadow: 0 4px 8px 0 rgba(0,0,0,0.24);
+}
+</style>
+<details>
+  <summary> Show option </summary>
+  <table id="options">
+    <tr>
+      <th>Full/Sub Graph</th>
+      <th>Show/Hide Depth</th>
+    </tr>
+    <tr>
+      <td>
+          <button class="button" onclick="drawBaseGraph(0)">Full-Graph</button>
+          <button class="button" onclick="drawSelectGraph()">Sub-Graph Selection</button>
+          <span id="description" style="color:blue" > </span>
+      </td>
+      <td>
+        Depth:
+        <select id="depth-select">
+          <option value="1024" selected>Full</option>
+          <option value="1">1</option>
+          <option value="2">2</option>
+          <option value="3">3</option>
+          <option value="4">4</option>
+          <option value="5">5</option>
+          <option value="6">6</option>
+          <option value="7">7</option>
+        </select>
+    </td>
+  </tr>
+</table>
+<br>
+</details>

--- a/utils/mermaid.js
+++ b/utils/mermaid.js
@@ -1,0 +1,205 @@
+const GRAPH_TITLE = new String("graph TB\n");
+const FULL_DEPTH = document.getElementById("depth-select").options[0];
+const COMMENT = new String("%% ");
+const FUNC_ID_PATTERN = /(?<node_depth>\d+)_(?<node_id>\d+)/;
+const COLOR_SUB_DEPTH = new String("#f9f");
+const COLOR_PARTIAL_GRAPH = new String("#cab8ff");
+const COLOR_STROKE = new String("#333");
+let startId = new Array();
+let startDepth = new Array();
+let startName = new Array();
+let callFlow = new Array();
+let openNode = new Array();
+let baseRootName = new String();
+let baseRootId = new String("0");
+let baseGraph = new String();
+let baseRootDepth = new Number(FULL_DEPTH);
+let showHideDesc = new String();
+let maxDepth = new Number(1);
+
+const mermaidTxt = document.getElementById("meraid_graph").innerHTML;
+
+var showHideNode = function(nodeId) {
+	const nodeIdResult = nodeId.match(FUNC_ID_PATTERN);
+	if (nodeIdResult == null) {
+		document.getElementById("description").innerHTML = "Invalid Node ID : " + nodeId;
+		return;
+	}
+	const id = nodeIdResult.groups.node_id;
+	const depth = nodeIdResult.groups.node_depth;
+	const open = openNode.includes(id);
+	let start = new Boolean(false);
+	for (let i = 0; i < callFlow.length; i++) {
+		if (start == false && Number(startId[i]) == id) {
+			start = true;
+		}
+		if (start == true) {
+			if (Number(startId[i]) == id || startDepth[i] > depth) {
+				if (open)
+					callFlow[i] = COMMENT + callFlow[i];
+				else
+					callFlow[i] = callFlow[i].replace(COMMENT, "");
+			}
+			else {
+				break;
+			}
+		}
+	}
+	if (open)
+		openNode.pop(id);
+	else
+		openNode.push(id);
+
+	renderGraph("".concat(GRAPH_TITLE, callFlow.join("\n"), "\n", showHideDesc));
+};
+
+var selectSubGraph = function(nodeId) {
+	const nodeIdResult = nodeId.match(FUNC_ID_PATTERN);
+	const id = nodeIdResult.groups.node_id;
+
+	for (let i = 0; i < callFlow.length; i++) {
+		if (Number(startId[i]) == id) {
+			drawBaseGraph(id);
+			break;
+		}
+	}
+};
+
+var initializeBaseGraph = function() {
+	startId.length = 0;
+	startDepth.length = 0;
+	startName.length = 0;
+	openNode.length = 0;
+	callFlow.length = 0;
+	showHideDesc = "";
+	baseGraph = "";
+};
+
+var getNodeStyle = function(id, fillColor, strokeColor) {
+	return "  style " + id + " fill:" + fillColor + " ,stroke:" + strokeColor +
+	       ",stroke-width:px;";
+};
+
+var drawDepthGraph = function(depth) {
+	mermaid.initialize(config);
+	showHideDesc = "";
+	openNode.length = 0;
+	const nodeList = new Array();
+	let id = new String();
+	for (let i = 0; i < callFlow.length; i++) {
+		callFlow[i] = callFlow[i].replace(COMMENT, "");
+		if (Number(startDepth[i]) >= depth)
+			callFlow[i] = (COMMENT + callFlow[i]);
+		if (Number(startDepth[i]) == depth) {
+			id = startDepth[i] + "_" + startId[i];
+			if (nodeList.includes(id) == false) {
+				nodeList.push(id);
+				showHideDesc = showHideDesc.concat(
+					getNodeStyle(id, COLOR_SUB_DEPTH, COLOR_STROKE), "\n");
+				showHideDesc =
+					showHideDesc.concat("  click " + id + " showHideNode;\n");
+			}
+		}
+	}
+	renderGraph("".concat(GRAPH_TITLE, callFlow.join("\n"), "\n", showHideDesc));
+};
+
+function drawSelectGraph()
+{
+	let selectionDesc = new String();
+	let nodeList = new Array();
+	if (callFlow.length == 0)
+		drawBaseGraph(0);
+	for (let i = 1; i < callFlow.length; i++) {
+		let id = startDepth[i] + "_" + startId[i];
+		if (nodeList.includes(id) == false) {
+			nodeList.push(id);
+			selectionDesc = selectionDesc.concat(
+				getNodeStyle(id, COLOR_PARTIAL_GRAPH, COLOR_STROKE), "\n");
+			selectionDesc =
+				selectionDesc.concat("  click " + id + " selectSubGraph;\n");
+		}
+	}
+	renderGraph(baseGraph.concat("\n", selectionDesc));
+	document.getElementById("description").innerHTML = "Click on a node to view Sub-Graph";
+};
+
+var drawBaseGraph = function(id) {
+	mermaid.initialize(config);
+	initializeBaseGraph();
+	let start = new Boolean(false);
+	maxDepth = 0;
+	var result = mermaidTxt.split(/\r?\n/);
+	for (let i = 0; i < result.length; i++) {
+		if (result[i].length == 0)
+			continue;
+		let oneCallFlow = result[i].match(
+			/\s+(?<start_depth>\d+)_(?<start_id>\d+)\[\"(?<start_name>\S+)\"\]\s+--\S+\|(?<call_num>\d+)\|\s+(?<end_depth>\d+)_(?<end_id>\d+)\[\"(?<end_name>\S+)\"];/);
+		// If call flow is
+		// 	3_6["A"] -->|2| 4_9["B"];
+		// , each matching value is like
+		// 	start_depth : 3, start_id : 6, start_name : A, call_num : 2, end_depth : 4, end_id : 9, end_name : B
+
+		if (oneCallFlow == null)
+			continue;
+		if (Number(oneCallFlow.groups.start_id) == id) {
+			start = true;
+			baseRootDepth = Number(oneCallFlow.groups.start_depth);
+			baseRootId = id;
+		}
+		if (start == true) {
+			if (Number(oneCallFlow.groups.start_depth) > baseRootDepth ||
+			    Number(oneCallFlow.groups.start_id == id)) {
+				callFlow.push(result[i]);
+				startId.push(oneCallFlow.groups.start_id);
+				startDepth.push(oneCallFlow.groups.start_depth);
+				startName.push(oneCallFlow.groups.start_name);
+			}
+			else {
+				break;
+			}
+		}
+		if (Number(oneCallFlow.groups.start_depth) > maxDepth)
+			maxDepth = Number(oneCallFlow.groups.start_depth);
+	}
+	baseGraph = "".concat(GRAPH_TITLE, callFlow.join("\n"));
+	updateDepthList();
+	renderGraph(baseGraph);
+};
+
+var updateDepthList =
+	function() {
+	var select = document.getElementById("depth-select");
+	select.options.length = 0;
+	select.options[0] = new Option("Full", FULL_DEPTH);
+	let limit = new Number(maxDepth - Number(baseRootDepth) + 1);
+	for (let i = 1; i <= limit; i++) {
+		select.options[select.options.length] = new Option(i, i);
+	}
+}
+
+var renderGraph = function(graphText) {
+	var graphDiv = document.getElementById("meraid_graph");
+	graphText = graphText.replace(/&gt;/g, ">");
+	var insertSvg = function(svgCode, bindFunctions) {
+		graphDiv.innerHTML = svgCode;
+		if (typeof callback != "undefined") {
+			callback(id);
+		}
+		bindFunctions(graphDiv);
+	};
+	mermaid.render("callGraph", graphText, insertSvg, graphDiv);
+	document.getElementById("description").innerHTML = "";
+};
+
+let selector = document.getElementById("depth-select");
+selector.addEventListener("click", () => {
+	selector.addEventListener("change", () => {
+		if (callFlow.length == 0)
+			drawBaseGraph(0);
+		showHideDepth = Number(document.getElementById("depth-select").value) +
+				Number(baseRootDepth);
+		if (showHideDepth != FULL_DEPTH)
+			drawDepthGraph(showHideDepth);
+	});
+});


### PR DESCRIPTION
This adds an interaction option to mermaid results. It allows users to
 check the call graph step by step with one uftrace result.
It supports the following graph following the user's input.
  a) Show the graph until specific call depth level.
     When the function has sub call flow, clicking the function node
      makes it attach the remaining call flow.
     It allows to toggle show/hide sub-graph.
  b) Show the partial graph starting from a specific function.
     This partial graph also support the a) depth option

For this feature, the following is added.
  1. Add the call depth level to mermaid node id as "depth_id" format.
  2. Add html and javascript to make the option. This code is included
      in the header file as raw string.
     This header file is converted incorrectly in pre-commit
      clang-format hook. So it is excluded in pre-commit.

Signed-off-by: Jia Ha <wendyisdream1004@gmail.com>