### PR TITLE
utils: Apply some updates for utils helpers

### DIFF
--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -25,6 +25,18 @@
 #define KEY_ESCAPE 27
 #define BLANK 32
 
+#define TUI_ASSERT(cond)                                                                           \
+	do {                                                                                       \
+		endwin();                                                                          \
+		ASSERT(cond);                                                                      \
+	} while (0)
+
+#define TUI_DASSERT(cond)                                                                          \
+	do {                                                                                       \
+		endwin();                                                                          \
+		DASSERT(cond);                                                                     \
+	} while (0)
+
 static bool tui_finished;
 static bool tui_debug;
 

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -34,6 +34,9 @@
 #define ALIGN(n, a) (((n) + (a)-1) & ~((a)-1))
 #endif
 
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+
 #define DIV_ROUND_UP(v, r) (((v) + (r)-1) / (r))
 #define ROUND_UP(v, r) (DIV_ROUND_UP((v), (r)) * (r))
 #define ROUND_DOWN(v, r) (((v) / (r)) * (r))

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -174,6 +174,7 @@ extern void setup_signal(void);
 #define pr_bold(fmt, ...) __pr_color(COLOR_CODE_BOLD, fmt, ##__VA_ARGS__)
 #define pr_gray(fmt, ...) __pr_color(COLOR_CODE_GRAY, fmt, ##__VA_ARGS__)
 #define pr_color(c, fmt, ...) __pr_color(c, fmt, ##__VA_ARGS__)
+#define pr_flush() fflush(outfp)
 
 #define xmalloc(sz)                                                                                \
 	({                                                                                         \
@@ -407,6 +408,7 @@ void stacktrace(void);
 		pr_red("%s:%d: %s: ASSERT `%s' failed.\n", __FILE__, __LINE__, __func__, #cond);   \
 		stacktrace();                                                                      \
 		pr_red(BUG_REPORT_MSG);                                                            \
+		pr_flush();                                                                        \
 		TRAP();                                                                            \
 	}
 
@@ -416,6 +418,7 @@ void stacktrace(void);
 		       #cond);                                                                     \
 		stacktrace();                                                                      \
 		pr_red(BUG_REPORT_MSG);                                                            \
+		pr_flush();                                                                        \
 		TRAP();                                                                            \
 	}
 


### PR DESCRIPTION
This PR contains the following changes.
- 65de9c6b utils: Add MIN() and MAX() helper macros
- 125beace tui: Add TUI_ASSERT() and TUI_DASSERT() helpers
- 3fc12800 utils: Add pr_flush() and use it in ASSERT/DASSERT