### PR TITLE
tests: Update 015 longjmp test code.

### DIFF
--- a/tests/s-longjmp.c
+++ b/tests/s-longjmp.c
@@ -8,9 +8,9 @@ int foo(void)
 	return 0;
 }
 
-int bar(void)
+int bar(int a)
 {
-	return -1;
+	return a - 2;
 }
 
 int main(int argc, char *argv[])
@@ -20,6 +20,6 @@ int main(int argc, char *argv[])
 	if (!setjmp(env))
 		ret = foo();
 	else
-		ret = bar();
+		ret = bar(argc);
 	return !(ret == -1);
 }


### PR DESCRIPTION
Because compiler likes to optimize `bar()` for simplicity, Update 015 longjmp test code.

Fixed: #1576
Signed-off-by: Paran Lee <p4ranlee@gmail.com>