### PR TITLE
tests: Fix t090_report_recursive tests in clang

### DIFF
--- a/tests/s-fibonacci.c
+++ b/tests/s-fibonacci.c
@@ -15,6 +15,5 @@ int main(int argc, char *argv[])
 	if (argc > 1)
 		n = atoi(argv[1]);
 
-	fib(n);
-	return 0;
+	return !!fib(n);
 }


### PR DESCRIPTION
This patch fixes the following test failures in t090_report_recursive.
```
  $ ./runtest.py 090
  Start 1 tests without worker pool
  Compiler                  gcc                            clang
  Test case                 pg             finstrument-fu  pg             finstrument-fu
  ------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os  O0 O1 O2 O3 Os O0 O1 O2 O3 Os
  090 report_recursive    : OK OK OK OK OK OK OK OK OK OK  OK NG NG NG NG OK OK OK OK OK
```
It fails in clang optimized tests, but it's just because fib() function is optimized out.

To avoid this optimization, use the return value of fib() function.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>