### PR TITLE
graph: Null dereference amend

### DIFF
--- a/cmds/graph.c
+++ b/cmds/graph.c
@@ -279,7 +279,8 @@ static struct task_graph *get_task_graph(struct uftrace_task_reader *task, uint6
 	graph = get_graph(task, time, addr);
 
 	if (tg->utg.graph && tg->utg.graph != graph) {
-		pr_dbg("detect new session: %.*s\n", SESSION_ID_LEN, graph->sess->sid);
+		if (graph && graph->sess)
+			pr_dbg("detect new session: %.*s\n", SESSION_ID_LEN, graph->sess->sid);
 		tg->utg.new_sess = true;
 	}
 	tg->utg.graph = graph;


### PR DESCRIPTION
pointer `graph` last assigned on static int start_graph(struct task_graph *tg); 
graph->sess->sid could be null and is dereferenced. 
issue #1574 related Null dereference amend works.

Signed-off-by: Yun Seong Kim <yunseong.kim@ahnlab.com>