### PR TITLE
mcount: Update depth and time filters at runtime

### DIFF
--- a/cmds/live.c
+++ b/cmds/live.c
@@ -122,6 +122,16 @@ static int forward_options(struct uftrace_opts *opts)
 			pr_dbg3("sent option depth = %d\n", opts->depth);
 	}
 
+	if (opts->threshold) {
+		if (socket_send_option(sfd, UFTRACE_DOPT_THRESHOLD, &opts->threshold,
+				       sizeof(uint64_t)) == -1) {
+			ret = -1;
+			pr_warn("cannot send option 'threshold'\n");
+		}
+		else
+			pr_dbg3("sent option threshold = %d\n", opts->threshold);
+	}
+
 	if (socket_send_option(sfd, UFTRACE_DOPT_CLOSE, NULL, 0) == -1) {
 		pr_warn("cannot terminate agent connection\n");
 		ret = -1;

--- a/cmds/live.c
+++ b/cmds/live.c
@@ -113,6 +113,15 @@ static int forward_options(struct uftrace_opts *opts)
 		goto socket_error;
 	}
 
+	if (opts->depth) {
+		if (socket_send_option(sfd, UFTRACE_DOPT_DEPTH, &opts->depth, sizeof(int)) == -1) {
+			ret = -1;
+			pr_warn("cannot send option 'depth'\n");
+		}
+		else
+			pr_dbg3("sent option depth = %d\n", opts->depth);
+	}
+
 	if (socket_send_option(sfd, UFTRACE_DOPT_CLOSE, NULL, 0) == -1) {
 		pr_warn("cannot terminate agent connection\n");
 		ret = -1;

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -51,6 +51,12 @@ struct filter_control {
 	int out_count;
 	uint16_t depth;
 	uint16_t saved_depth;
+	/* call depth relative to the closest parent with default depth (e.g.
+	 * matched entry) */
+	uint16_t depth_relative;
+	uint16_t saved_depth_relative;
+	bool depth_trigger;
+	bool saved_depth_trigger;
 	uint64_t time;
 	uint64_t saved_time;
 };

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -59,6 +59,8 @@ struct filter_control {
 	bool saved_depth_trigger;
 	uint64_t time;
 	uint64_t saved_time;
+	bool time_trigger;
+	bool saved_time_trigger;
 };
 #else
 struct filter_control {};

--- a/libmcount/mcount.h
+++ b/libmcount/mcount.h
@@ -52,6 +52,7 @@ struct mcount_ret_stack {
 	int tid;
 	unsigned dyn_idx;
 	uint64_t filter_time;
+	bool filter_time_trigger;
 	unsigned short depth;
 	unsigned short filter_depth;
 	unsigned short filter_depth_relative;

--- a/libmcount/mcount.h
+++ b/libmcount/mcount.h
@@ -54,6 +54,8 @@ struct mcount_ret_stack {
 	uint64_t filter_time;
 	unsigned short depth;
 	unsigned short filter_depth;
+	unsigned short filter_depth_relative;
+	bool filter_depth_trigger;
 	unsigned short nr_events;
 	unsigned short event_idx;
 	struct plthook_data *pd;

--- a/uftrace.c
+++ b/uftrace.c
@@ -1311,7 +1311,6 @@ int main(int argc, char *argv[])
 		.dirname = UFTRACE_DIR_NAME,
 		.libcall = true,
 		.bufsize = SHMEM_BUFFER_SIZE,
-		.depth = OPT_DEPTH_DEFAULT,
 		.max_stack = OPT_RSTACK_DEFAULT,
 		.port = UFTRACE_RECV_PORT,
 		.use_pager = true,
@@ -1412,6 +1411,10 @@ int main(int argc, char *argv[])
 
 	if (opts.use_pager)
 		pager = setup_pager();
+
+	if (!opts.pid && !opts.depth)
+		/* ignore implicit depth when in client mode */
+		opts.depth = OPT_DEPTH_DEFAULT;
 
 	setup_color(opts.color, pager);
 	setup_signal();

--- a/uftrace.h
+++ b/uftrace.h
@@ -416,6 +416,7 @@ enum uftrace_msg_type {
 
 /* Dynamic options sent by the client to the agent */
 enum uftrace_dopt {
+	UFTRACE_DOPT_DEPTH,
 	UFTRACE_DOPT_CLOSE, /* Close the connection with the client */
 };
 

--- a/uftrace.h
+++ b/uftrace.h
@@ -417,6 +417,7 @@ enum uftrace_msg_type {
 /* Dynamic options sent by the client to the agent */
 enum uftrace_dopt {
 	UFTRACE_DOPT_DEPTH,
+	UFTRACE_DOPT_THRESHOLD,
 	UFTRACE_DOPT_CLOSE, /* Close the connection with the client */
 };
 


### PR DESCRIPTION
Hi,

This pull request implements a dynamic mechanism for `-D` and `-t` options. Both can be updated at runtime, using the agent.

~~It is constructed on top of #1543 (not accepted yet at the time of writing). The first four commits are from #1543. The last two commits actually implement the dynamic features.~~

Given a running `uftrace` instance with its agent enabled:
```
$ uftrace -g <some-target>
```

One can use the following commands to set new depth/time filter value:
```
$ uftrace -p `pidof some-target` -D <depth>
$ uftrace -p `pidof some-target` -t <threshold>
```