### PR TITLE
[RFC] Record CTF traces with LTTng integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ $(LIBMCOUNT_SINGLE_OBJS): $(objdir)/%-single.op: $(srcdir)/%.c $(LIBMCOUNT_DEPS)
 $(LIBMCOUNT_FAST_SINGLE_OBJS): $(objdir)/%-fast-single.op: $(srcdir)/%.c $(LIBMCOUNT_DEPS)
 	$(QUIET_CC_FPIC)$(CC) $(LIB_CFLAGS) $(LIBMCOUNT_FAST_SINGLE_CFLAGS) -c -o $@ $<
 
-$(LIBMCOUNT_LTTNG_OBJS): $(objdir)/%-lttng.op: $(srcdir)/%.c $(LIBMCOUNT_DEPS)
+$(LIBMCOUNT_LTTNG_OBJS): $(objdir)/%-lttng.op: $(srcdir)/%.c $(LIBMCOUNT_DEPS) $(srcdir)/libmcount/lttng-tp.h
 	$(QUIET_CC_FPIC)$(CC) $(LIB_CFLAGS) $(LIBMCOUNT_LTTNG_CFLAGS) -c -o $@ $<
 
 $(LIBMCOUNT_NOP_OBJS): $(objdir)/%.op: $(srcdir)/%.c $(LIBMCOUNT_DEPS)

--- a/arch/x86_64/dynamic.S
+++ b/arch/x86_64/dynamic.S
@@ -42,8 +42,16 @@
 
 GLOBAL(__dentry__)
 	.cfi_startproc
-	sub $48, %rsp
+#ifdef ENABLE_LTTNG
+	sub $112, %rsp
+	.cfi_adjust_cfa_offset 112
+
+    vmovdqu %ymm0, 80(%rsp)
+    vmovdqu %ymm1, 48(%rsp)
+#else
+    sub $48, %rsp
 	.cfi_adjust_cfa_offset 48
+#endif // ENABLE_LTTNG
 
 	movq %rdi, 40(%rsp)
 	movq %rsi, 32(%rsp)
@@ -53,10 +61,18 @@ GLOBAL(__dentry__)
 	movq %r9,   0(%rsp)
 
 	/* child addr */
-	movq 48(%rsp), %rsi
+#ifdef ENABLE_LTTNG
+	movq 112(%rsp), %rsi
+#else
+    movq 48(%rsp), %rsi
+#endif // ENABLE_LTTNG
 
 	/* parent location */
-	lea 56(%rsp), %rdi
+#ifdef ENABLE_LTTNG
+	lea 120(%rsp), %rdi
+#else
+    lea 56(%rsp), %rdi
+#endif // ENABLE_LTTNG
 
 	/* mcount_args */
 	movq %rsp, %rdx
@@ -79,7 +95,11 @@ GLOBAL(__dentry__)
 	movq 24(%rsp), %rdx
 
 	/* child addr */
+#ifdef ENABLE_LTTNG
+    movq 112(%rdx), %rdi
+#else
 	movq 48(%rdx), %rdi
+#endif // ENABLE_LTTNG
 
 	/* find location that has the original code */
 	call mcount_find_code
@@ -88,7 +108,11 @@ GLOBAL(__dentry__)
 	movq 24(%rsp), %rdx
 
 	/* overwrite return address */
-	movq %rax, 48(%rdx)
+#ifdef ENABLE_LTTNG
+	movq %rax, 112(%rdx)
+#else
+    movq %rax, 48(%rdx)
+#endif // ENABLE_LTTNG
 
 	pop  %r11
 	pop  %r10
@@ -103,9 +127,17 @@ GLOBAL(__dentry__)
 	movq 24(%rsp), %rdx
 	movq 32(%rsp), %rsi
 	movq 40(%rsp), %rdi
+#ifdef ENABLE_LTTNG
+    vmovdqu 48(%rsp), %ymm1
+    vmovdqu 80(%rsp), %ymm0
 
-	add $48, %rsp
+    add $112, %rsp
+	.cfi_adjust_cfa_offset -112
+#else
+    add $48, %rsp
 	.cfi_adjust_cfa_offset -48
+#endif // ENABLE_LTTNG
+
 
 	retq
 	.cfi_endproc
@@ -114,8 +146,16 @@ END(__dentry__)
 
 ENTRY(dynamic_return)
 	.cfi_startproc
+#ifdef ENABLE_LTTNG
+    sub    $160, %rsp
+	.cfi_def_cfa_offset 160
+
+    vmovdqu %ymm0, 120(%rsp)
+    vmovdqu %ymm1, 88(%rsp)
+#else
 	sub    $96, %rsp
 	.cfi_def_cfa_offset 96
+#endif // ENABLE_LTTNG
 
 	/* save all caller-saved registers due to -fipa-ra */
 	movq   %r11,  80(%rsp)
@@ -147,7 +187,11 @@ ENTRY(dynamic_return)
 	movq   (%rsp), %rsp
 
 	/* restore original return address in parent */
+#ifdef ENABLE_LTTNG
+    movq   %rax,   152(%rsp)
+#else
 	movq   %rax,   88(%rsp)
+#endif // ENABLE_LTTNG
 
 	movq    0(%rsp), %rax
 	movq    8(%rsp), %rdx
@@ -161,7 +205,14 @@ ENTRY(dynamic_return)
 	movq   72(%rsp), %r10
 	movq   80(%rsp), %r11
 
-	add    $88, %rsp
+#ifdef ENABLE_LTTNG
+    vmovdqu 88(%rsp),  %ymm1
+    vmovdqu 120(%rsp), %ymm0
+
+    add $152, %rsp
+#else
+	add $88, %rsp
+#endif // ENABLE_LTTNG
 	.cfi_def_cfa_offset 8
 	retq
 	.cfi_endproc

--- a/arch/x86_64/fentry.S
+++ b/arch/x86_64/fentry.S
@@ -28,8 +28,16 @@
 
 GLOBAL(__fentry__)
 	.cfi_startproc
+#ifdef ENABLE_LTTNG
+    sub $112, %rsp
+	.cfi_adjust_cfa_offset 112
+
+    vmovdqu %ymm0, 80(%rsp)
+    vmovdqu %ymm1, 48(%rsp)
+#else
 	sub $48, %rsp
 	.cfi_adjust_cfa_offset 48
+#endif // ENABLE_LTTNG
 
 	/* save register arguments in mcount_args */
 	movq %rdi, 40(%rsp)
@@ -40,10 +48,18 @@ GLOBAL(__fentry__)
 	movq %r9,   0(%rsp)
 
 	/* child addr */
+#ifdef ENABLE_LTTNG
+    movq 112(%rsp), %rsi
+#else
 	movq 48(%rsp), %rsi
+#endif // ENABLE_LTTNG
 
 	/* parent location */
+#ifdef ENABLE_LTTNG
+    lea 120(%rsp), %rdi
+#else
 	lea 56(%rsp), %rdi
+#endif // ENABLE_LTTNG
 
 	/* mcount_args */
 	movq %rsp, %rdx
@@ -72,9 +88,16 @@ GLOBAL(__fentry__)
 	movq 24(%rsp), %rdx
 	movq 32(%rsp), %rsi
 	movq 40(%rsp), %rdi
+#ifdef ENABLE_LTTNG
+    vmovdqu 48(%rsp), %ymm1
+    vmovdqu 80(%rsp), %ymm0
 
+    add $112, %rsp
+    .cfi_adjust_cfa_offset -112
+#else
 	add $48, %rsp
 	.cfi_adjust_cfa_offset -48
+#endif // ENABLE_LTTNG
 	retq
 	.cfi_endproc
 END(__fentry__)

--- a/arch/x86_64/mcount.S
+++ b/arch/x86_64/mcount.S
@@ -30,8 +30,16 @@
 
 GLOBAL(mcount)
 	.cfi_startproc
+#ifdef ENABLE_LTTNG
+    sub $112, %rsp
+	.cfi_adjust_cfa_offset 112
+
+    vmovdqu %ymm0, 80(%rsp)
+    vmovdqu %ymm1, 48(%rsp)
+#else
 	sub $48, %rsp
 	.cfi_adjust_cfa_offset 48
+#endif // ENABLE_LTTNG
 
 	/* save register arguments in mcount_args */
 	movq %rdi, 40(%rsp)
@@ -42,7 +50,11 @@ GLOBAL(mcount)
 	movq %r9,   0(%rsp)
 
 	/* child addr */
+#ifdef ENABLE_LTTNG
+    movq 112(%rsp), %rsi
+#else
 	movq 48(%rsp), %rsi
+#endif // ENABLE_LTTNG
 
 	/* parent location */
 	lea 8(%rbp), %rdi
@@ -74,9 +86,16 @@ GLOBAL(mcount)
 	movq 24(%rsp), %rdx
 	movq 32(%rsp), %rsi
 	movq 40(%rsp), %rdi
+#ifdef ENABLE_LTTNG
+    vmovdqu 48(%rsp), %ymm1
+    vmovdqu 80(%rsp), %ymm0
 
+    add $112, %rsp
+	.cfi_adjust_cfa_offset -112
+#else
 	add $48, %rsp
 	.cfi_adjust_cfa_offset -48
+#endif // ENABLE_LTTNG
 	retq
 	.cfi_endproc
 END(mcount)
@@ -88,11 +107,20 @@ END(mcount)
  */
 ENTRY(mcount_return)
 	.cfi_startproc
+#ifdef ENABLE_LTTNG
+    sub $96, %rsp
+	.cfi_def_cfa_offset 96
+
+    vmovdqu %ymm0, 56(%rsp)
+    vmovdqu %ymm1, 24(%rsp)
+    movq    %rdi,  16(%rsp)
+#else
 	sub $48, %rsp
 	.cfi_def_cfa_offset 48
 
 	movq   %rdi,  32(%rsp)
 	movdqu %xmm0, 16(%rsp)
+#endif // ENABLE_LTTNG
 	movq   %rdx,   8(%rsp)
 	movq   %rax,   0(%rsp)
 
@@ -113,14 +141,26 @@ ENTRY(mcount_return)
 	movq    0(%rsp), %rsp
 
 	/* restore original return address in parent */
+#ifdef ENABLE_LTTNG
+    movq    %rax, 88(%rsp)
+#else
 	movq    %rax, 40(%rsp)
+#endif // ENABLE_LTTNG
 
 	movq    0(%rsp), %rax
 	movq    8(%rsp), %rdx
+#ifdef ENABLE_LTTNG
+    movq    16(%rsp), %rdi
+    vmovdqu 24(%rsp), %ymm1
+    vmovdqu 56(%rsp), %ymm0
+
+    add $88, %rsp
+#else
 	movdqu 16(%rsp), %xmm0
 	movq   32(%rsp), %rdi
 
 	add $40, %rsp
+#endif // ENABLE_LTTNG
 	.cfi_def_cfa_offset 8
 	retq
 	.cfi_endproc

--- a/arch/x86_64/plthook.S
+++ b/arch/x86_64/plthook.S
@@ -6,8 +6,16 @@ ENTRY(plt_hooker)
 	.cfi_startproc
 	/* PLT code already pushed symbol and module indices */
 	.cfi_adjust_cfa_offset 16
+#ifdef ENABLE_LTTNG
+	sub $112, %rsp
+	.cfi_adjust_cfa_offset 112
+
+	vmovdqu %ymm0, 80(%rsp)
+    vmovdqu %ymm1, 48(%rsp)
+#else
 	sub $48, %rsp
 	.cfi_adjust_cfa_offset 48
+#endif // ENABLE_LTTNG
 
 	/* save register arguments in mcount_args */
 	movq %rdi, 40(%rsp)
@@ -18,13 +26,25 @@ ENTRY(plt_hooker)
 	movq %r9,   0(%rsp)
 
 	/* module id */
+#ifdef ENABLE_LTTNG
+	movq 112(%rsp), %rdx
+#else
 	movq 48(%rsp), %rdx
+#endif // ENABLE_LTTNG
 
 	/* child idx */
+#ifdef ENABLE_LTTNG
+	movq 120(%rsp), %rsi
+#else
 	movq 56(%rsp), %rsi
+#endif // ENABLE_LTTNG
 
 	/* parent location */
+#ifdef ENABLE_LTTNG
+	leaq 128(%rsp), %rdi
+#else
 	leaq 64(%rsp), %rdi
+#endif // ENABLE_LTTNG
 
 	/* mcount_args */
 	movq %rsp, %rcx
@@ -47,6 +67,7 @@ ENTRY(plt_hooker)
 	movq %rcx, %rsp
 	.cfi_def_cfa_register rsp
 
+
 	/* restore mcount_args */
 	movq  0(%rsp), %r9
 	movq  8(%rsp), %r8
@@ -54,9 +75,16 @@ ENTRY(plt_hooker)
 	movq 24(%rsp), %rdx
 	movq 32(%rsp), %rsi
 	movq 40(%rsp), %rdi
+#ifdef ENABLE_LTTNG
+	vmovdqu 48(%rsp), %ymm1
+    vmovdqu 80(%rsp), %ymm0
 
+	add $112, %rsp
+	.cfi_adjust_cfa_offset -112
+#else
 	add $48, %rsp
 	.cfi_adjust_cfa_offset -48
+#endif // ENABLE_LTTNG
 
 	cmpq $0, %r11
 	cmovz plthook_resolver_addr(%rip), %r11
@@ -72,11 +100,20 @@ END(plt_hooker)
 
 ENTRY(plthook_return)
 	.cfi_startproc
+#ifdef ENABLE_LTTNG
+	sub $104, %rsp
+	.cfi_def_cfa_offset 104
+
+	vmovdqu %ymm0, 56(%rsp)
+    vmovdqu %ymm1, 24(%rsp)
+	movq    %rdi,  16(%rsp)
+#else
 	sub $56, %rsp
 	.cfi_def_cfa_offset 56
 
 	movq   %rdi,  32(%rsp)
 	movdqu %xmm0, 16(%rsp)
+#endif // ENABLE_LTTNG
 	movq   %rdx,   8(%rsp)
 	movq   %rax,   0(%rsp)
 
@@ -95,14 +132,26 @@ ENTRY(plthook_return)
 	movq   0(%rsp),  %rsp
 
 	/* restore original return address in parent */
+#ifdef ENABLE_LTTNG
+	movq   %rax, 96(%rsp)
+#else
 	movq   %rax, 48(%rsp)
+#endif // ENABLE_LTTNG
 
 	movq    0(%rsp), %rax
 	movq    8(%rsp), %rdx
+#ifdef ENABLE_LTTNG
+	movq    16(%rsp), %rdi
+    vmovdqu 24(%rsp), %ymm1
+    vmovdqu 56(%rsp), %ymm0
+
+    add $96, %rsp
+#else
 	movdqu 16(%rsp), %xmm0
 	movq   32(%rsp), %rdi
 
 	add $48, %rsp
+#endif // ENABLE_LTTNG
 	.cfi_def_cfa_offset 8
 	retq
 	.cfi_endproc

--- a/arch/x86_64/xray.S
+++ b/arch/x86_64/xray.S
@@ -7,8 +7,16 @@
 
 GLOBAL(__xray_entry)
 	.cfi_startproc
+#ifdef ENABLE_LTTNG
+	sub $112, %rsp
+	.cfi_adjust_cfa_offset 112
+
+	vmovdqu %ymm0, 80(%rsp)
+    vmovdqu %ymm1, 48(%rsp)
+#else
 	sub $48, %rsp
 	.cfi_adjust_cfa_offset 48
+#endif // ENABLE_LTTNG
 
 	movq %rdi, 40(%rsp)
 	movq %rsi, 32(%rsp)
@@ -18,10 +26,18 @@ GLOBAL(__xray_entry)
 	movq %r9,   0(%rsp)
 
 	/* child ip */
+#ifdef ENABLE_LTTNG
+	movq 112(%rsp), %rsi
+#else
 	movq 48(%rsp), %rsi
+#endif // ENABLE_LTTNG
 
 	/* parent location */
+#ifdef ENABLE_LTTNG
+	lea 120(%rsp), %rdi
+#else
 	lea 56(%rsp), %rdi
+#endif // ENABLE_LTTNG
 
 	/* mcount_args */
 	movq %rsp, %rdx
@@ -50,9 +66,17 @@ GLOBAL(__xray_entry)
 	movq 24(%rsp), %rdx
 	movq 32(%rsp), %rsi
 	movq 40(%rsp), %rdi
+#ifdef ENABLE_LTTNG
+	vmovdqu 48(%rsp), %ymm1
+    vmovdqu 80(%rsp), %ymm0
+
+	add $112, %rsp
+	.cfi_adjust_cfa_offset -112
+#else
 
 	add $48, %rsp
 	.cfi_adjust_cfa_offset -48
+#endif // ENABLE_LTTNG
 	retq
 	.cfi_endproc
 END(__xray_entry)
@@ -60,12 +84,21 @@ END(__xray_entry)
 
 ENTRY(__xray_exit)
 	.cfi_startproc
+#ifdef ENABLE_LTTNG
+	sub $88, %rsp  /* return address already consume 8 byte */
+	.cfi_def_cfa_offset 88
+
+	vmovdqu %ymm0, 56(%rsp)
+    vmovdqu %ymm1, 24(%rsp)
+	movq    %rdi,  16(%rsp)
+#else
 	sub $40, %rsp  /* return address already consume 8 byte */
 	.cfi_def_cfa_offset 40
 
 	movq   %rdi,  32(%rsp)
 	/* save original return values */
 	movdqu %xmm0, 16(%rsp)
+#endif // ENABLE_LTTNG
 	movq   %rdx,   8(%rsp)
 	movq   %rax,   0(%rsp)
 
@@ -88,8 +121,16 @@ ENTRY(__xray_exit)
 	movq    8(%rsp), %rdx
 	movdqu 16(%rsp), %xmm0
 	movq   32(%rsp), %rdi
+#ifdef ENABLE_LTTNG
+	movq    16(%rsp), %rdi
+    vmovdqu 24(%rsp), %ymm1
+    vmovdqu 56(%rsp), %ymm0
+
+    add $88, %rsp
+#else
 
 	add $40, %rsp
+#endif // ENABLE_LTTNG
 
 	retq
 	.cfi_endproc

--- a/check-deps/Makefile
+++ b/check-deps/Makefile
@@ -13,6 +13,7 @@ CHECK_LIST += have_libncurses
 CHECK_LIST += have_libdw
 CHECK_LIST += have_libunwind
 CHECK_LIST += have_libcapstone
+CHECK_LIST += have_liblttng
 CHECK_LIST += cc_has_minline_all_stringops
 
 #
@@ -50,6 +51,8 @@ CFLAGS_have_libcapstone  = $(shell pkg-config --cflags capstone 2> /dev/null)
 LDFLAGS_have_libcapstone = $(shell pkg-config --libs   capstone 2> /dev/null)
 CFLAGS_have_libunwind  = $(shell pkg-config --cflags libunwind 2> /dev/null)
 LDFLAGS_have_libunwind = $(shell pkg-config --libs   libunwind 2> /dev/null)
+CFLAGS_have_liblttng = -I.
+LDFLAGS_have_liblttng = -llttng-ust
 CFLAGS_cc_has_minline_all_stringops = -minline-all-stringops
 
 check-build: $(CHECK_LIST)

--- a/check-deps/Makefile.check
+++ b/check-deps/Makefile.check
@@ -80,3 +80,7 @@ endif
 ifneq ($(wildcard $(objdir)/check-deps/cc_has_minline_all_stringops),)
   LIB_CFLAGS += -minline-all-stringops
 endif
+
+ifneq ($(wildcard $(objdir)/check-deps/have_liblttng),)
+  export HAVE_LTTNG = 1
+endif

--- a/check-deps/__have_liblttng.c
+++ b/check-deps/__have_liblttng.c
@@ -1,0 +1,10 @@
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+#include "__have_liblttng.h"
+
+int main(int argc, char *argv[])
+{
+	lttng_ust_tracepoint(uftrace_check_deps, have_lttng);
+	return 0;
+}

--- a/check-deps/__have_liblttng.h
+++ b/check-deps/__have_liblttng.h
@@ -1,0 +1,17 @@
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER uftrace_check_deps
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "./__have_liblttng.h"
+
+#if !defined(__HAVE_LIBLTTNG_H) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define __HAVE_LIBLTTNG_H
+
+#include "lttng/tracepoint.h"
+
+LTTNG_UST_TRACEPOINT_EVENT(uftrace_check_deps, have_lttng, LTTNG_UST_TP_ARGS(),
+			   LTTNG_UST_TP_FIELDS())
+
+#endif // __HAVE_LIBLTTNG_H
+
+#include <lttng/tracepoint-event.h>

--- a/configure
+++ b/configure
@@ -33,6 +33,7 @@ usage() {
   --without-libncurses  build without libncursesw            (even if found on the system)
   --without-libunwind   build without libunwind              (even if found on the system)
   --without-capstone    build without libcapstone            (even if found on the system)
+  --without-lttng       build without liblttng-ust           (even if found on the system)
   --without-perf        build without perf event             (even if available)
   --without-schedule    build without scheduler event        (even if available)
 
@@ -192,6 +193,7 @@ for dep in $IGNORE; do
         libunwind)   TARGET=have_libunwind     ;;
         libstdc++)   TARGET=cxa_demangle       ;;
         capstone)    TARGET=have_libcapstone   ;;
+        lttng)       TARGET=have_liblttng      ;;
         perf*)       TARGET=perf_clockid       ;;
         sched*)      TARGET=perf_context_switch;;
         *)           ;;
@@ -261,6 +263,7 @@ print_feature "perf_event" "perf_clockid" "perf (PMU) event support"
 print_feature "schedule" "perf_context_switch" "scheduler event support"
 print_feature "capstone" "have_libcapstone" "full dynamic tracing support"
 print_feature "libunwind" "have_libunwind" "stacktrace support (optional for debugging)"
+print_feature "lttng" "have_liblttng" "LTTng-UST tracing support"
 
 cat >$output <<EOF
 # this file is generated automatically

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -377,6 +377,9 @@ extern void mcount_arch_get_retval(struct mcount_arg_context *ctx, struct uftrac
 extern enum filter_result mcount_entry_filter_check(struct mcount_thread_data *mtdp,
 						    unsigned long child,
 						    struct uftrace_trigger *tr);
+extern void record_event_exit(struct mcount_ret_stack *rstack, long *retval);
+extern void record_event_entry(struct mcount_thread_data *mtdp, struct mcount_ret_stack *rstack,
+			       struct uftrace_trigger *tr, struct mcount_regs *regs);
 extern void mcount_entry_filter_record(struct mcount_thread_data *mtdp,
 				       struct mcount_ret_stack *rstack, struct uftrace_trigger *tr,
 				       struct mcount_regs *regs);

--- a/libmcount/lttng-tp.h
+++ b/libmcount/lttng-tp.h
@@ -1,0 +1,57 @@
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER lttng_ust_cyg_profile
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "libmcount/lttng-tp.h"
+
+#if !defined(UFTRACE_LTTNG_TP_H) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define UFTRACE_LTTNG_TP_H
+
+#include <lttng/tracepoint.h>
+
+/* clang-format off */
+LTTNG_UST_TRACEPOINT_EVENT(
+	lttng_ust_cyg_profile,
+	func_entry,
+	LTTNG_UST_TP_ARGS(
+		void *, func_addr,
+		void *, call_site,
+		long *, args,
+		unsigned int, arg_count
+	),
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_integer_hex(unsigned long, addr,
+			(unsigned long) func_addr)
+		lttng_ust_field_integer_hex(unsigned long, call_site,
+			(unsigned long) call_site)
+		lttng_ust_field_sequence_hex(long, args, args, unsigned int, arg_count)
+	)
+)
+
+LTTNG_UST_TRACEPOINT_LOGLEVEL(lttng_ust_cyg_profile, func_entry,
+			LTTNG_UST_TRACEPOINT_LOGLEVEL_DEBUG_FUNCTION)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	lttng_ust_cyg_profile,
+	func_exit,
+	LTTNG_UST_TP_ARGS(
+		void *, func_addr,
+		void *, call_site,
+		long , retval
+	),
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_integer_hex(unsigned long, addr,
+			(unsigned long) func_addr)
+		lttng_ust_field_integer_hex(unsigned long, call_site,
+			(unsigned long) call_site)
+		lttng_ust_field_integer_hex(long, retval, retval)
+	)
+)
+
+LTTNG_UST_TRACEPOINT_LOGLEVEL(lttng_ust_cyg_profile, func_exit,
+			LTTNG_UST_TRACEPOINT_LOGLEVEL_DEBUG_FUNCTION)
+/* clang-format on */
+
+#endif // UFTRACE_LTTNG_TP_H
+
+#include <lttng/tracepoint-event.h>

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -1028,8 +1028,11 @@ void mcount_entry_filter_record(struct mcount_thread_data *mtdp, struct mcount_r
 				record_trace_data(mtdp, rstack, NULL);
 		}
 		else {
+			record_event_entry(mtdp, rstack, tr, regs);
+
 			if (tr->flags & TRIGGER_FL_ARGUMENT)
 				save_argument(mtdp, rstack, tr->pargs, regs);
+
 			if (tr->flags & TRIGGER_FL_READ) {
 				save_trigger_read(mtdp, rstack, tr->read, false);
 				rstack->flags |= MCOUNT_FL_READ;
@@ -1123,6 +1126,7 @@ void mcount_exit_filter_record(struct mcount_thread_data *mtdp, struct mcount_re
 		if (((rstack->end_time - rstack->start_time > time_filter) &&
 		     (!mcount_has_caller || rstack->flags & MCOUNT_FL_CALLER)) ||
 		    rstack->flags & (MCOUNT_FL_WRITTEN | MCOUNT_FL_TRACE)) {
+			record_event_exit(rstack, retval);
 			if (record_trace_data(mtdp, rstack, retval) < 0)
 				pr_err("error during record");
 		}

--- a/misc/install-deps.sh
+++ b/misc/install-deps.sh
@@ -21,20 +21,24 @@ case $distro in
     "ubuntu" | "debian" | "raspbian" | "kali" | "linuxmint")
         apt-get $OPT install pandoc libdw-dev python3-dev libncursesw5-dev pkg-config
         apt-get $OPT install libluajit-5.1-dev || true
-        apt-get $OPT install libcapstone-dev || true ;;
+        apt-get $OPT install libcapstone-dev || true
+        apt-get $OPT install lttng-tools liblttng-ust1 || true ;;
     "fedora")
         dnf install $OPT pandoc elfutils-devel python3-devel ncurses-devel pkgconf-pkg-config
         dnf install $OPT luajit-devel || true
-        dnf install $OPT capstone-devel || true ;;
+        dnf install $OPT capstone-devel || true
+        dnf install $OPT lttng-tools lttng-ust || true ;;
     "rhel" | "centos")
         rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
         yum install $OPT pandoc elfutils-devel python3-devel ncurses-devel pkgconfig
         yum install $OPT luajit-devel || true
         yum install $OPT capstone-devel || true ;;
+        # lttng not packaged
     "arch" | "manjaro")
         pacman $OPT -S pandoc libelf python3 ncurses pkgconf
         pacman $OPT -S luajit || true
         pacman $OPT -S capstone || true ;;
+        # lttng not available from official repositories
     "alpine")
         apk $OPT add elfutils-dev python3-dev ncurses-dev pkgconf
         apk $OPT add luajit-dev || true

--- a/uftrace.c
+++ b/uftrace.c
@@ -101,6 +101,7 @@ enum uftrace_short_options {
 	OPT_usage,
 	OPT_libmcount_path,
 	OPT_mermaid,
+	OPT_tracer,
 };
 
 /* clang-format off */
@@ -173,6 +174,7 @@ __used static const char uftrace_help[] =
 "  -l, --nest-libcall         Show nested library calls\n"
 "      --libname              Show libname name with symbol name\n"
 "      --libmcount-path=PATH  Load libmcount libraries from this PATH\n"
+"      --tracer=TRACER        Record event using TRACER: uftrace, lttng (default: uftrace)\n"
 "      --match=TYPE           Support pattern match: regex, glob (default:\n"
 "                             regex)\n"
 "      --max-stack=DEPTH      Set max stack depth to DEPTH (default: "
@@ -332,6 +334,7 @@ static const struct option uftrace_options[] = {
 	REQ_ARG(with-syms, OPT_with_syms),
 	NO_ARG(agent, 'g'),
 	REQ_ARG(pid, 'p'),
+	REQ_ARG(tracer, OPT_tracer),
 	{ 0 }
 };
 /* clang-format on */
@@ -1019,6 +1022,16 @@ static int parse_option(struct uftrace_opts *opts, int key, char *arg)
 		opts->mermaid = true;
 		break;
 
+	case OPT_tracer:
+		if (strcmp(arg, "uftrace") && strcmp(arg, "lttng")) {
+			pr_use("invalid tracer: '%s' "
+			       "(force to use 'uftrace')\n",
+			       arg);
+			arg = "uftrace";
+		}
+		opts->tracer = arg;
+		break;
+
 	default:
 		return -1;
 	}
@@ -1325,6 +1338,7 @@ int main(int argc, char *argv[])
 		.patt_type = PATT_REGEX,
 		.show_args = true,
 		.clock = "mono",
+		.tracer = "uftrace",
 	};
 	int ret = -1;
 	char *pager = NULL;
@@ -1371,6 +1385,9 @@ int main(int argc, char *argv[])
 
 	if (opts.mode == UFTRACE_MODE_INVALID)
 		opts.mode = UFTRACE_MODE_DEFAULT;
+
+	if (opts.mode == UFTRACE_MODE_LIVE && strcmp(opts.tracer, "uftrace"))
+		opts.mode = UFTRACE_MODE_RECORD; /* replay: no trace to read */
 
 	if (dbg_domain_set && !debug)
 		debug = 1;

--- a/uftrace.h
+++ b/uftrace.h
@@ -246,6 +246,7 @@ struct uftrace_opts {
 	char *hide;
 	char *with_syms;
 	char *clock;
+	char *tracer;
 	int mode;
 	int idx;
 	int depth;


### PR DESCRIPTION
Hi,

This is a proposition to make the tracing mechanics in uftrace modular. uftrace has powerful builtin trace recording, which records events using shared memory buffers, and writes them in a custom format trace file.

# LTTng integration

[LTTng](https://lttng.org) is a kernel and userspace system-wide tracer with very low overhead, which "produces trace files in the [CTF](https://diamon.org/ctf) format, a file format optimized for the production and analyses of multi-gigabyte data". [[ref](https://lttng.org/docs/v2.13/#doc-lttng-alternatives)]

The proposed work brings LTTng as an alternative tracing mechanism in uftrace, diverting the recorded events to LTTng buffers. This would allow to leverage uftrace's strong capabilities (e.g. filters, scripts, dynamic patching) in other workflows (e.g. [TraceCompass](https://www.eclipse.org/tracecompass/) analyses).

## Usage

In order to use LTTng, one has to start an LTTng session. The LTTng tracer is selected using the new `--tracer=lttng` option. In this example, the trace is displayed using the [babeltrace](https://babeltrace.org/) tool.

```
$ gcc -o abc -pg tests/s-abc

$ lttng create
$ lttng enable-event -a -u    # enable all userspace events
$ lttng start

$ uftrace --tracer lttng -A. -R. abc    # functions except main() don't have arguments

$ lttng destroy
$ babeltrace /path/to/trace
[...]
lttng_ust_cyg_profile:func_entry: { cpu_id = 14 }, { vpid = 319732, vtid = 319732, procname = "abc", ip = 140021668969126 }, { addr = 0x560BE23BB214, call_site = 0x7F5955B5B290, _args_length = 2, args = [ [0] = 0x1, [1] = 0x7FFDD8C78D48 ] }
lttng_ust_cyg_profile:func_entry: { cpu_id = 14 }, { vpid = 319732, vtid = 319732, procname = "abc", ip = 140021668969126 }, { addr = 0x560BE23BB1B3, call_site = 0x560BE23BB243, _args_length = 0, args = [ ] }
lttng_ust_cyg_profile:func_entry: { cpu_id = 14 }, { vpid = 319732, vtid = 319732, procname = "abc", ip = 140021668969126 }, { addr = 0x560BE23BB1C7, call_site = 0x560BE23BB1B8, _args_length = 0, args = [ ] }
lttng_ust_cyg_profile:func_entry: { cpu_id = 14 }, { vpid = 319732, vtid = 319732, procname = "abc", ip = 140021668969126 }, { addr = 0x560BE23BB1DB, call_site = 0x560BE23BB1CC, _args_length = 0, args = [ ] }
lttng_ust_cyg_profile:func_entry: { cpu_id = 14 }, { vpid = 319732, vtid = 319732, procname = "abc", ip = 140021668969126 }, { addr = 0x560BE23BB030, call_site = 0x560BE23BB1E0, _args_length = 0, args = [ ] }
lttng_ust_cyg_profile:func_exit: { cpu_id = 14 }, { vpid = 319732, vtid = 319732, procname = "abc", ip = 140021668969461 }, { addr = 0x560BE23BB030, call_site = 0x560BE23BB1E0, retval = 0x4E0F4 }
lttng_ust_cyg_profile:func_exit: { cpu_id = 14 }, { vpid = 319732, vtid = 319732, procname = "abc", ip = 140021668969461 }, { addr = 0x560BE23BB1DB, call_site = 0x560BE23BB1CC, retval = 0x4D14 }
lttng_ust_cyg_profile:func_exit: { cpu_id = 14 }, { vpid = 319732, vtid = 319732, procname = "abc", ip = 140021668969461 }, { addr = 0x560BE23BB1C7, call_site = 0x560BE23BB1B8, retval = 0x4D15 }
lttng_ust_cyg_profile:func_exit: { cpu_id = 14 }, { vpid = 319732, vtid = 319732, procname = "abc", ip = 140021668969461 }, { addr = 0x560BE23BB1B3, call_site = 0x560BE23BB243, retval = 0x4D14 }
lttng_ust_cyg_profile:func_exit: { cpu_id = 14 }, { vpid = 319732, vtid = 319732, procname = "abc", ip = 140021668969461 }, { addr = 0x560BE23BB214, call_site = 0x7F5955B5B290, retval = 0x0 }

```

The trace can be opened in TraceCompass, see [LTTng-UST Analyses](https://archive.eclipse.org/tracecompass/doc/stable/org.eclipse.tracecompass.doc.user/LTTng-UST-Analyses.html).

# Features

At the moment, arguments and return can be captured in CFT traces using uftrace, with limited support (integer types and pointers).

# Known problems

LTTng events are emitted using `lttng_ust_tracepoint()` which uses floating point registers (`ymm0` and `ymm1`). These need to be preserved when calling an instrumented function. I currently use a lot of `#ifdef ENABLE_LTTNG` in `arch/x86_64/*.S` entry and exit points. This is a proof of concept and it needs to be improved.

# Related

#80 aimed at producing CFT traces but is stalled.