### PR TITLE
utils: Fix warnings in utils/socket.c

### DIFF
--- a/utils/socket.c
+++ b/utils/socket.c
@@ -1,6 +1,7 @@
 #include <errno.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <unistd.h>
 
 #include "uftrace.h"
 #include "utils/socket.h"


### PR DESCRIPTION
This patch adds explicit include to fix the following warnings.
```
  utils/socket.c:12:6: warning: implicit declaration of function ‘unlink’ [-Wimplicit-function-declaration]
     12 |  if (unlink(addr->sun_path) == -1) {
        |      ^~~~~~

  utils/socket.c:43:3: warning: implicit declaration of function ‘close’; did you mean ‘pclose’? [-Wimplicit-function-declaration]
     43 |   close(fd);
        |   ^~~~~
        |   pclose
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>