### PR TITLE
mcount: Fix segfault in Asahi Linux on Apple M1

### DIFF
--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -322,7 +322,8 @@ static int hook_pltgot(const char *modname, unsigned long offset)
 		ret = find_got(&elf, &iter, modname, offset);
 
 		if (relro)
-			mprotect((void *)relro_start, relro_size, PROT_READ);
+			if (relro_size <= 0x1000)
+				mprotect((void *)relro_start, relro_size, PROT_READ);
 	}
 
 	elf_finish(&elf);


### PR DESCRIPTION
Hi.

This PR fix #1581, segfault on Asahi Linux, the Linux for Apple M1 Silicon.
I look into target binary to gdb, and found some weird thing.
```gdb
0x00aaaaaaaa0000 0x00aaaaaaaa4000 0x00000000000000 r-x /home/kyuwoncho18/test
0x00aaaaaaab0000 0x00aaaaaaab4000 0x00000000000000 rw- /home/kyuwoncho18/test
0x00aaaaaaab4000 0x00aaaaaaad8000 0x00000000000000 rw- [heap]
0x00fffff7dd0000 0x00fffff7f60000 0x00000000000000 r-x /usr/lib/libc.so.6
0x00fffff7f60000 0x00fffff7f70000 0x00000000190000 --- /usr/lib/libc.so.6
0x00fffff7f70000 0x00fffff7f74000 0x00000000190000 r-- /usr/lib/libc.so.6
0x00fffff7f74000 0x00fffff7f78000 0x00000000194000 rw- /usr/lib/libc.so.6
0x00fffff7f78000 0x00fffff7f84000 0x00000000000000 rw-
0x00fffff7fc0000 0x00fffff7fec000 0x00000000000000 r-x /usr/lib/ld-linux-aarch64.so.1
0x00fffff7fec000 0x00fffff7ff4000 0x00000000000000 r-- [vvar]
0x00fffff7ff4000 0x00fffff7ff8000 0x00000000000000 r-x [vdso]
0x00fffff7ff8000 0x00fffff7ffc000 0x00000000028000 r-- /usr/lib/ld-linux-aarch64.so.1
0x00fffff7ffc000 0x00fffff8000000 0x0000000002c000 rw- /usr/lib/ld-linux-aarch64.so.1
0x00fffffffdc000 0x01000000000000 0x00000000000000 rw- [stack]
```
This is the ``vmmap`` result for the normal binary. Even partial RELRO is enabled, there is no additional page for the plt or got.

With uftrace, this ``vmmap`` becomes as follow:
```gdb
0x00aaaaaaaa0000 0x00aaaaaaaa4000 0x00000000000000 r-x /home/kyuwoncho18/test
0x00aaaaaaab0000 0x00aaaaaaab4000 0x00000000000000 r-- /home/kyuwoncho18/test
0x00aaaaaaab4000 0x00aaaaaab00000 0x00000000000000 rw- [heap]
0x00fffff7130000 0x00fffff7150000 0x00000000000000 rw- /dev/shm/uftrace-25b8c744867b023b-1731681-001
0x00fffff7150000 0x00fffff7160000 0x00000000000000 r-x /usr/lib/libbz2.so.1.0.8
0x00fffff7160000 0x00fffff716c000 0x00000000010000 --- /usr/lib/libbz2.so.1.0.8
0x00fffff716c000 0x00fffff7170000 0x0000000000c000 r-- /usr/lib/libbz2.so.1.0.8
...
```
As you can see, the permission of the second page (``0x00aaaaaaab0000``) has been changed.
It's because the Asahi Linux's loader puts every data on a single page, but the pltgot hooker doesn't know this kind of context.

So I add when the page size is 0x4000, pass the page permission recovery because it's not really ***recovery***:

EDIT: I change the check routine because it seems that RELRO dosen't work for the system that has bigger page size than 4k.

```patch
if (relro) {
+	if (relro_size <= 0x1000)
		mprotect((void *)relro_start, relro_size, PROT_READ);
}
```

However, the check routine is so naive, but I can't find any Asahi-Linux-specific flags, so I just use the page size.