### PR TITLE
Draft port to Android platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,12 @@ COMMON_CFLAGS := -D_GNU_SOURCE $(CFLAGS) $(CPPFLAGS)
 COMMON_CFLAGS += -iquote $(srcdir) -iquote $(objdir) -iquote $(srcdir)/arch/$(ARCH)
 COMMON_CFLAGS += -Wdeclaration-after-statement
 #CFLAGS-DEBUG = -g -D_GNU_SOURCE $(CFLAGS_$@)
-COMMON_LDFLAGS := -lrt -ldl -pthread -Wl,-z,noexecstack $(LDFLAGS)
+COMMON_LDFLAGS := -ldl -pthread -Wl,-z,noexecstack $(LDFLAGS)
+ifeq ($(ANDROID),)
+COMMON_LDFLAGS += -lrt
+else
+COMMON_LDFLAGS += -landroid
+endif
 ifneq ($(elfdir),)
   COMMON_CFLAGS  += -I$(elfdir)/include
   COMMON_LDFLAGS += -L$(elfdir)/lib

--- a/check-deps/Makefile.check
+++ b/check-deps/Makefile.check
@@ -15,7 +15,7 @@ ifneq ($(wildcard $(objdir)/check-deps/cc_has_mno_sse2),)
   LIB_CFLAGS += -mno-sse2
 endif
 
-ifneq ($(wildcard $(srcdir)/check-deps/have_libpython3),)
+ifneq ($(wildcard $(objdir)/check-deps/have_libpython3),)
   # libpython3 provides an embed version of pkg-config file since python3.8
   ifeq ($(shell pkg-config python3-embed --exists 2> /dev/null; echo $$?), 0)
     EMBED := -embed
@@ -23,7 +23,7 @@ ifneq ($(wildcard $(srcdir)/check-deps/have_libpython3),)
   COMMON_CFLAGS += -DHAVE_LIBPYTHON3
   COMMON_CFLAGS += $(shell pkg-config python3$(EMBED) --cflags)
   COMMON_CFLAGS += -DLIBPYTHON_VERSION=$(shell pkg-config python3$(EMBED) --modversion)
-else ifneq ($(wildcard $(srcdir)/check-deps/have_libpython2.7),)
+else ifneq ($(wildcard $(objdir)/check-deps/have_libpython2.7),)
   COMMON_CFLAGS += -DHAVE_LIBPYTHON2
   COMMON_CFLAGS += -I/usr/include/python2.7
   COMMON_CFLAGS += -DLIBPYTHON_VERSION="2.7"

--- a/configure
+++ b/configure
@@ -151,6 +151,10 @@ fi
 CC=${CC:-${CROSS_COMPILE}gcc}
 LD=${LD:-${CROSS_COMPILE}ld}
 
+if $CC --version | grep -q Android; then
+    ANDROID=1
+fi
+
 # objdir can be changed, reset output
 objdir=$(readlink -f ${objdir})
 output=${output:-${objdir}/.config}
@@ -282,6 +286,7 @@ override CC     := $CC
 override LD     := $LD
 override CFLAGS  = $CFLAGS
 override LDFLAGS = $LDFLAGS
+override ANDROID = $ANDROID
 
 override srcdir := $srcdir
 override objdir := $objdir

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -300,6 +300,7 @@ static int find_dynamic_module(struct dl_phdr_info *info, size_t sz, void *data)
 	struct find_module_data *fmd = data;
 	struct uftrace_sym_info *sym_info = fmd->sinfo;
 	struct uftrace_mmap *map;
+	int is_executable = mcount_is_main_executable(info->dlpi_name, sym_info->filename);
 
 	mdi = create_mdi(info);
 
@@ -315,7 +316,7 @@ static int find_dynamic_module(struct dl_phdr_info *info, size_t sz, void *data)
 		free(mdi);
 	}
 
-	return !fmd->needs_modules;
+	return !fmd->needs_modules && is_executable;
 }
 
 static void prepare_dynamic_update(struct uftrace_sym_info *sinfo, bool needs_modules)

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -65,6 +65,7 @@ struct mcount_shmem {
 	int nr_buf;
 	int max_buf;
 	bool done;
+	int *fds;
 	struct mcount_shmem_buffer **buffer;
 };
 
@@ -428,5 +429,7 @@ void mcount_hook_functions(void);
 int read_pmu_event(struct mcount_thread_data *mtdp, enum uftrace_event_id id, void *buf);
 void release_pmu_event(struct mcount_thread_data *mtdp, enum uftrace_event_id id);
 void finish_pmu_event(struct mcount_thread_data *mtdp);
+
+int mcount_is_main_executable(const char *filename, const char *exename);
 
 #endif /* UFTRACE_MCOUNT_INTERNAL_H */

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -481,6 +481,11 @@ static int setup_mod_plthook_data(struct dl_phdr_info *info, size_t sz, void *ar
 		"ld-linux-*.so.*",
 		"libdl.so.2",
 		"libdl-2.*.so",
+#ifdef __ANDROID__
+		"linker64",
+		"libc.so",
+		"libm.so",
+#endif
 	};
 	size_t k;
 	static bool exe_once = true;
@@ -511,7 +516,8 @@ static int setup_exe_plthook_data(struct dl_phdr_info *info, size_t sz, void *ar
 	const char *exename = arg;
 	unsigned long offset = info->dlpi_addr;
 
-	pr_dbg2("setup plthook data for %s (offset: %lx)\n", exename, offset);
+	if (!mcount_is_main_executable(info->dlpi_name, exename))
+		return 0;
 
 	hook_pltgot(exename, offset);
 	return 1;

--- a/utils/symbol-rawelf.h
+++ b/utils/symbol-rawelf.h
@@ -31,8 +31,12 @@ typedef ElfT(Rela) Elf_Rela;
 #define ELF_M1(N, ACT) ELF_MACRO(N, ACT)
 #define ELF_MACRO(N, ACT) ELF##N##_##ACT
 
+#ifndef ELF_ST_BIND
 #define ELF_ST_BIND(v) ELF_M(ST_BIND)(v)
+#endif
+#ifndef ELF_ST_TYPE
 #define ELF_ST_TYPE(v) ELF_M(ST_TYPE)(v)
+#endif
 #define ELF_R_SYM(i) ELF_M(R_SYM)(i)
 #define ELF_R_TYPE(i) ELF_M(R_TYPE)(i)
 

--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -824,6 +824,10 @@ enum uftrace_trace_type check_trace_functions(const char *filename)
 
 		/* undefined function is ok here */
 		if (elf_symbol_type(&iter.sym) != STT_FUNC &&
+#ifdef __ANDROID__
+		    // Profiling functions are undefined on Android
+		    elf_symbol_type(&iter.sym) != STT_NOTYPE &&
+#endif
 		    elf_symbol_type(&iter.sym) != STT_GNU_IFUNC)
 			continue;
 


### PR DESCRIPTION
This is an initial take on porting uftrace to Android platform. It works for simple command-line tools in adb shell but please consider it as a base for discussion rather than a complete PR.

Currently patch contains too many ifdefs which is caused by the fact that Android and Linux use different shmem APIs (Ashmem+`sendmsg`/`recvmsg` VS SysV shmem respectively). To get rid of this we could
- unify Android and Linux by switching to `memfd_create`+`sendmsg`/`recvmsg` on Linux instead
- re-implement SysV shmem APIs (`shm_open`, etc.) on top of Ashmem