### PR TITLE
uftrace: Port to Android x86_64/AArch64.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -168,6 +168,22 @@ This assumes you already installed the cross-built `libelf` on the sysroot
 directory.  Otherwise, you can also build it from source (please see below) or
 use it on a different path using `--with-elfutils=<PATH>`.
 
+To compile for Android 9+, export the CC environment variable and disable the not
+yet implemented python and libstdc++ support. E.g. to configure for Android
+AArch64 do
+
+    $ export CC=$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android33-clang
+    $ export LD=$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/ld.lld
+    $ ./configure --arch=aarch64 --cross-compile=aarch64-linux-gnu- --without-libpython --without-libstdc++
+
+It's recommended to compile instrumented program with
+`-fpatchable-function-entry` on Android. You could also use
+`-finstrument-functions` or `-pg` but in that case you also need to link program
+with `-Wl,-z,undefs` because Android runtime does not include
+`__cyg_profile_func_enter` or `mcount`.
+
+Note that Android has been tested on AArch64 and x86\_64 so far.
+
 
 BUILD WITH ELFUTILS (libelf)
 ============================

--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,7 @@ LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/script.c $(srcdir)/utils/script-python.c
 LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/auto-args.c $(srcdir)/utils/dwarf.c
 LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/hashmap.c $(srcdir)/utils/argspec.c
 LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/tracefs.c $(srcdir)/utils/socket.c
+LIBMCOUNT_UTILS_SRCS += $(srcdir)/utils/shmem.c
 LIBMCOUNT_UTILS_SRCS += $(wildcard $(srcdir)/utils/symbol*.c)
 LIBMCOUNT_UTILS_OBJS := $(patsubst $(srcdir)/utils/%.c,$(objdir)/libmcount/%.op,$(LIBMCOUNT_UTILS_SRCS))
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,12 @@ COMMON_CFLAGS := -D_GNU_SOURCE $(CFLAGS) $(CPPFLAGS)
 COMMON_CFLAGS += -iquote $(srcdir) -iquote $(objdir) -iquote $(srcdir)/arch/$(ARCH)
 COMMON_CFLAGS += -Wdeclaration-after-statement
 #CFLAGS-DEBUG = -g -D_GNU_SOURCE $(CFLAGS_$@)
-COMMON_LDFLAGS := -lrt -ldl -pthread -Wl,-z,noexecstack $(LDFLAGS)
+COMMON_LDFLAGS := -ldl -pthread -Wl,-z,noexecstack $(LDFLAGS)
+ifeq ($(ANDROID),)
+COMMON_LDFLAGS += -lrt
+else
+COMMON_LDFLAGS += -landroid
+endif
 ifneq ($(elfdir),)
   COMMON_CFLAGS  += -I$(elfdir)/include
   COMMON_LDFLAGS += -L$(elfdir)/lib

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ now.
 
 Limitations
 ===========
-- It can trace a native C/C++ application on Linux.
+- It can trace a native C/C++ application on Linux and Android.
 - It *cannot* trace already running process.
 - It *cannot* be used for system-wide tracing.
 - It supports x86 (32 and 64 bit), ARM (v6 or later) and AArch64 for now.

--- a/cmds/live.c
+++ b/cmds/live.c
@@ -252,7 +252,7 @@ int command_live(int argc, char *argv[], struct uftrace_opts *opts)
 			/* can't reuse first template because it was trashed by mkstemp */
 			strcpy(template, LIVE_NAME);
 
-			if (errno != EPERM)
+			if (errno != EPERM && errno != ENOENT)
 				pr_err("cannot access to /tmp");
 
 			fd = mkstemp(template);

--- a/cmds/record.c
+++ b/cmds/record.c
@@ -25,6 +25,7 @@
 #include "utils/kernel.h"
 #include "utils/list.h"
 #include "utils/perf.h"
+#include "utils/shmem.h"
 #include "utils/symbol.h"
 #include "utils/utils.h"
 
@@ -826,7 +827,7 @@ static void record_mmap_file(const char *dirname, char *sess_id, int bufsize)
 	struct mcount_shmem_buffer *shmem_buf;
 
 	/* write (append) it to disk */
-	fd = shm_open(sess_id, O_RDWR, 0600);
+	fd = uftrace_shmem_open(sess_id, O_RDWR, 0600);
 	if (fd < 0) {
 		pr_dbg("open shmem buffer failed: %s: %m\n", sess_id);
 		return;
@@ -935,12 +936,12 @@ static void unlink_shmem_list(void)
 		sscanf(sl->id, "/uftrace-%[^-]-%*d-%*d", shmem_session);
 		pr_dbg2("unlink for session: %s\n", shmem_session);
 
-		num = scandir("/dev/shm/", &shmem_bufs, filter_shmem, alphasort);
+		num = scandir(uftrace_shmem_root(), &shmem_bufs, filter_shmem, alphasort);
 		for (i = 0; i < num; i++) {
 			sid[0] = '/';
 			memcpy(&sid[1], shmem_bufs[i]->d_name, MSG_ID_SIZE);
 			pr_dbg3("unlink %s\n", sid);
-			shm_unlink(sid);
+			uftrace_shmem_unlink(sid);
 			free(shmem_bufs[i]);
 		}
 

--- a/configure
+++ b/configure
@@ -151,6 +151,10 @@ fi
 CC=${CC:-${CROSS_COMPILE}gcc}
 LD=${LD:-${CROSS_COMPILE}ld}
 
+if $CC --version | grep -q Android; then
+    ANDROID=1
+fi
+
 # objdir can be changed, reset output
 objdir=$(readlink -f ${objdir})
 output=${output:-${objdir}/.config}
@@ -282,6 +286,7 @@ override CC     := $CC
 override LD     := $LD
 override CFLAGS  = $CFLAGS
 override LDFLAGS = $LDFLAGS
+override ANDROID = $ANDROID
 
 override srcdir := $srcdir
 override objdir := $objdir

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -300,6 +300,7 @@ static int find_dynamic_module(struct dl_phdr_info *info, size_t sz, void *data)
 	struct find_module_data *fmd = data;
 	struct uftrace_sym_info *sym_info = fmd->sinfo;
 	struct uftrace_mmap *map;
+	bool is_executable = mcount_is_main_executable(info->dlpi_name, sym_info->filename);
 
 	mdi = create_mdi(info);
 
@@ -315,7 +316,7 @@ static int find_dynamic_module(struct dl_phdr_info *info, size_t sz, void *data)
 		free(mdi);
 	}
 
-	return !fmd->needs_modules;
+	return !fmd->needs_modules && is_executable;
 }
 
 static void prepare_dynamic_update(struct uftrace_sym_info *sinfo, bool needs_modules)

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -443,4 +443,6 @@ int read_pmu_event(struct mcount_thread_data *mtdp, enum uftrace_event_id id, vo
 void release_pmu_event(struct mcount_thread_data *mtdp, enum uftrace_event_id id);
 void finish_pmu_event(struct mcount_thread_data *mtdp);
 
+bool mcount_is_main_executable(const char *filename, const char *exename);
+
 #endif /* UFTRACE_MCOUNT_INTERNAL_H */

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -2147,6 +2147,21 @@ void __visible_default __cyg_profile_func_exit(void *child, void *parent)
 }
 UFTRACE_ALIAS(__cyg_profile_func_exit);
 
+bool mcount_is_main_executable(const char *filename, const char *exename)
+{
+	/* on Linux main executable has empty name
+	   whereas on Android we need to compare with exename */
+	char filename_canonized[PATH_MAX];
+	char exename_canonized[PATH_MAX];
+
+	if (!*filename)
+		return true;
+	if (realpath(filename, filename_canonized) && realpath(exename, exename_canonized)) {
+		return strcmp(filename_canonized, exename_canonized) == 0;
+	}
+	return false;
+}
+
 #ifndef UNIT_TEST
 /*
  * Initializer and Finalizer

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -481,6 +481,11 @@ static int setup_mod_plthook_data(struct dl_phdr_info *info, size_t sz, void *ar
 		"ld-linux-*.so.*",
 		"libdl.so.2",
 		"libdl-2.*.so",
+#ifdef __ANDROID__
+		"linker64",
+		"libc.so",
+		"libm.so",
+#endif
 	};
 	size_t k;
 	static bool exe_once = true;

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -511,6 +511,9 @@ static int setup_exe_plthook_data(struct dl_phdr_info *info, size_t sz, void *ar
 	const char *exename = arg;
 	unsigned long offset = info->dlpi_addr;
 
+	if (!mcount_is_main_executable(info->dlpi_name, exename))
+		return 0;
+
 	pr_dbg2("setup plthook data for %s (offset: %lx)\n", exename, offset);
 
 	hook_pltgot(exename, offset);

--- a/libmcount/record.c
+++ b/libmcount/record.c
@@ -17,6 +17,7 @@
 #include "mcount-arch.h"
 #include "utils/event.h"
 #include "utils/filter.h"
+#include "utils/shmem.h"
 #include "utils/symbol.h"
 #include "utils/utils.h"
 
@@ -33,7 +34,7 @@ static struct mcount_shmem_buffer *allocate_shmem_buffer(char *sess_id, size_t s
 
 	snprintf(sess_id, size, SHMEM_SESSION_FMT, mcount_session_name(), tid, idx);
 
-	fd = shm_open(sess_id, O_RDWR | O_CREAT | O_TRUNC, 0600);
+	fd = uftrace_shmem_open(sess_id, O_RDWR | O_CREAT | O_TRUNC, 0600);
 	if (fd < 0) {
 		saved_errno = errno;
 		pr_dbg("failed to open shmem buffer: %s\n", sess_id);

--- a/utils/shmem.c
+++ b/utils/shmem.c
@@ -1,0 +1,96 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "utils/shmem.h"
+
+#ifdef __ANDROID__
+
+const char *uftrace_shmem_root(void)
+{
+	static char uftrace_dir[PATH_MAX] = "";
+
+	if (uftrace_dir[0] == 0) {
+		const char *tmpdir;
+		tmpdir = getenv("TMPDIR");
+		if (!tmpdir)
+			tmpdir = "/tmp";
+
+		snprintf(uftrace_dir, sizeof(uftrace_dir), "%s/uftrace", tmpdir);
+	}
+
+	return uftrace_dir;
+}
+
+int uftrace_shmem_open(const char *name, int oflag, mode_t mode)
+{
+	const char *uftrace_dir;
+	char *fname;
+	int fd;
+	int status;
+
+	uftrace_dir = uftrace_shmem_root();
+
+	status = mkdir(uftrace_dir, mode);
+	if (status < 0 && errno != EEXIST)
+		return -1;
+
+	if (asprintf(&fname, "%s/%s", uftrace_dir, name) < 0)
+		return -1;
+
+	fd = open(fname, oflag, mode);
+	if (fd >= 0) {
+		int flags = fcntl(fd, F_GETFD, 0);
+		flags |= FD_CLOEXEC;
+		if (fcntl(fd, F_SETFD, flags) < 0) {
+			int saved_errno = errno;
+			close(fd);
+			fd = -1;
+			errno = saved_errno;
+		}
+	}
+
+	free(fname);
+
+	return fd;
+}
+
+int uftrace_shmem_unlink(const char *name)
+{
+	const char *uftrace_dir;
+	char *fname;
+	int status;
+
+	uftrace_dir = uftrace_shmem_root();
+
+	if (asprintf(&fname, "%s/%s", uftrace_dir, name))
+		return -1;
+	status = unlink(fname);
+	free(fname);
+
+	return status;
+}
+
+#else /* ! __ANDROID__ */
+
+#include <sys/mman.h>
+
+const char *uftrace_shmem_root(void)
+{
+	return "/dev/shm";
+}
+
+int uftrace_shmem_open(const char *name, int oflag, mode_t mode)
+{
+	return shm_open(name, oflag, mode);
+}
+
+int uftrace_shmem_unlink(const char *name)
+{
+	return shm_unlink(name);
+}
+
+#endif

--- a/utils/shmem.h
+++ b/utils/shmem.h
@@ -1,0 +1,8 @@
+#ifndef UFTRACE_SHMEM_H
+#define UFTRACE_SHMEM_H
+
+int uftrace_shmem_open(const char *name, int oflag, mode_t mode);
+int uftrace_shmem_unlink(const char *name);
+const char *uftrace_shmem_root(void);
+
+#endif /* UFTRACE_SHMEM_H */

--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -825,6 +825,10 @@ enum uftrace_trace_type check_trace_functions(const char *filename)
 
 		/* undefined function is ok here */
 		if (elf_symbol_type(&iter.sym) != STT_FUNC &&
+#ifdef __ANDROID__
+		    // Profiling functions are undefined on Android
+		    elf_symbol_type(&iter.sym) != STT_NOTYPE &&
+#endif
 		    elf_symbol_type(&iter.sym) != STT_GNU_IFUNC)
 			continue;
 


### PR DESCRIPTION
This is an updated port of uftrace to Android platform. I have got rid of dedicated Ashmem-based code and instead followed the [termux approach](https://github.com/termux/termux-packages/blob/master/packages/uftrace/cmds-record.c.patch) which mimics the `shm_open`/`shm_unlink` APIs using temporary files.

With these changes uftrace works for simple command-line tools in x86_64/AArch64 adb shell (compiled with `-fpatchable-function-entry=5`/`=2` respectively), both on emulator and on real device.