### PR TITLE
tests: Add -q/--quiet option for runtests.py and nightly test

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -27,4 +27,4 @@ jobs:
           sudo sh -c "chmod +x /sys/kernel/tracing"
 
       - name: "run tests"
-        run: make test -j1 RUNTESTARG='--color on'
+        run: make test -j1 RUNTESTARG='--quiet --color on'

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -769,8 +769,6 @@ def print_test_result(case, result, diffs, color, ftests, nr_compilers):
         output += ' '.join(result_list[begin:end])
     output += '\n'
 
-    sys.stdout.write(output)
-
     # write abnormal test result to failed-tests.txt
     normal = [TestBase.TEST_SUCCESS, TestBase.TEST_SUCCESS_FIXED, TestBase.TEST_SKIP]
     for r in result:
@@ -778,6 +776,14 @@ def print_test_result(case, result, diffs, color, ftests, nr_compilers):
             ftests.write(output)
             ftests.flush()
             break
+
+    if arg.quiet:
+        for r in result:
+            if r not in normal:
+                sys.stdout.write(output)
+                break
+    else:
+        sys.stdout.write(output)
 
 
 def print_test_header(opts, flags, ftests, compilers):
@@ -852,6 +858,8 @@ def parse_argument():
                         help="Select compiler gcc or clang. (use both by default)")
     parser.add_argument("-k", "--keep", dest='keep', action='store_true',
                         help="keep the test directories with compiled binaries")
+    parser.add_argument("-q", "--quiet", dest='quiet', action='store_true',
+                        help="Hide normal results and print only abnormal results.")
 
     return parser.parse_args()
 


### PR DESCRIPTION
Since test result is getting bigger, option for printing only abnormal result can be useful at this point.

So this commit adds -q, --quiet for runtests.py,
which can be used as follows:

```
$ ./runtest.py -q
Start 272 tests with 56 worker
Compiler                  gcc                            clang
Test case                 pg             finstrument-fu  pg             finstrument-fu
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os  O0 O1 O2 O3 Os O0 O1 O2 O3 Os
015 longjmp             : OK OK OK OK OK OK OK OK OK OK  OK NG NG NG NG OK OK OK OK OK
062 arg_char            : OK OK OK OK OK SK SK SK SK SK  OK NG NG NG NG SK SK SK SK SK
082 arg_many            : OK OK OK OK OK SK SK SK SK SK  NG OK OK OK OK SK SK SK SK SK
084 arg_mixed           : OK OK OK OK OK SK SK SK SK SK  OK NG NG NG NG SK SK SK SK SK
085 arg_reg             : OK OK OK OK OK SK SK SK SK SK  OK NG NG NG NG SK SK SK SK SK
087 arg_variadic        : OK OK OK OK OK SK SK SK SK SK  NG OK OK OK OK SK SK SK SK SK
...
```

Also, this option can be applied in nightly test.

Closes: #1565

Signed-off-by: Kang Minchul <tegongkang@gmail.com>