### PR TITLE
bench: Fix multiple problems and issues in bench

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ LIBMCOUNT_TARGETS += libmcount/libmcount-single.so libmcount/libmcount-fast-sing
 
 _TARGETS := uftrace libtraceevent/libtraceevent.a
 _TARGETS += $(LIBMCOUNT_TARGETS) libmcount/libmcount-nop.so
-_TARGETS += misc/demangler misc/symbols misc/dbginfo misc/bench
+_TARGETS += misc/demangler misc/symbols misc/dbginfo
 TARGETS  := $(patsubst %,$(objdir)/%,$(_TARGETS))
 
 UFTRACE_SRCS := $(srcdir)/uftrace.c $(wildcard $(srcdir)/cmds/*.c $(srcdir)/utils/*.c)
@@ -380,7 +380,7 @@ unittest: all
 runtest: all
 	@$(MAKE) -C $(srcdir)/tests TESTARG="$(TESTARG)" RUNTESTARG="$(RUNTESTARG)" test_run
 
-bench: all
+bench: all $(objdir)/misc/bench
 	@cd $(srcdir)/misc && echo && ./bench.sh $(BENCHARG)
 
 dist:

--- a/misc/bench.c
+++ b/misc/bench.c
@@ -6,7 +6,7 @@ int foo(volatile int *ptr)
 	return *ptr;
 }
 
-int baz(volatile int *ptr)
+void baz(volatile int *ptr)
 {
 	*ptr += 1;
 }

--- a/misc/bench.sh
+++ b/misc/bench.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 UFTRACE="../uftrace --libmcount-path=../libmcount"
 UOPTS=


### PR DESCRIPTION
There are multiple issues in bench compilation as follows.

First, the baz does not return a value although its return type is int so set it to void.
```
  uftrace/misc/bench.c:12:1: warning: non-void function does not return a value [-Wreturn-type]
```
Second, the bench.sh script uses bash syntax, but its shebang is /bin/sh so it makes the following error in some environments.
```
  $ make bench
      ...
  ./bench.sh: 11: Syntax error: "(" unexpected
  make: *** [Makefile:390: bench] Error 2
```
Lastly, the bench executable requires it to be compiled with -pg, but android build doesn't support -pg build so it shows the following error.
```
  clang-14: warning: argument unused during compilation: '-pg' [-Wunused-command-line-argument]
  ld: error: undefined symbol: _mcount
```
It seems there is no reason to build bench image in default build, so it'd be better to opt it out and build it only in 'make bench'.

This patch fixes all the problems and issues above.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>