### PR TITLE
misc: Check ID_LIKE along with ID in /etc/os-release

### DIFF
--- a/misc/install-deps.sh
+++ b/misc/install-deps.sh
@@ -1,5 +1,41 @@
 #!/bin/sh
 
+install_packages() {
+    case $1 in
+        "ubuntu" | "debian")
+            apt-get install $OPT pandoc libdw-dev python3-dev libncursesw5-dev pkg-config
+            apt-get install $OPT libluajit-5.1-dev || true
+            apt-get install $OPT libcapstone-dev || true
+            exit
+            ;;
+        "fedora")
+            dnf install $OPT pandoc elfutils-devel python3-devel ncurses-devel pkgconf-pkg-config
+            dnf install $OPT luajit-devel || true
+            dnf install $OPT capstone-devel || true
+            exit
+            ;;
+        "rhel" | "centos")
+            rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+            yum install $OPT pandoc elfutils-devel python3-devel ncurses-devel pkgconfig
+            yum install $OPT luajit-devel || true
+            yum install $OPT capstone-devel || true
+            exit
+            ;;
+        "arch" | "manjaro")
+            pacman $OPT -S pandoc libelf python3 ncurses pkgconf
+            pacman $OPT -S luajit || true
+            pacman $OPT -S capstone || true
+            exit
+            ;;
+        "alpine")
+            apk add $OPT elfutils-dev python3-dev ncurses-dev pkgconf
+            apk add $OPT luajit-dev || true
+            apk add $OPT capstone-dev || true
+            exit
+            ;;
+    esac
+}
+
 if [ "x$(id -u)" != x0 ]; then
     echo "You might have to run it as root user."
     echo "Please run it again with 'sudo'."
@@ -16,30 +52,13 @@ if [ ! -f /etc/os-release ]; then
 fi
 
 distro=$(grep "^ID=" /etc/os-release | cut -d\= -f2 | sed -e 's/"//g')
+id_like=$(grep "^ID_LIKE=" /etc/os-release | cut -d\= -f2 | sed -e 's/"//g')
 
-case $distro in
-    "ubuntu" | "debian" | "raspbian" | "kali" | "linuxmint")
-        apt-get $OPT install pandoc libdw-dev python3-dev libncursesw5-dev pkg-config
-        apt-get $OPT install libluajit-5.1-dev || true
-        apt-get $OPT install libcapstone-dev || true ;;
-    "fedora")
-        dnf install $OPT pandoc elfutils-devel python3-devel ncurses-devel pkgconf-pkg-config
-        dnf install $OPT luajit-devel || true
-        dnf install $OPT capstone-devel || true ;;
-    "rhel" | "centos")
-        rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-        yum install $OPT pandoc elfutils-devel python3-devel ncurses-devel pkgconfig
-        yum install $OPT luajit-devel || true
-        yum install $OPT capstone-devel || true ;;
-    "arch" | "manjaro")
-        pacman $OPT -S pandoc libelf python3 ncurses pkgconf
-        pacman $OPT -S luajit || true
-        pacman $OPT -S capstone || true ;;
-    "alpine")
-        apk $OPT add elfutils-dev python3-dev ncurses-dev pkgconf
-        apk $OPT add luajit-dev || true
-        apk $OPT add capstone-dev || true ;;
-    *) # we can add more install command for each distros.
-        echo "\"$distro\" is not supported distro, so please install packages manually."
-        echo ;;
-esac
+install_packages "$distro"
+
+for distro_like in $id_like; do
+    install_packages "$distro_like"
+done
+
+echo "\"$distro\" is not supported distro, so please install packages manually."
+echo


### PR DESCRIPTION
Since ID in /etc/os-release cannot contain distribution in /misc/install-deps.sh,

/etc/os-release can also have ID_LIKE,
which can contain distribution in /misc/install-deps.sh like below:

```
  $ cat /etc/os-release
  NAME="Amazon Linux"
  VERSION="2"
  ID="amzn"
  ID_LIKE="centos rhel fedora"
  VERSION_ID="2"
  PRETTY_NAME="Amazon Linux 2"
  ANSI_COLOR="0;33"
  CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
  HOME_URL="https://amazonlinux.com/"
```

So this commit adds parsing logic in /misc/install-deps.sh to check ID first, and ID_LIKE also.

Closes: #1468

Signed-off-by: Kang Minchul <tegongkang@gmail.com>