### PR TITLE
Enable testing of -fpatchable-function-entry instrumentation.

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -154,6 +154,10 @@ class TestBase:
         cmd[src_idx] = abs_src
         return " ".join(cmd)
 
+    def strip_tracing_flags(self, cmd):
+        cmd = cmd.replace('-pg', '').replace('-finstrument-functions', '')
+        return cmd
+
     def build_it(self, build_cmd):
         build_cmd = self.convert_abs_path(build_cmd)
 
@@ -202,7 +206,7 @@ class TestBase:
         build_cmd = '%s -o lib%s.so %s s-%s.c %s' % \
                     (lang['cc'], dstname, lib_cflags, srcname, build_ldflags)
 
-        build_cmd = build_cmd.replace('-pg', '').replace('-finstrument-functions', '')
+        build_cmd = self.strip_tracing_flags(build_cmd)
         self.pr_debug("build command for library: %s" % build_cmd)
         return self.build_it(build_cmd)
 
@@ -256,7 +260,7 @@ class TestBase:
 
         build_cmd = '%s -o %s %s %s %s' % (lang['cc'], prog, build_cflags, srcname, exe_ldflags)
         if not instrument:
-            build_cmd = build_cmd.replace('-pg', '').replace('-finstrument-functions', '')
+            build_cmd = self.strip_tracing_flags(build_cmd)
 
         self.pr_debug("build command for executable: %s" % build_cmd)
         return self.build_it(build_cmd)

--- a/tests/t117_time_range.py
+++ b/tests/t117_time_range.py
@@ -32,7 +32,10 @@ class TestCase(TestBase):
 
         p = sp.Popen(replay_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
         r = p.communicate()[0].decode(errors='ignore')
-        START = r.split('\n')[4].split()[0] # skip header, main, a and b (= 4)
+        lines = r.split('\n')
+        if len(lines) < 5:
+            return TestBase.TEST_DIFF_RESULT
+        START = lines[4].split()[0] # skip header, main, a and b (= 4)
         p.wait()
 
         return TestBase.TEST_SUCCESS

--- a/tests/t122_time_range2.py
+++ b/tests/t122_time_range2.py
@@ -34,7 +34,10 @@ class TestCase(TestBase):
 
         p = sp.Popen(replay_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
         r = p.communicate()[0].decode(errors='ignore')
-        START, unit = r.split('\n')[4].split()[0:2] # skip header, main, a and b (= 4)
+        lines = r.split('\n')
+        if len(lines) < 5:
+            return TestBase.TEST_DIFF_RESULT
+        START, unit = lines[4].split()[0:2] # skip header, main, a and b (= 4)
         START += unit
         p.wait()
 

--- a/tests/t125_report_range.py
+++ b/tests/t125_report_range.py
@@ -34,7 +34,10 @@ class TestCase(TestBase):
 
         p = sp.Popen(replay_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
         r = p.communicate()[0].decode(errors='ignore')
-        START = r.split('\n')[6].split()[0] # skip header, main, a, b, c and getpid (= 6)
+        lines = r.split('\n')
+        if len(lines) < 7:
+            return TestBase.TEST_DIFF_RESULT
+        START = lines[6].split()[0] # skip header, main, a, b, c and getpid (= 6)
         p.wait()
 
         return TestBase.TEST_SUCCESS

--- a/tests/t135_trigger_time2.py
+++ b/tests/t135_trigger_time2.py
@@ -42,7 +42,10 @@ class TestCase(TestBase):
 
         p = sp.Popen(replay_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
         r = p.communicate()[0].decode(errors='ignore')
-        TIME, UNIT = r.split('\n')[1].split()[0:2] # skip header
+        lines = r.split('\n')
+        if len(lines) < 2:
+            return TestBase.TEST_DIFF_RESULT
+        TIME, UNIT = lines[1].split()[0:2] # skip header
         TIME = float(TIME) + 0.001 # for time filtering
         p.wait()
 

--- a/tests/t151_recv_runcmd.py
+++ b/tests/t151_recv_runcmd.py
@@ -37,6 +37,8 @@ class TestCase(TestBase):
         record_cmd  = [TestBase.uftrace_cmd, 'record']
         record_cmd += TestBase.default_opt.split()
         record_cmd += ['--host', 'localhost', '--port', str(self.port)]
+        if self.p_flag:
+            record_cmd += self.p_flag.split()
         record_cmd += ['t-' + self.name]
         self.pr_debug('prerun command: ' + ' '.join(record_cmd))
         sp.call(record_cmd)

--- a/tests/t222_external_data.py
+++ b/tests/t222_external_data.py
@@ -47,6 +47,8 @@ class TestCase(TestBase):
             # parse first line to get the timestamp
             t = l.split(' | ')[0].strip()
             point = t.find('.')
+            if point < 0:
+                return TestBase.TEST_DIFF_RESULT
             nsec = int(t[point+1:point+10])
 
             # add the external data right after the first line

--- a/tests/t223_dynamic_full.py
+++ b/tests/t223_dynamic_full.py
@@ -18,8 +18,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
+        cflags = self.strip_tracing_flags(cflags)
         cflags += ' -fno-pie -fno-plt'  # workaround of build failure
         return TestBase.build(self, name, cflags, ldflags)
 

--- a/tests/t225_dynamic_size.py
+++ b/tests/t225_dynamic_size.py
@@ -18,8 +18,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
+        cflags = self.strip_tracing_flags(cflags)
         cflags += ' -funroll-loops'
         return TestBase.build(self, name, cflags, ldflags)
 

--- a/tests/t233_dynamic_unpatch2.py
+++ b/tests/t233_dynamic_unpatch2.py
@@ -17,8 +17,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
+        cflags = self.strip_tracing_flags(cflags)
         cflags += ' -fno-pie -fno-plt'  # workaround of build failure
         return TestBase.build(self, name, cflags, ldflags)
 

--- a/tests/t248_dynamic_dlopen.py
+++ b/tests/t248_dynamic_dlopen.py
@@ -30,8 +30,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
+        cflags = self.strip_tracing_flags(cflags)
 
         if TestBase.build_libabc(self, cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL

--- a/tests/t263_patchable_dynamic.py
+++ b/tests/t263_patchable_dynamic.py
@@ -21,8 +21,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
+        cflags = self.strip_tracing_flags(cflags)
 
         # add patchable function entry option
         machine = TestBase.get_machine(self)

--- a/tests/t264_patchable_dynamic2.py
+++ b/tests/t264_patchable_dynamic2.py
@@ -19,8 +19,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
+        cflags = self.strip_tracing_flags(cflags)
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):

--- a/tests/t265_patchable_dynamic3.py
+++ b/tests/t265_patchable_dynamic3.py
@@ -17,8 +17,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
+        cflags = self.strip_tracing_flags(cflags)
         return TestBase.build(self, name, cflags, ldflags)
 
     def setup(self):

--- a/tests/t266_patchable_dynamic4.py
+++ b/tests/t266_patchable_dynamic4.py
@@ -21,8 +21,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
+        cflags = self.strip_tracing_flags(cflags)
 
         # add patchable function entry option
         machine = TestBase.get_machine(self)

--- a/tests/t267_patchable_dynamic5.py
+++ b/tests/t267_patchable_dynamic5.py
@@ -19,8 +19,7 @@ class TestCase(TestBase):
         return TestBase.TEST_SUCCESS
 
     def build(self, name, cflags='', ldflags=''):
-        cflags = cflags.replace('-pg', '')
-        cflags = cflags.replace('-finstrument-functions', '')
+        cflags = self.strip_tracing_flags(cflags)
         cflags += ' -Wl,--gc-sections'
         return TestBase.build(self, name, cflags, ldflags)
 

--- a/tests/t269_arg_no_args_replay.py
+++ b/tests/t269_arg_no_args_replay.py
@@ -29,8 +29,8 @@ class TestCase(TestBase):
         return TestBase.build(self, name, cflags, ldflags)
 
     def prerun(self, timeout):
-        record_cmd = '%s record -d %s -A ^str_@arg1/s,arg2/s -R ^str_@retval/s %s %s' \
-                        % (TestBase.uftrace_cmd, TDIR, TestBase.default_opt, 't-' + self.name)
+        record_cmd = '%s record -d %s %s -A ^str_@arg1/s,arg2/s -R ^str_@retval/s %s %s' \
+                        % (TestBase.uftrace_cmd, TDIR, TestBase.default_opt, self.p_flag, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t270_arg_no_args_dump.py
+++ b/tests/t270_arg_no_args_dump.py
@@ -44,8 +44,8 @@ reading 72944.dat
         return TestBase.build(self, name, cflags, ldflags)
 
     def prerun(self, timeout):
-        record_cmd = '%s record -d %s -A ^str_@arg1/s,arg2/s -R ^str_@retval/s %s %s' \
-                        % (TestBase.uftrace_cmd, TDIR, TestBase.default_opt, 't-' + self.name)
+        record_cmd = '%s record -d %s -A ^str_@arg1/s,arg2/s -R ^str_@retval/s %s %s %s' \
+                        % (TestBase.uftrace_cmd, TDIR, TestBase.default_opt, self.p_flag, 't-' + self.name)
         sp.call(record_cmd.split())
         return TestBase.TEST_SUCCESS
 

--- a/tests/t277_time_range3.py
+++ b/tests/t277_time_range3.py
@@ -44,10 +44,13 @@ task: 16676
 
         p = sp.Popen(replay_cmd, shell=True, stdout=sp.PIPE, stderr=sp.PIPE)
         r = p.communicate()[0].decode(errors='ignore')
-        END = r.split('\n')[4].split()[0] # skip header, main, foo and bar (= 4)
+        lines = r.split('\n')
+        if len(lines) < 7:
+            return TestBase.TEST_DIFF_RESULT
+        END = lines[4].split()[0] # skip header, main, foo and bar (= 4)
         p.wait()
 
-        TS1 = r.split('\n')[6].split()[0] # next, next line after usleep
+        TS1 = lines[6].split()[0] # next, next line after usleep
         f = open('uftrace.data/extern.dat', 'w')
         f.write("%s %s\n" % (TS1, 'external message'))
         f.close()


### PR DESCRIPTION
This PR adds testing configuration for `-fpatchable-function-entry` to `runtests.py`. It mostly fails on GCC due to #1613 but works well with clang (955 tests passed VS 1006 with `-pg`).