### PR TITLE
build: Add DEBUG=2 build option for macro debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ LIB_LDFLAGS        = $(COMMON_LDFLAGS) $(LDFLAGS_$@) $(LDFLAGS_lib) -Wl,--no-und
 TEST_LDFLAGS       = $(COMMON_LDFLAGS) -L$(objdir)/libtraceevent -ltraceevent
 
 ifeq ($(DEBUG), 1)
-  COMMON_CFLAGS += -O0 -g -DDEBUG_MODE=1
+  COMMON_CFLAGS += -O0 -g3 -DDEBUG_MODE=1
 else
   COMMON_CFLAGS += -O2 -g -DDEBUG_MODE=0
 endif


### PR DESCRIPTION
This patch adds a build option DEBUG=2 that enables '-gdwarf-2 -g3' and it allows gdb to understand C/C++ macros as follows.
```
  $ make DEBUG=2
      ...
  $ gdb -q -ex="b main" -ex="r" --args uftrace
  Reading symbols from uftrace...
  Breakpoint 1 at 0x10873: file /home/honggyu/work/uftrace/uftrace.c, line 1368.
  Starting program: /home/honggyu/work/uftrace/uftrace
  [Thread debugging using libthread_db enabled]
  Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

  Breakpoint 1, main (argc=1, argv=0x7fffffffdd38) at /home/honggyu/work/uftrace/uftrace.c:1368
  1368    {

  (gdb) info macro list_entry
  Defined at /home/honggyu/work/uftrace/utils/list.h:343
    included at /home/honggyu/work/uftrace/utils/argspec.h:4
    included at /home/honggyu/work/uftrace/utils/filter.h:9
    included at /home/honggyu/work/uftrace/uftrace.h:10
    included at /home/honggyu/work/uftrace/uftrace.c:33
  #define list_entry(ptr, type, member) container_of(ptr, type, member)

  (gdb) info macro container_of
  Defined at /home/honggyu/work/uftrace/utils/rbtree.h:33
    included at /home/honggyu/work/uftrace/utils/argspec.h:5
    included at /home/honggyu/work/uftrace/utils/filter.h:9
    included at /home/honggyu/work/uftrace/uftrace.h:10
    included at /home/honggyu/work/uftrace/uftrace.c:33
  #define container_of(ptr, type, member) ({ const typeof(((type *)0)->member) *__mptr = (ptr); (type *)((char *)__mptr - offsetof(type, member)); })
```
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>