### PR TITLE
Fix a build race related to utils/mermaid.html.cstr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,6 +304,8 @@ $(objdir)/misc/dbginfo.o: $(srcdir)/misc/dbginfo.c $(objdir)/version.h $(COMMON_
 $(objdir)/misc/bench.o: $(srcdir)/misc/bench.c
 	$(QUIET_CC)$(CC) $(BENCH_CFLAGS) -c -o $@ $<
 
+$(objdir)/cmds/dump.o: c-str-conversion
+
 $(UFTRACE_OBJS_VERSION): $(objdir)/version.h
 
 $(filter-out $(objdir)/uftrace.o, $(UFTRACE_OBJS)): $(objdir)/%.o: $(srcdir)/%.c $(COMMON_DEPS)


### PR DESCRIPTION
Sometimes build fails like below

| /home/pokybuild/yocto-worker/meta-oe/build/build/tmp/work/core2-64-poky-linux/uftrace/0.13-r0/git/cmds/dump.c: In function 'dump_mermaid_footer': | /home/pokybuild/yocto-worker/meta-oe/build/build/tmp/work/core2-64-poky-linux/uftrace/0.13-r0/git/cmds/dump.c:1347:10: fatal error: utils/mermaid.html.cstr: No such file or directory |  1347 | #include "utils/mermaid.html.cstr" /* This file is a converted of mermaid.html to one string literal in build-time */
|       |          ^~~~~~~~~~~~~~~~~~~~~~~~~
| compilation terminated.
| make[1]: *** [Makefile:310: /home/pokybuild/yocto-worker/meta-oe/build/build/tmp/work/core2-64-poky-linux/uftrace/0.13-r0/build/cmds/dump.o] Error 1

Create a dependency on c-str-conversion for dump.o

Signed-off-by: Khem Raj <raj.khem@gmail.com>