### PR TITLE
tests: Fix multiple issues in runtest.py

### DIFF
--- a/cmds/recv.c
+++ b/cmds/recv.c
@@ -46,7 +46,7 @@ static int server_socket(struct uftrace_opts *opts)
 		pr_warn("socket setting failed\n");
 
 	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0)
-		pr_err("socket bind failed");
+		pr_err("socket bind failed (port: %d)", opts->port);
 
 	if (listen(sock, 5) < 0)
 		pr_err("socket listen failed");
@@ -99,7 +99,7 @@ int setup_client_socket(struct uftrace_opts *opts)
 	addr.sin_addr = *(struct in_addr *)hostinfo->h_addr;
 
 	if (connect(sock, (const struct sockaddr *)&addr, sizeof(addr)) < 0)
-		pr_err("socket connect failed");
+		pr_err("socket connect failed (host: %s, port: %d)", opts->host, opts->port);
 
 	return sock;
 }

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -506,7 +506,7 @@ class TestBase:
             v = int(f.readline())
             f.close()
 
-            if v == 3:
+            if v >= 3:
                 return False
         except:
             pass

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -667,7 +667,9 @@ class TestBase:
                 f = open('result', 'w')
                 f.write(result_tested + '\n')
                 f.close()
-                dif = "%s: diff result of %s\n" % (name, cflags)
+
+                compiler = self.supported_lang['C']['cc']
+                dif = "%s: diff result of %s %s\n" % (name, compiler, cflags)
                 try:
                     p = sp.Popen(['colordiff', '-U1', 'expect', 'result'], stdout=sp.PIPE)
                 except:

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -854,7 +854,7 @@ def parse_argument():
                         help="profiling with -pg option")
     parser.add_argument("-i", "--instrument-functions", dest='if_flag', action='store_true',
                         help="profiling with -finstrument-functions option")
-    parser.add_argument("--patch-functions", dest='pfe_flag', action='store_true',
+    parser.add_argument("-e", "--patchable-function-entry", dest='pfe_flag', action='store_true',
                         help="profiling with -fpatchable-function-entry option")
     parser.add_argument("-d", "--diff", dest='diff', action='store_true',
                         help="show diff result if not matched")

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -297,8 +297,11 @@ class TestBase:
             for lib in self.p_libs:
                 self.p_flag += '-P .@%s ' % lib
 
+        if '-P' in self.option:
+            self.p_flag = ''
+
         return '%s %s %s %s %s %s' % (TestBase.uftrace_cmd, self.subcmd, \
-                                   TestBase.default_opt, self.option, self.p_flag, self.exearg)
+                                   TestBase.default_opt, self.p_flag, self.option, self.exearg)
 
     def task_sort(self, output, ignore_children=False):
         """ This function post-processes output of the test to be compared .

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -870,8 +870,8 @@ def parse_argument():
                         help="comma separated list of compiler profiling flags")
     parser.add_argument("-O", "--optimize-levels", dest='opts', default="0123s",
                         help="compiler optimization levels")
-    parser.add_argument("case", nargs='?', default="all",
-                        help="test case: 'all' or test number or (partial) name")
+    parser.add_argument("cases", nargs='?', default="all",
+                        help="test cases: 'all' or test number or (partial) name")
     parser.add_argument("-p", "--profile-pg", dest='pg_flag', action='store_true',
                         help="profiling with -pg option")
     parser.add_argument("-i", "--instrument-functions", dest='if_flag', action='store_true',
@@ -904,15 +904,18 @@ if __name__ == "__main__":
 
     arg = parse_argument()
 
-    if arg.case == 'all':
+    testcases = []
+    if arg.cases == 'all':
         testcases = glob.glob('t???_*.py')
     else:
         try:
-            testcases = glob.glob('t*' + arg.case + '*.py')
+            cases = arg.cases.split('|')
+            for case in cases:
+                testcases.extend(glob.glob('t*' + case + '*.py'))
             arg.worker = min(arg.worker, len(testcases))
         finally:
             if len(testcases) == 0:
-                print("cannot find testcase for : %s" % arg.case)
+                print("cannot find testcase for : %s" % arg.cases)
                 sys.exit(0)
 
     # Use multiprocessing pool if the number of workers is greater than 1.

--- a/tests/s-dwarf1.c
+++ b/tests/s-dwarf1.c
@@ -1,5 +1,9 @@
 #include <stdio.h>
 
+char *gs;
+char gc;
+double gd;
+
 enum xx {
 	ONE = 1,
 	TWO,
@@ -16,6 +20,9 @@ int foo(volatile int a, long b)
 
 float bar(char *s, char c, double d, void (*fp)(char *s))
 {
+	gs = s;
+	gc = c;
+	gd = d;
 	fp(NULL);
 	return -1.0;
 }

--- a/tests/s-dwarf5.c
+++ b/tests/s-dwarf5.c
@@ -1,6 +1,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+int gx;
+char *gy;
+
 struct int1 {
 	int a;
 };
@@ -37,46 +40,64 @@ struct mix3 {
 
 int pass_int1(struct int1 a, int x, char *y, double z)
 {
+	gx = x;
+	gy = y;
 	return (a.a == z) ? 0 : 1;
 }
 
 int pass_int3(struct int3 a, int x, char *y, double z)
 {
+	gx = x;
+	gy = y;
 	return (a.a + a.b + a.c) == z ? 0 : 1;
 }
 
 long pass_lng1(struct lng1 a, int x, char *y, double z)
 {
+	gx = x;
+	gy = y;
 	return (a.a == z) ? 0 : 1;
 }
 
 long pass_lng3(struct lng3 a, int x, char *y, double z)
 {
+	gx = x;
+	gy = y;
 	return (a.a + a.b + a.c) == z ? 0 : 1;
 }
 
 double pass_dbl1(struct dbl1 a, int x, char *y, double z)
 {
+	gx = x;
+	gy = y;
 	return (a.a == z) ? 0 : 1;
 }
 
 double pass_dbl3(struct dbl3 a, int x, char *y, double z)
 {
+	gx = x;
+	gy = y;
 	return (a.a + a.b + a.c) == z ? 0 : 1;
 }
 
 float pass_mix1(struct mix1 a, int x, char *y, double z)
 {
+	gx = x;
+	gy = y;
 	return (a.a + a.b == z) ? 0 : 1;
 }
 
 float pass_mix2(struct mix2 a, int x, char *y, double z)
 {
+	gx = x;
+	gy = y;
 	return (a.a + a.b + a.c) == z ? 0 : 1;
 }
 
 int pass_mix3(struct mix3 a, int x, char *y, double z)
 {
+	gx = x;
+	gy = y;
 	return (a.a + a.b + a.c + a.d) == z ? 0 : 1;
 }
 

--- a/tests/s-exp-char.c
+++ b/tests/s-exp-char.c
@@ -1,12 +1,24 @@
 #include <stdint.h>
 
-char foo(char a, unsigned char b, int8_t c)
+char ga;
+char gb;
+char gc;
+char gd;
+
+char foo(char a, char b, char c)
 {
+	ga = a;
+	gb = b;
+	gc = c;
 	return 'd';
 }
 
 char bar(char a, char b, char c, char d)
 {
+	ga = a;
+	gb = b;
+	gc = c;
+	gd = d;
 	return 0;
 }
 

--- a/tests/s-exp-mixed.c
+++ b/tests/s-exp-mixed.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 
+char *p;
+
 double mixed_add(int a, float b)
 {
 	return a + b;
@@ -24,6 +26,7 @@ char *mixed_str(char *a, double b)
 {
 	static char buf[32];
 
+	p = a;
 	if (b)
 		snprintf(buf, sizeof(buf), "%.2f", b);
 

--- a/tests/s-ucontext.c
+++ b/tests/s-ucontext.c
@@ -12,7 +12,7 @@ int bar(int c)
 	return c + getpid();
 }
 
-int baz(int c)
+int baz(volatile int c)
 {
 	return c % 2;
 }

--- a/tests/t147_event_sdt.py
+++ b/tests/t147_event_sdt.py
@@ -22,3 +22,8 @@ class TestCase(TestBase):
 
     def setup(self):
         self.option = '-E uftrace:* --match glob'
+
+    def runcmd(self):
+        cmd = TestBase.runcmd(self)
+        # change it to glob matching pattern
+        return cmd.replace('-P .', '-P "*"')

--- a/tests/t151_recv_runcmd.py
+++ b/tests/t151_recv_runcmd.py
@@ -32,7 +32,7 @@ class TestCase(TestBase):
         recv_cmd += ['-d', TDIR, '--port', str(self.port)]
         recv_cmd += ['--run-cmd', '%s %s' % (TestBase.uftrace_cmd, 'replay')]
         self.pr_debug('prerun command: ' + ' '.join(recv_cmd))
-        self.recv_p = sp.Popen(recv_cmd, stdout=self.file_p, stderr=self.file_p)
+        self.recv_p = sp.Popen(recv_cmd, stdout=sp.PIPE)
 
         record_cmd  = [TestBase.uftrace_cmd, 'record']
         record_cmd += TestBase.default_opt.split()
@@ -42,6 +42,11 @@ class TestCase(TestBase):
         record_cmd += ['t-' + self.name]
         self.pr_debug('prerun command: ' + ' '.join(record_cmd))
         sp.call(record_cmd)
+        self.recv_p.terminate()
+
+        out = self.recv_p.communicate()[0].decode(errors='ignore')
+        self.file_p.write(out)
+        self.file_p.close()
 
         return TestBase.TEST_SUCCESS
 
@@ -50,6 +55,4 @@ class TestCase(TestBase):
         return 'cat ' + TMPF
 
     def postrun(self, ret):
-        self.recv_p.terminate()
-        self.file_p.close()
         return ret

--- a/tests/t151_recv_runcmd.py
+++ b/tests/t151_recv_runcmd.py
@@ -32,7 +32,7 @@ class TestCase(TestBase):
         recv_cmd += ['-d', TDIR, '--port', str(self.port)]
         recv_cmd += ['--run-cmd', '%s %s' % (TestBase.uftrace_cmd, 'replay')]
         self.pr_debug('prerun command: ' + ' '.join(recv_cmd))
-        self.recv_p = sp.Popen(recv_cmd, stdout=sp.PIPE)
+        self.recv_p = sp.Popen(recv_cmd, stdout=sp.PIPE, stderr=sp.PIPE)
 
         record_cmd  = [TestBase.uftrace_cmd, 'record']
         record_cmd += TestBase.default_opt.split()
@@ -41,7 +41,7 @@ class TestCase(TestBase):
             record_cmd += self.p_flag.split()
         record_cmd += ['t-' + self.name]
         self.pr_debug('prerun command: ' + ' '.join(record_cmd))
-        sp.call(record_cmd)
+        sp.call(record_cmd, stderr=sp.PIPE)
         self.recv_p.terminate()
 
         out = self.recv_p.communicate()[0].decode(errors='ignore')

--- a/tests/t200_lib_dlopen2.py
+++ b/tests/t200_lib_dlopen2.py
@@ -34,3 +34,6 @@ class TestCase(TestBase):
 
     def setup(self):
         self.option = '-F a'
+
+    def fixup(self, cflags, result):
+        return result.replace('creat', 'creat64')

--- a/tests/t220_trace_script.py
+++ b/tests/t220_trace_script.py
@@ -34,3 +34,8 @@ class TestCase(TestBase):
     def setup(self):
         self.option = "--force -F fork -F main"
         self.exearg = TEST_SCRIPT
+
+    def fixup(self, cflags, result):
+        result = result.replace(' 133.697 us [28137] | fork();\n', '')
+        result = result.replace('            [28141] | } /* fork */\n', '')
+        return result


### PR DESCRIPTION
This PR fixes some tests with the following patches.
- d5c8653f tests: Fix broken -fpatchable-function-entry tests
- 3142999e tests: Rename --patch-functions option in runtest.py
- 7ea2051f tests: Fix check_perf_paranoid() routine
