### PR TITLE
libmcount: Turn off unexpected vectorization in libmcount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ BENCH_CFLAGS       = -D_GNU_SOURCE -g -pg $(CFLAGS_$@) $(CFLAGS_bench)
 TRACEEVENT_CFLAGS  = $(COMMON_CFLAGS) $(CFLAGS_$@) $(CFLAGS_traceevent)
 LIB_CFLAGS         = $(COMMON_CFLAGS) $(CFLAGS_$@) $(CFLAGS_lib)
 LIB_CFLAGS        += -fPIC -fvisibility=hidden -fno-omit-frame-pointer
+LIB_CFLAGS        += -fno-builtin -fno-tree-vectorize
 TEST_CFLAGS        = $(COMMON_CFLAGS) -DUNIT_TEST
 
 UFTRACE_LDFLAGS    = $(COMMON_LDFLAGS) $(LDFLAGS_$@) $(LDFLAGS_uftrace)


### PR DESCRIPTION
Sometimes compiler inserts some builtin functions such as memcpy, memmove even if the source code doesn't have them at all.

It's internally used because the compiler thinks that using those calls is faster when optimized.

However, this can overwrite vector registers such as xmm registers in x86 or VFP registers in arm and that makes uftrace record floating point arguments or return values incorrectly.

One of the example can be found as follows.
```diff
$ ./runtest.py -vdp -c gcc -O0 083
      ...
t083_arg_float: diff result of gcc -pg -O0
--- expect      2023-02-16 19:28:09.750616419 +0900
+++ result      2023-02-16 19:28:09.750616419 +0900
@@ -4,3 +4,3 @@
    float_mul(300.000000, 400.000000) = 120000.000000;
-   float_div(40000000000.000000, -0.020000) = -2000000000000.000000;
+   float_div(40000000000.000000, -0.020000) = 40000000000.000000;
  } /* main */

083 arg_float           : NG
```
To avoid this problem, libmcount should be compiled with '-fno-builtin' and '-fno-tree-vectorize' options.

The problem is fixed by having those options.

Fixed: #1631
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>