### PR TITLE
uftrace: Modify install location for uftrace libraries

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -116,7 +116,7 @@ directories or build directory with this script.
       --help                print this message
       --prefix=<DIR>        set install root dir as <DIR>        (default: /usr/local)
       --bindir=<DIR>        set executable install dir as <DIR>  (default: ${prefix}/bin)
-      --libdir=<DIR>        set library install dir as <DIR>     (default: ${prefix}/lib)
+      --libdir=<DIR>        set library install dir as <DIR>     (default: ${prefix}/lib/uftrace)
       --mandir=<DIR>        set manual doc install dir as <DIR>  (default: ${prefix}/share/man)
       --objdir=<DIR>        set build dir as <DIR>               (default: ${PWD})
       --sysconfdir=<DIR>    override the etc dir as <DIR>

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 
 prefix ?= /usr/local
 bindir = $(prefix)/bin
-libdir = $(prefix)/lib
+libdir = $(prefix)/lib/uftrace
 etcdir = $(prefix)/etc
 mandir = $(prefix)/share/man
 docdir = $(srcdir)/doc

--- a/configure
+++ b/configure
@@ -18,7 +18,7 @@ usage() {
   --help                print this message
   --prefix=<DIR>        set install root dir as <DIR>        (default: /usr/local)
   --bindir=<DIR>        set executable install dir as <DIR>  (default: \${prefix}/bin)
-  --libdir=<DIR>        set library install dir as <DIR>     (default: \${prefix}/lib)
+  --libdir=<DIR>        set library install dir as <DIR>     (default: \${prefix}/lib/uftrace)
   --mandir=<DIR>        set manual doc install dir as <DIR>  (default: \${prefix}/share/man)
   --objdir=<DIR>        set build dir as <DIR>               (default: \${PWD})
   --sysconfdir=<DIR>    override the etc dir as <DIR>
@@ -137,7 +137,7 @@ if [ ! -z "$ldflags" ]; then
 fi
 
 bindir=${bindir:-${prefix}/bin}
-libdir=${libdir:-${prefix}/lib}
+libdir=${libdir:-${prefix}/lib/uftrace}
 etcdir=${etcdir:-${prefix}/etc}
 mandir=${mandir:-${prefix}/share/man}
 


### PR DESCRIPTION
This commit changes default uftrace library location from `${prefix}/lib` to `${prefix}/lib/uftrace`.

Also users can set library location with `--libdir=<DIR>` option of configure script like below:
```
  $ ./configure --libdir=/home/minchul/libuftrace
  $ cat .config
  # this file is generated automatically
  override prefix := /usr/local
  override bindir := /usr/local/bin
  override libdir := /home/minchul/libuftrace
  ...
  $ make && sudo make install
  ...
  $ ls /home/minchul/libuftrace/
  libmcount-fast-single.so  libmcount-fast.so  libmcount-nop.so  libmcount-single.so  libmcount.so
```
Closes: #1618