### PR TITLE
pre-commit: Fix RuntimeError in isort hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
     -   id: isort
 -   repo: https://github.com/pre-commit/mirrors-clang-format

--- a/gdb/uftrace/mcount.py
+++ b/gdb/uftrace/mcount.py
@@ -12,10 +12,7 @@
 #
 
 import gdb
-from uftrace import utils
-from uftrace import rbtree
-from uftrace import trigger
-
+from uftrace import rbtree, trigger, utils
 
 filter_type = utils.CachedType("struct uftrace_filter")
 

--- a/gdb/uftrace/plthook.py
+++ b/gdb/uftrace/plthook.py
@@ -14,10 +14,10 @@
 # This work is licensed under the terms of the GNU GPL version 2.
 #
 
-import gdb
 import os
-from uftrace import utils, lists
 
+import gdb
+from uftrace import lists, utils
 
 plthook_data_type = utils.CachedType("struct plthook_data")
 

--- a/gdb/uftrace/trigger.py
+++ b/gdb/uftrace/trigger.py
@@ -12,8 +12,7 @@
 #
 
 import gdb
-from uftrace import utils
-from uftrace import lists
+from uftrace import lists, utils
 
 filter_type  = utils.CachedType("struct uftrace_filter")
 trigger_type = utils.CachedType("struct uftrace_trigger")


### PR DESCRIPTION
The pre-commit shows an error in isort hook as follows.

  RuntimeError: The Poetry configuration is invalid

This can be fixed by upgrading isort rev to 5.11.5 so this patch changes the version to fix it.

In addition, apply changes from isort 5.11.5 to make pre-commit happy.

Link: https://github.com/PyCQA/isort/issues/2083#issuecomment-1408300628
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>