### PR TITLE
tests: Fix t191_posix_spawn.py

### DIFF
--- a/tests/s-posix_spawn.c
+++ b/tests/s-posix_spawn.c
@@ -12,18 +12,14 @@
 int main(int argc, char *argv[])
 {
 	int pid;
-	char *args[] = {
-		NULL,
-		NULL,
-	};
+	char *args1[] = { TEST_PROG1, NULL };
+	char *args2[] = { TEST_PROG2, NULL };
 	char *envp[] = { "PATH=.", "HOME=/home/user", NULL };
 
-	args[0] = TEST_PROG1;
-	posix_spawn(&pid, TEST_PROG1, NULL, NULL, args, envp);
+	posix_spawn(&pid, TEST_PROG1, NULL, NULL, args1, envp);
 	waitpid(pid, NULL, 0);
 
-	args[0] = TEST_PROG2;
-	posix_spawn(&pid, TEST_PROG2, NULL, NULL, args, envp);
+	posix_spawn(&pid, TEST_PROG2, NULL, NULL, args2, envp);
 	waitpid(pid, NULL, 0);
 
 	return 0;


### PR DESCRIPTION
The current t191_posix_spawn.py test fails as follows in clang build.
```
  191 posix_spawn         : OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK  NG OK OK OK OK NG OK OK OK OK NG OK OK OK OK
```
The error comes from that the array initialization is done using implicit 'memset' call inside as follows.
```diff
  $ ./runtest.py -vdi -O0 -c clang 191
      ...
  t191_posix_spawn: diff result of clang -finstrument-functions -O0
  --- expect      2023-02-25 07:50:25.639449974 +0900
  +++ result      2023-02-25 07:50:25.639449974 +0900
  @@ -1,2 +1,3 @@
   main() {
  +   memset();
      posix_spawn();

  191 posix_spawn         : NG
```
This patch simplifies the test program to suppress this 'memset' call.