### PR TITLE
x86_64: Fix an error in s-nested.c with -fpatchable-function-entry

### DIFF
--- a/arch/x86_64/fentry.S
+++ b/arch/x86_64/fentry.S
@@ -56,8 +56,14 @@ GLOBAL(__fentry__)
 	/* save rax (implicit argument for variadic functions) */
 	push %rax
 
+	/* save scratch registers due to -fipa-ra */
+	push %r10
+	push %r11
+
 	call mcount_entry
 
+	pop  %r11
+	pop  %r10
 	pop  %rax
 
 	/* restore original stack pointer */


### PR DESCRIPTION
The current s-nested.c gets crashed when built with -fpatchable-function-entry as follows.
```
  $ gcc -fpatchable-function-entry=5 s-nested.c
  $ uftrace record -P foo_internal.0 a.out
  WARN: Segmentation fault: invalid permission (addr: 0x7fff263b3080)
```
The crash happens because the inner function 'foo_internal.0' reads r10 register to access variables in the outter function.

However, our '__fentry__' implementation doesn't push r10 register for later usage so r10 is changed unexpectedly.

The x86-64-ABI document[1] describes r10 register as follows.
```
  r10 is used for passing a function's static chain pointer.
```
This patch pushes r10 register inside '__fentry__' and it also pushes r11 register together just like '__dentry__' does[2].

[1] https://gitlab.com/x86-psABIs/x86-64-ABI/-/commit/adc986909f2c5aad7aeedbcc05b5f449a2eabfbf
[2] 68104739 arch/x86_64: Fix crash on (full) dynamic tracing

Fixed: #1630
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>