### PR TITLE
tests: Fix t135_trigger_time2.py test

### DIFF
--- a/tests/t135_trigger_time2.py
+++ b/tests/t135_trigger_time2.py
@@ -53,4 +53,4 @@ class TestCase(TestBase):
 
     def setup(self):
         self.subcmd = 'replay'
-        self.option = '-T main@time=%.3f%s' % (TIME, UNIT)
+        self.option = '-T mem_alloc@time=%.3f%s' % (TIME, UNIT)


### PR DESCRIPTION
The current t135_trigger_time2.py fails in some cases as follows.
```
  $ ./runtest.py 135
  Start 1 tests without worker pool
  Compiler                  gcc                                           clang
  Test case                 pg             finstrument-fu fpatchable-fun  pg             finstrument-fu fpatchable-fun
  ------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os  O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os
  135 trigger_time2       : OK OK OK OK OK NG OK OK OK OK NG OK OK NG OK  OK OK OK OK OK OK OK OK OK OK OK OK OK OK NG
```
The failure comes from that 'free' is discarded from the result.
```
  t135_trigger_time2: diff result of gcc -finstrument-functions -O0
  --- expect      2023-02-25 11:30:13.744456689 +0900
  +++ result      2023-02-25 11:30:13.744456689 +0900
  @@ -6,5 +6,3 @@
        } /* bar */
  -     mem_free() {
  -       free();
  -     } /* mem_free */
  +     mem_free();
      } /* foo */

  135 trigger_time2       : NG
```
This happens because the test expects that 'free' takes longer than 'malloc' so it adds a time trigger based on malloc's duration, but if free took less than malloc, then free is also discarded from the result.

To avoid the problem, this patch changes the function for time trigger from 'main' to 'mem_alloc' to apply time trigger only to 'malloc'.