### PR TITLE
unittest: Fix c99 compiler error

### DIFF
--- a/misc/bench.c
+++ b/misc/bench.c
@@ -20,8 +20,9 @@ int bar(volatile int *ptr)
 int bench(int count)
 {
 	volatile int result = 0;
+	int i;
 
-	for (int i = 0; i < count; i++) {
+	for (i = 0; i < count; i++) {
 		if (i % 2 == 0)
 			foo(&result);
 		else
@@ -33,6 +34,7 @@ int bench(int count)
 int main(int argc, char *argv[])
 {
 	int n = 1;
+	int i;
 	int loop = 1000000;
 	int result = 0;
 
@@ -41,7 +43,7 @@ int main(int argc, char *argv[])
 	if (argc > 2)
 		loop = atoi(argv[2]);
 
-	for (int i = 0; i < n; i++)
+	for (i = 0; i < n; i++)
 		result += bench(loop);
 
 	return result ? 0 : 1;

--- a/utils/event.c
+++ b/utils/event.c
@@ -322,6 +322,7 @@ int read_events_file(struct uftrace_data *handle)
 
 TEST_CASE(event_name)
 {
+	unsigned i;
 	struct uftrace_data handle = {};
 	struct {
 		unsigned evt_id;
@@ -338,7 +339,7 @@ TEST_CASE(event_name)
 	};
 
 	pr_dbg("testing event name strings\n");
-	for (unsigned i = 0; i < ARRAY_SIZE(expected); i++) {
+	for (i = 0; i < ARRAY_SIZE(expected); i++) {
 		char *got = event_get_name(&handle, expected[i].evt_id);
 		TEST_STREQ(expected[i].evt_name, got);
 		free(got);
@@ -354,6 +355,7 @@ TEST_CASE(event_data)
 	struct uftrace_page_fault pgfault = { 1977, 1102 };
 	struct uftrace_pmu_cycle cycle = { 1024, 2048 };
 	int cpu = 123;
+	unsigned i;
 
 	struct {
 		unsigned evt_id;
@@ -368,7 +370,7 @@ TEST_CASE(event_data)
 	};
 
 	pr_dbg("testing event data strings\n");
-	for (unsigned i = 0; i < ARRAY_SIZE(expected); i++) {
+	for (i = 0; i < ARRAY_SIZE(expected); i++) {
 		char *got = event_get_data_str(expected[i].evt_id, expected[i].data, true);
 		TEST_STREQ(expected[i].str, got);
 		free(got);

--- a/utils/extern.c
+++ b/utils/extern.c
@@ -206,9 +206,10 @@ TEST_CASE(fstack_extern_data2)
 	const char test_data[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ123456";
 	int msg_size = EXTERN_DATA_MAX * 2;
 	char *extern_data;
+	int i;
 
 	extern_data = xmalloc(msg_size + 1);
-	for (int i = 0; i < msg_size; i += sizeof(test_data) - 1)
+	for (i = 0; i < msg_size; i += sizeof(test_data) - 1)
 		strcpy(&extern_data[i], test_data);
 
 	pr_dbg("creating external data file\n");


### PR DESCRIPTION
Hello Namhyung and Honggyu!

I'm back with this very short fix to begin with, because some unit tests can't compile with old gcc.

After having figured out our upstreaming process at Ciena, I'm ready to send you propositions for the agent in upcoming pull requests. I suggest you label my work as `ciena` from now if you want.