### PR TITLE
mcount: Toggle tracing at runtime

### DIFF
--- a/cmds/live.c
+++ b/cmds/live.c
@@ -56,7 +56,7 @@ static bool match_replay_triggers(const char *trigger)
 static void reset_live_opts(struct uftrace_opts *opts)
 {
 	/* this is needed to set display_depth at replay */
-	live_disabled = opts->disabled;
+	live_disabled = (opts->trace == TRACE_STATE_OFF);
 
 	/*
 	 * These options are handled in record and no need to do it in
@@ -144,7 +144,7 @@ static void reset_live_opts(struct uftrace_opts *opts)
 
 others:
 	opts->depth = MCOUNT_DEFAULT_DEPTH;
-	opts->disabled = false;
+	opts->trace = TRACE_STATE_ON;
 	opts->no_event = false;
 	opts->no_sched = false;
 }
@@ -461,7 +461,7 @@ TEST_CASE(live_reset_options)
 {
 	struct uftrace_opts o = {
 		.depth = 3,
-		.disabled = true,
+		.trace = TRACE_STATE_OFF,
 		.no_event = true,
 		.no_sched = true,
 	};
@@ -482,7 +482,7 @@ TEST_CASE(live_reset_options)
 	TEST_EQ(o.caller, NULL);
 	/* it should only have the color trigger */
 	TEST_STREQ(o.trigger, "bar@time=1us,color=red;baz@backtrace,trace");
-	TEST_EQ(o.disabled, false);
+	TEST_EQ(o.trace, TRACE_STATE_ON);
 	TEST_EQ(o.no_event, false);
 	TEST_EQ(o.no_sched, false);
 

--- a/cmds/live.c
+++ b/cmds/live.c
@@ -340,9 +340,13 @@ static int forward_options(struct uftrace_opts *opts)
 	if (capabilities < 0)
 		goto close;
 
-	/* FIXME Forward user options and set status */
-	if (0)
-		status = forward_option(sfd, capabilities, 0, NULL, 0);
+	if (opts->trace != TRACE_STATE_NONE) {
+		int trace = (opts->trace == TRACE_STATE_ON);
+		status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_TRACE, &trace,
+					sizeof(trace));
+		if (status < 0)
+			goto close;
+	}
 
 close:
 	status_close = agent_message_send(sfd, UFTRACE_MSG_AGENT_CLOSE, NULL, 0);

--- a/cmds/record.c
+++ b/cmds/record.c
@@ -299,8 +299,8 @@ static void setup_child_environ(struct uftrace_opts *opts, int argc, char *argv[
 		setenv("UFTRACE_DEBUG_DOMAIN", build_debug_domain_string(), 1);
 	}
 
-	if (opts->disabled)
-		setenv("UFTRACE_DISABLED", "1", 1);
+	if (opts->trace == TRACE_STATE_OFF)
+		setenv("UFTRACE_TRACE_OFF", "1", 1);
 
 	if (log_color == COLOR_ON) {
 		snprintf(buf, sizeof(buf), "%d", log_color);

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -70,8 +70,12 @@ COMMON OPTIONS
     Default is `regex`.
 
 \--disable
-:   Start uftrace with tracing disabled.  This is only meaningful when used with
-    a `trace_on` trigger.
+:   DEPRECATED. Use `--trace=off` instead.
+
+\--trace=*STATE*
+:   Set uftrace tracing STATE. Possible states are `on` and `off`. Default is
+    `on`. This is only meaningful when used with a `trace_on` trigger or with
+    the agent
 
 \--with-syms=*DIR*
 :   Read symbol data from the .sym files in *DIR* directory instead of the

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -167,8 +167,12 @@ COMMON OPTIONS
     Default is `regex`.
 
 \--disable
-:   Start uftrace with tracing disabled.  This is only meaningful when used with
-    a `trace_on` trigger.
+:   DEPRECATED. Use `--trace=off` instead.
+
+\--trace=*STATE*
+:   Set uftrace tracing STATE. Possible states are `on` and `off`. Default is
+    `on`. This is only meaningful when used with a `trace_on` trigger or with
+    the agent.
 
 \--with-syms=*DIR*
 :   Read symbol data from the .sym files in *DIR* directory instead of the

--- a/doc/uftrace-replay.md
+++ b/doc/uftrace-replay.md
@@ -109,8 +109,12 @@ COMMON OPTIONS
     Default is `regex`.
 
 \--disable
-:   Start replay with tracing disabled.  This is only meaningful when used with
-    a `trace_on` trigger.
+:   DEPRECATED. Use `--trace=off` instead.
+
+\--trace=*STATE*
+:   Set uftrace tracing STATE. Possible states are `on` and `off`. Default is
+    `on`. This is only meaningful when used with a `trace_on` trigger or with
+    the agent
 
 \--with-syms=*DIR*
 :   Read symbol data from the .sym files in *DIR* directory instead of the

--- a/doc/uftrace.html
+++ b/doc/uftrace.html
@@ -3823,13 +3823,13 @@ class: code-24px
 ```
 ---
 class: code-24px
-### Trace Control Triggers (--disable)
-.footnote[.red[--disable] starts uftrace with tracing disabled]
+### Trace Control Triggers (--trace=off)
+.footnote[.red[--trace=off] starts uftrace with tracing disabled]
 ```
 
     $ gcc -pg -g tests/s-signal.c
 
-    $ uftrace -a `--disable` a.out
+    $ uftrace -a `--trace=off` a.out
     WARN: cannot open record data: ... : No data available
 ```
 ---
@@ -3840,7 +3840,7 @@ class: code-24px
 
     $ gcc -pg -g tests/s-signal.c
 
-    $ uftrace -a --disable `-T foo@trace_on` a.out
+    $ uftrace -a --trace=off `-T foo@trace_on` a.out
     # DURATION     TID     FUNCTION
        0.316 us [ 17381] |   `foo`() = 0;
        2.760 us [ 17381] |   signal(SIGUSR1, &sighandler) = 0;
@@ -3912,7 +3912,7 @@ class: code-24px
 
     $ gcc -pg -g tests/s-signal.c
 
-    $ uftrace -a --disable `--signal SIGUSR1@trace_on` a.out
+    $ uftrace -a --trace=off `--signal SIGUSR1@trace_on` a.out
     uftrace: install signal handlers to task 175678
     # DURATION     TID     FUNCTION
                 [ 17678] |     } /* sighandler */

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -106,7 +106,7 @@ static pthread_t agent;
 /* state flag for the agent */
 static volatile bool agent_run = false;
 
-#define MCOUNT_AGENT_CAPABILITIES 0
+#define MCOUNT_AGENT_CAPABILITIES (UFTRACE_AGENT_OPT_TRACE)
 
 __weak void dynamic_return(void)
 {
@@ -1865,8 +1865,17 @@ static int agent_read_option(int fd, int *opt, void **value, size_t read_size)
 static int agent_apply_option(int opt, void *value, size_t size, struct rb_root *triggers)
 {
 	int ret = 0;
+	int trace;
 
 	switch (opt) {
+	case UFTRACE_AGENT_OPT_TRACE:
+		trace = *((int *)value);
+		if (mcount_enabled != trace) {
+			mcount_enabled = trace;
+			pr_dbg("turn trace %s\n", mcount_enabled ? "on" : "off");
+		}
+		break;
+
 	default:
 		ret = -1;
 	}

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -445,7 +445,7 @@ static void mcount_filter_init(enum uftrace_pattern_type ptype, bool force)
 	if (getenv("UFTRACE_DEPTH"))
 		mcount_depth = strtol(getenv("UFTRACE_DEPTH"), NULL, 0);
 
-	if (getenv("UFTRACE_DISABLED"))
+	if (getenv("UFTRACE_TRACE_OFF"))
 		mcount_enabled = false;
 }
 

--- a/tests/s-agent.c
+++ b/tests/s-agent.c
@@ -1,11 +1,65 @@
-/*
- *  This is a test to see if the agent is running and responsive.
+/* This target program is intended for use with the agent. It executes a loop
+ * and awaits for external input at each iteration.
+ *
+ * It accepts options so it can adapt its execution to test various agent
+ * features.
  */
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int func(int depth);
+static int a(int depth);
+static int b(int depth);
+static int c(int depth);
+
+static int func(int depth)
+{
+	if (depth)
+		return a(--depth) + 1;
+
+	return 0;
+}
+
+static int a(int depth)
+{
+	if (depth)
+		return b(--depth) + 1;
+
+	return 0;
+}
+
+static int b(int depth)
+{
+	if (depth)
+		return c(--depth) + 1;
+
+	return 0;
+}
+
+static int c(int depth)
+{
+	if (getpid()) /* true */
+		return depth;
+
+	return -1; /* unreached */
+}
 
 int main(int argc, char *argv[])
 {
-	getchar();
+	int i;
+	int depth = 3;
+
+	for (i = 1; i < argc; i++) {
+		if (!strcmp(argv[i], "--depth"))
+			depth = atoi(argv[++i]);
+	}
+
+	do {
+		func(depth);
+	} while (getchar() != EOF);
+
 	return 0;
 }

--- a/tests/t038_trace_disable.py
+++ b/tests/t038_trace_disable.py
@@ -21,4 +21,4 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def setup(self):
-        self.option = '--disable -T "ns::ns2::foo::bar@trace_on"'
+        self.option = '--trace=off -T "ns::ns2::foo::bar@trace_on"'

--- a/tests/t039_trace_onoff_F.py
+++ b/tests/t039_trace_onoff_F.py
@@ -17,4 +17,4 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def setup(self):
-        self.option = '--disable -F "ns::ns1::foo::bar" -T ".*foo::bar3@trace_on"'
+        self.option = '--trace=off -F "ns::ns1::foo::bar" -T ".*foo::bar3@trace_on"'

--- a/tests/t040_replay_onoff.py
+++ b/tests/t040_replay_onoff.py
@@ -26,4 +26,4 @@ class TestCase(TestBase):
 
     def setup(self):
         self.subcmd = "replay"
-        self.option = "--disable -T 'operator new@trace_on' -T 'malloc@trace_off'"
+        self.option = "--trace=off -T 'operator new@trace_on' -T 'malloc@trace_off'"

--- a/tests/t041_replay_onoff_N.py
+++ b/tests/t041_replay_onoff_N.py
@@ -25,5 +25,5 @@ class TestCase(TestBase):
 
     def setup(self):
         self.subcmd  = 'replay'
-        self.option  = "--disable -N 'ns2.*' -T 'operator new@trace-on' "
+        self.option  = "--trace=off -N 'ns2.*' -T 'operator new@trace-on' "
         self.option += "-T 'malloc@traceoff'"

--- a/tests/t042_live_disable.py
+++ b/tests/t042_live_disable.py
@@ -21,4 +21,4 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def setup(self):
-        self.option = '--disable -F ".*foo::foo" -T .foo::foo@trace_on -F .bar2'
+        self.option = '--trace=off -F ".*foo::foo" -T .foo::foo@trace_on -F .bar2'

--- a/tests/t273_agent_basic.py
+++ b/tests/t273_agent_basic.py
@@ -9,35 +9,36 @@ class TestCase(TestBase):
     def __init__(self):
         TestBase.__init__(self, 'agent', """
 # DURATION     TID     FUNCTION
-            [ 22621] | main() {
-  43.742 ms [ 22621] |   getchar();
-  43.759 ms [ 22621] | } /* main */
+  34.330 ms [ 22621] | main();
 """)
 
-    def prerun(self, timeout):
-        self.subcmd = 'record'
-        self.option = '--keep-pid -g'
-        self.exearg = 't-' + self.name
-        record_cmd  = self.runcmd()
-        self.pr_debug("prerun command: " + record_cmd)
-        record_p = sp.Popen(record_cmd.split(), stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE)
-
-        sleep(.05)              # time for the agent to start
+    def client_send_command(self, pid, option):
         self.subcmd = 'live'
-        self.option = '-p %d' % record_p.pid
+        self.option = '-p %d %s' % (pid, option)
         self.exearg = ''
         client_cmd = self.runcmd()
         self.pr_debug('prerun command: ' + client_cmd)
-        client_ret = sp.call(client_cmd.split())
+        client_p = sp.run(client_cmd.split())
+        return client_p.returncode
 
-        record_p.communicate(b"^D") # target waits for a char to end
-        record_p.wait()
+    def prerun(self, timeout):
+        self.subcmd = 'record'
+        self.option  = '--agent'
+        self.option += ' --keep-pid'
+        self.option += ' --no-libcall'
+        self.exearg = 't-' + self.name
+        record_cmd  = self.runcmd()
+        self.pr_debug("prerun command: " + record_cmd)
+        record_p = sp.Popen(record_cmd.split(), stdin=sp.PIPE, stderr=sp.PIPE, bufsize=0)
 
-        if client_ret != 0:
+        sleep(.05)              # time for the agent to start
+        if self.client_send_command(record_p.pid, '') != 0:
             return TestBase.TEST_NONZERO_RETURN
+        record_p.stdin.close()
+
         return TestBase.TEST_SUCCESS
 
     def setup(self):
         self.subcmd = 'replay'
-        self.option = ''
+        self.option = '-D 1'
         self.exearg = ''

--- a/tests/t281_agent_trace_toggle.py
+++ b/tests/t281_agent_trace_toggle.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+import subprocess as sp
+from time import sleep
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    """Run the target with the agent activated. Tracing is disabled by the
+    client before triggering the second loop in the target, and restored just
+    after.
+
+    That way, func() gets executed 3 times in the target, but is only recorded 2
+    times by uftrace."""
+    def __init__(self):
+        TestBase.__init__(self, 'agent', """
+# DURATION     TID     FUNCTION
+            [  5650] | main() {
+            [  5650] |   func() {
+            [  5650] |     a() {
+            [  5650] |       b() {
+   0.113 us [  5650] |         c();
+   1.618 us [  5650] |       } /* b */
+   1.910 us [  5650] |     } /* a */
+   2.301 us [  5650] |   } /* func */
+            [  5650] |   func() {
+            [  5650] |     a() {
+            [  5650] |       b() {
+   0.430 us [  5650] |         c();
+   3.898 us [  5650] |       } /* b */
+   4.993 us [  5650] |     } /* a */
+   6.843 us [  5650] |   } /* func */
+  37.310 ms [  5650] | } /* main */
+""")
+
+    def client_send_command(self, pid, option):
+        self.subcmd = 'live'
+        self.option = '-p %d %s' % (pid, option)
+        self.exearg = ''
+        client_cmd = self.runcmd()
+        self.pr_debug('prerun command: ' + client_cmd)
+        client_p = sp.run(client_cmd.split())
+        return client_p.returncode
+
+    def prerun(self, timeout):
+        self.subcmd = 'record'
+        self.option  = '--agent'
+        self.option += ' --keep-pid'
+        self.option += ' --no-libcall'
+        self.exearg = 't-' + self.name
+        record_cmd  = self.runcmd()
+        self.pr_debug("prerun command: " + record_cmd)
+        record_p = sp.Popen(record_cmd.split(), stdin=sp.PIPE, stderr=sp.PIPE, bufsize=0)
+
+        sleep(.05)              # time for the agent to start
+        if self.client_send_command(record_p.pid, '--trace=off') != 0:
+            return TestBase.TEST_NONZERO_RETURN
+        record_p.stdin.write(b'0')
+
+        if self.client_send_command(record_p.pid, '--trace=on') != 0:
+            return TestBase.TEST_NONZERO_RETURN
+        record_p.stdin.write(b'0')
+
+        record_p.stdin.close()
+        record_p.wait()
+
+        return TestBase.TEST_SUCCESS
+
+    def setup(self):
+        self.subcmd = 'replay'
+        self.option = ''
+        self.exearg = ''

--- a/uftrace.h
+++ b/uftrace.h
@@ -279,7 +279,6 @@ struct uftrace_opts {
 	bool use_pager;
 	bool avg_total;
 	bool avg_self;
-	bool disabled;
 	bool report;
 	bool column_view;
 	bool want_bind_not;
@@ -310,6 +309,7 @@ struct uftrace_opts {
 	bool agent;
 	struct uftrace_time_range range;
 	enum uftrace_pattern_type patt_type;
+	enum uftrace_trace_state trace;
 };
 
 extern struct strv default_opts;

--- a/uftrace.h
+++ b/uftrace.h
@@ -458,7 +458,7 @@ struct uftrace_msg_dlopen {
 };
 
 enum uftrace_agent_opt {
-	UFTRACE_AGENT_OPT_XXX,
+	UFTRACE_AGENT_OPT_TRACE = (1U << 0), /* turn tracing on/off */
 };
 
 extern struct uftrace_session *first_session;

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -89,6 +89,12 @@ struct uftrace_pattern {
 	regex_t re;
 };
 
+enum uftrace_trace_state {
+	TRACE_STATE_NONE,
+	TRACE_STATE_OFF,
+	TRACE_STATE_ON,
+};
+
 struct uftrace_filter_setting {
 	enum uftrace_pattern_type ptype;
 	enum uftrace_cpu_arch arch;

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -50,7 +50,7 @@ static void setup_task_handle(struct uftrace_data *handle, struct uftrace_task_r
 	task->event_color = DEFAULT_EVENT_COLOR;
 
 	/*
-	 * set display depth to non-zero only when trace-on trigger (with --disabled
+	 * set display depth to non-zero only when trace-on trigger (with --trace=off
 	 * option) or time range is set.
 	 */
 	task->display_depth_set = (fstack_enabled && !live_disabled && !handle->time_range.start);
@@ -515,7 +515,7 @@ int fstack_setup_filters(struct uftrace_opts *opts, struct uftrace_data *handle)
 		}
 	}
 
-	if (opts->disabled)
+	if (opts->trace == TRACE_STATE_OFF)
 		fstack_enabled = false;
 
 	fstack_setup_task(opts->tid, handle);


### PR DESCRIPTION
Hi Namhyung and Honggyu,

This PR makes it possible to pause and resume tracing from the client, in a similar fashion to `trace_on` and `trace_off` triggers. When tracing is stopped, the instrumentation is simply skipped on function entry or exit, and event collection doesn't take place.

This mechanism can be used in conjunction with function or signal trigger actions.
```
$ uftrace record --agent --trace=off ./prog
$ uftrace --pid $(pidof prog) --trace=on     # toggle tracing on
$ uftrace --pid $(pidof prog) --trace=off    # toggle tracing back off
```

I'm refactoring the `--disable` option to `--trace=on|off` for clarity.
I'm simplifying agent internals to make it easier to integrate other options.

~Based on: #1642~
~Based on: #1665~