### PR TITLE
Control name filters at runtime

### DIFF
--- a/cmds/live.c
+++ b/cmds/live.c
@@ -360,6 +360,11 @@ static int forward_options(struct uftrace_opts *opts)
 			goto close;
 	}
 
+	status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_PATTERN, &opts->patt_type,
+				sizeof(opts->patt_type));
+	if (status < 0)
+		goto close;
+
 close:
 	status_close = agent_message_send(sfd, UFTRACE_MSG_AGENT_CLOSE, NULL, 0);
 	if (status_close == 0) {

--- a/cmds/live.c
+++ b/cmds/live.c
@@ -360,7 +360,7 @@ static int forward_options(struct uftrace_opts *opts)
 			goto close;
 	}
 
-	if (opts->filter) { /* provide a pattern type for options that need it */
+	if (opts->filter || opts->caller) { /* provide a pattern type for options that need it */
 		status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_PATTERN,
 					&opts->patt_type, sizeof(opts->patt_type));
 		if (status < 0)
@@ -370,6 +370,13 @@ static int forward_options(struct uftrace_opts *opts)
 	if (opts->filter) {
 		status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_FILTER, opts->filter,
 					strlen(opts->filter) + 1);
+		if (status < 0)
+			goto close;
+	}
+
+	if (opts->caller) {
+		status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_CALLER, opts->caller,
+					strlen(opts->caller) + 1);
 		if (status < 0)
 			goto close;
 	}

--- a/cmds/live.c
+++ b/cmds/live.c
@@ -360,10 +360,19 @@ static int forward_options(struct uftrace_opts *opts)
 			goto close;
 	}
 
-	status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_PATTERN, &opts->patt_type,
-				sizeof(opts->patt_type));
-	if (status < 0)
-		goto close;
+	if (opts->filter) { /* provide a pattern type for options that need it */
+		status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_PATTERN,
+					&opts->patt_type, sizeof(opts->patt_type));
+		if (status < 0)
+			goto close;
+	}
+
+	if (opts->filter) {
+		status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_FILTER, opts->filter,
+					strlen(opts->filter) + 1);
+		if (status < 0)
+			goto close;
+	}
 
 close:
 	status_close = agent_message_send(sfd, UFTRACE_MSG_AGENT_CLOSE, NULL, 0);

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -297,10 +297,14 @@ The uftrace tool supports filtering out uninteresting functions.  Filtering is
 highly recommended since it helps users focus on the interesting functions and
 reduces the data size.  When uftrace is called, it receives two types of function
 filter; an opt-in filter with `-F`/`--filter` and an opt-out filter with
-`-N`/`--notrace`.  These filters can be applied either at record time or
-replay time.
+`-N`/`--notrace`.
 
-The first one is an opt-in filter. By default, it doesn't trace anything.  But
+These filters can be applied either at record time or replay time.  For record
+time, they can be added and removed at runtime from the client.  Removing
+filters is achieved by specifying the `@clear` suffix for the `-F` / `--filter`
+or `-N` / `--notrace` options.
+
+The first type of filter is opt-in. By default, it doesn't trace anything.  But
 when one of the specified functions is executed, tracing is started.  When the
 function returns, tracing is stopped again.
 

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -400,6 +400,9 @@ parent functions to the function.
 In the above example, functions not in the calling path were not shown.  Also
 the function 'c' - which is a child of the function 'b' - is also hidden.
 
+Caller filters can be added and removed from the client at runtime, using the
+`@clear` suffix for the `-C` / `--caller-filter` option.
+
 In addition, you can limit the nesting level of functions with the `-D` option.
 
     $ uftrace -D 3 ./abc

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -321,6 +321,9 @@ parent functions to the function.
 In the above example, functions not in the calling path were not shown.  Also
 the function 'c' - which is a child of the function 'b' - is also hidden.
 
+Caller filters can be added and removed from the client at runtime, using the
+`@clear` suffix for the `-C` / `--caller-filter` option.
+
 In addition, you can limit the nesting level of functions with the `-D` option.
 
     $ uftrace record -D 3 ./abc

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -233,10 +233,14 @@ The uftrace tool supports filtering out uninteresting functions.  Filtering is
 highly recommended since it helps users focus on the interesting functions and
 reduces the data size.  When uftrace is called it receives two types of function
 filter; an opt-in filter with `-F`/`--filter` and an opt-out filter with
-`-N`/`--notrace`.  These filters can be applied either at record time or
-replay time.
+`-N`/`--notrace`.
 
-The first one is an opt-in filter. By default, it doesn't trace anything.  But
+These filters can be applied either at record time or replay time.  They can be
+added and removed at runtime from the client.  Removing filters is achieved by
+specifying the `@clear` suffix for the `-F` / `--filter` or `-N` / `--notrace`
+options.
+
+The first type of filter is opt-in. By default, it doesn't trace anything.  But
 when one of the specified functions is executed, tracing is started.  When the
 function returns, tracing is stopped again.
 

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -460,7 +460,7 @@ static void mcount_filter_release(struct mcount_thread_data *mtdp)
 
 static void mcount_filter_finish(void)
 {
-	uftrace_cleanup_filter(&mcount_triggers->root);
+	uftrace_cleanup_triggers(mcount_triggers);
 	free(mcount_triggers);
 	finish_auto_args();
 
@@ -1810,7 +1810,7 @@ static void swap_triggers(struct mcount_triggers_info **old, struct mcount_trigg
 	struct mcount_triggers_info *tmp;
 	tmp = __sync_val_compare_and_swap(old, *old, new);
 	sleep(1); /* RCU-like grace period */
-	uftrace_cleanup_filter(&tmp->root);
+	uftrace_cleanup_triggers(tmp);
 	free(tmp);
 }
 

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -114,7 +114,8 @@ static pthread_t agent;
 static volatile bool agent_run = false;
 
 #define MCOUNT_AGENT_CAPABILITIES                                                                  \
-	(UFTRACE_AGENT_OPT_TRACE | UFTRACE_AGENT_OPT_DEPTH | UFTRACE_AGENT_OPT_THRESHOLD)
+	(UFTRACE_AGENT_OPT_TRACE | UFTRACE_AGENT_OPT_DEPTH | UFTRACE_AGENT_OPT_THRESHOLD |         \
+	 UFTRACE_AGENT_OPT_PATTERN)
 
 __weak void dynamic_return(void)
 {
@@ -1929,6 +1930,14 @@ static int agent_apply_option(int opt, void *value, size_t size, struct rb_root 
 		}
 		else
 			pr_dbg3("dynamic time threshold unchanged\n");
+		break;
+
+	case UFTRACE_AGENT_OPT_PATTERN:
+		opts.patt_type = *((int *)value);
+		if (opts.patt_type != mcount_filter_setting.ptype) {
+			mcount_filter_setting.ptype = opts.patt_type;
+			pr_dbg3("use pattern type %#x\n", opts.patt_type);
+		}
 		break;
 
 	default:

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -76,6 +76,13 @@ int page_size_in_kb;
 /* call depth to filter */
 static int __maybe_unused mcount_depth = MCOUNT_DEFAULT_DEPTH;
 
+/* setting for all filter actions */
+static struct uftrace_filter_setting mcount_filter_setting = {
+	.ptype = PATT_REGEX,
+	.auto_args = false,
+	.allow_kernel = false,
+};
+
 /* boolean flag to turn on/off recording */
 static bool __maybe_unused mcount_enabled = true;
 
@@ -115,7 +122,7 @@ __weak void dynamic_return(void)
 
 #ifdef DISABLE_MCOUNT_FILTER
 
-static void mcount_filter_init(enum uftrace_pattern_type ptype, bool force)
+static void mcount_filter_init(struct uftrace_filter_setting *filter_setting, bool force)
 {
 	if (getenv("UFTRACE_SRCLINE") == NULL)
 		return;
@@ -123,7 +130,7 @@ static void mcount_filter_init(enum uftrace_pattern_type ptype, bool force)
 	load_module_symtabs(&mcount_sym_info);
 
 	/* use debug info if available */
-	prepare_debug_info(&mcount_sym_info, ptype, NULL, NULL, false, force);
+	prepare_debug_info(&mcount_sym_info, filter_setting->ptype, NULL, NULL, false, force);
 	save_debug_info(&mcount_sym_info, mcount_sym_info.dirname);
 }
 
@@ -367,7 +374,7 @@ static void mcount_signal_finish(void)
 	}
 }
 
-static void mcount_filter_init(enum uftrace_pattern_type ptype, bool force)
+static void mcount_filter_init(struct uftrace_filter_setting *filter_setting, bool force)
 {
 	char *filter_str = getenv("UFTRACE_FILTER");
 	char *trigger_str = getenv("UFTRACE_TRIGGER");
@@ -377,23 +384,19 @@ static void mcount_filter_init(enum uftrace_pattern_type ptype, bool force)
 	char *caller_str = getenv("UFTRACE_CALLER");
 	char *loc_str = getenv("UFTRACE_LOCATION");
 
-	struct uftrace_filter_setting filter_setting = {
-		.ptype = ptype,
-		.auto_args = false,
-		.allow_kernel = false,
-		.lp64 = host_is_lp64(),
-		.arch = host_cpu_arch(),
-	};
+	filter_setting->lp64 = host_is_lp64();
+	filter_setting->arch = host_cpu_arch();
+
 	bool needs_debug_info = false;
 
 	load_module_symtabs(&mcount_sym_info);
 
-	mcount_signal_init(getenv("UFTRACE_SIGNAL"), &filter_setting);
+	mcount_signal_init(getenv("UFTRACE_SIGNAL"), filter_setting);
 
 	/* setup auto-args only if argument/return value is used */
 	if (argument_str || retval_str || autoargs_str ||
 	    (trigger_str && (strstr(trigger_str, "arg") || strstr(trigger_str, "retval")))) {
-		setup_auto_args(&filter_setting);
+		setup_auto_args(filter_setting);
 		needs_debug_info = true;
 	}
 
@@ -402,28 +405,28 @@ static void mcount_filter_init(enum uftrace_pattern_type ptype, bool force)
 
 	/* use debug info if available */
 	if (needs_debug_info) {
-		prepare_debug_info(&mcount_sym_info, ptype, argument_str, retval_str,
-				   !!autoargs_str, force);
+		prepare_debug_info(&mcount_sym_info, filter_setting->ptype, argument_str,
+				   retval_str, !!autoargs_str, force);
 		save_debug_info(&mcount_sym_info, mcount_sym_info.dirname);
 	}
 
 	mcount_triggers = xmalloc(sizeof(*mcount_triggers));
 	*mcount_triggers = RB_ROOT;
 	uftrace_setup_filter(filter_str, &mcount_sym_info, mcount_triggers, &mcount_filter_mode,
-			     &filter_setting);
+			     filter_setting);
 	uftrace_setup_trigger(trigger_str, &mcount_sym_info, mcount_triggers, &mcount_filter_mode,
-			      &filter_setting);
-	uftrace_setup_argument(argument_str, &mcount_sym_info, mcount_triggers, &filter_setting);
-	uftrace_setup_retval(retval_str, &mcount_sym_info, mcount_triggers, &filter_setting);
+			      filter_setting);
+	uftrace_setup_argument(argument_str, &mcount_sym_info, mcount_triggers, filter_setting);
+	uftrace_setup_retval(retval_str, &mcount_sym_info, mcount_triggers, filter_setting);
 
 	if (needs_debug_info) {
 		uftrace_setup_loc_filter(loc_str, &mcount_sym_info, mcount_triggers,
-					 &mcount_loc_mode, &filter_setting);
+					 &mcount_loc_mode, filter_setting);
 	}
 
 	if (caller_str) {
 		uftrace_setup_caller_filter(caller_str, &mcount_sym_info, mcount_triggers,
-					    &filter_setting);
+					    filter_setting);
 	}
 
 	/* there might be caller triggers, count it separately */
@@ -434,13 +437,13 @@ static void mcount_filter_init(enum uftrace_pattern_type ptype, bool force)
 		char *autoarg = ".";
 		char *autoret = ".";
 
-		if (ptype == PATT_GLOB)
+		if (filter_setting->ptype == PATT_GLOB)
 			autoarg = autoret = "*";
 
-		filter_setting.auto_args = true;
+		filter_setting->auto_args = true;
 
-		uftrace_setup_argument(autoarg, &mcount_sym_info, mcount_triggers, &filter_setting);
-		uftrace_setup_retval(autoret, &mcount_sym_info, mcount_triggers, &filter_setting);
+		uftrace_setup_argument(autoarg, &mcount_sym_info, mcount_triggers, filter_setting);
+		uftrace_setup_retval(autoret, &mcount_sym_info, mcount_triggers, filter_setting);
 	}
 
 	if (getenv("UFTRACE_DEPTH"))
@@ -2121,7 +2124,6 @@ static __used void mcount_startup(void)
 	char *symdir_str;
 	struct stat statbuf;
 	bool nest_libcall;
-	enum uftrace_pattern_type patt_type = PATT_REGEX;
 
 	if (!(mcount_global_flags & MCOUNT_GFL_SETUP))
 		return;
@@ -2222,14 +2224,14 @@ static __used void mcount_startup(void)
 	record_proc_maps(dirname, mcount_session_name(), &mcount_sym_info);
 
 	if (pattern_str)
-		patt_type = parse_filter_pattern(pattern_str);
+		mcount_filter_setting.ptype = parse_filter_pattern(pattern_str);
 
 	if (patch_str)
 		mcount_return_fn = (unsigned long)dynamic_return;
 	else
 		mcount_return_fn = (unsigned long)mcount_return;
 
-	mcount_filter_init(patt_type, !!patch_str);
+	mcount_filter_init(&mcount_filter_setting, !!patch_str);
 	mcount_watch_init();
 
 	if (maxstack_str)
@@ -2242,10 +2244,10 @@ static __used void mcount_startup(void)
 		mcount_min_size = strtoul(minsize_str, NULL, 0);
 
 	if (patch_str)
-		mcount_dynamic_update(&mcount_sym_info, patch_str, patt_type);
+		mcount_dynamic_update(&mcount_sym_info, patch_str, mcount_filter_setting.ptype);
 
 	if (event_str)
-		mcount_setup_events(dirname, event_str, patt_type);
+		mcount_setup_events(dirname, event_str, mcount_filter_setting.ptype);
 
 	if (getenv("UFTRACE_KERNEL_PID_UPDATE"))
 		kernel_pid_update = true;
@@ -2270,7 +2272,7 @@ static __used void mcount_startup(void)
 
 	/* initialize script binding */
 	if (SCRIPT_ENABLED && script_str)
-		mcount_script_init(patt_type);
+		mcount_script_init(mcount_filter_setting.ptype);
 
 	compiler_barrier();
 	pr_dbg("mcount setup done\n");

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -89,8 +89,8 @@ static bool __maybe_unused mcount_enabled = true;
 /* count of registered opt-in filters (-F) */
 static int __maybe_unused mcount_filter_count;
 
-/* location filtering mode - inclusive or exclusive */
-static enum filter_mode __maybe_unused mcount_loc_mode = FILTER_MODE_NONE;
+/* count of registered opt-in location filters (-L) */
+static int __maybe_unused mcount_loc_count;
 
 /* tree of trigger actions */
 static struct rb_root __maybe_unused *mcount_triggers;
@@ -422,7 +422,7 @@ static void mcount_filter_init(struct uftrace_filter_setting *filter_setting, bo
 
 	if (needs_debug_info) {
 		uftrace_setup_loc_filter(loc_str, &mcount_sym_info, mcount_triggers,
-					 &mcount_loc_mode, filter_setting);
+					 &mcount_loc_count, filter_setting);
 	}
 
 	if (caller_str) {
@@ -861,6 +861,14 @@ static inline enum filter_mode mcount_get_filter_mode()
 	return mcount_filter_count > 0 ? FILTER_MODE_IN : FILTER_MODE_OUT;
 }
 
+/**
+ * mcount_get_loc_mode - compute the location filter mode from the location count
+ */
+static inline enum filter_mode mcount_get_loc_mode()
+{
+	return mcount_loc_count > 0 ? FILTER_MODE_IN : FILTER_MODE_OUT;
+}
+
 static void mcount_save_filter(struct mcount_thread_data *mtdp)
 {
 	/* save original depth and time to restore at exit time */
@@ -914,7 +922,7 @@ enum filter_result mcount_entry_filter_check(struct mcount_thread_data *mtdp, un
 			return FILTER_OUT;
 	}
 	else {
-		if (mcount_loc_mode == FILTER_MODE_IN)
+		if (mcount_get_loc_mode() == FILTER_MODE_IN)
 			return FILTER_OUT;
 	}
 

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -115,7 +115,7 @@ static volatile bool agent_run = false;
 
 #define MCOUNT_AGENT_CAPABILITIES                                                                  \
 	(UFTRACE_AGENT_OPT_TRACE | UFTRACE_AGENT_OPT_DEPTH | UFTRACE_AGENT_OPT_THRESHOLD |         \
-	 UFTRACE_AGENT_OPT_PATTERN | UFTRACE_AGENT_OPT_FILTER)
+	 UFTRACE_AGENT_OPT_PATTERN | UFTRACE_AGENT_OPT_FILTER | UFTRACE_AGENT_OPT_CALLER)
 
 __weak void dynamic_return(void)
 {
@@ -1815,11 +1815,23 @@ static void swap_triggers(struct rb_root **old, struct rb_root *new)
 /**
  * agent_setup_filter - update the registered filters from the agent
  * @filter_str - filters to add or remove
+ * @triggers   - rbtree of tracing filters
  */
 static void agent_setup_filter(char *filter_str, struct rb_root *triggers)
 {
 	uftrace_setup_filter(filter_str, &mcount_sym_info, triggers, &mcount_filter_mode,
 			     &mcount_filter_setting);
+}
+
+/**
+ * agent_setup_caller_filter - update the registered caller filters from the agent
+ * @caller_str - caller filters to add or remove
+ * @triggers   - rbtree where the filters are stored
+ */
+static void agent_setup_caller_filter(char *caller_str, struct rb_root *triggers)
+{
+	uftrace_setup_caller_filter(caller_str, &mcount_sym_info, triggers, &mcount_filter_setting);
+	mcount_has_caller = true;
 }
 
 /**
@@ -1955,6 +1967,11 @@ static int agent_apply_option(int opt, void *value, size_t size, struct rb_root 
 		agent_setup_filter(value, triggers);
 		break;
 
+	case UFTRACE_AGENT_OPT_CALLER:
+		pr_dbg3("apply caller filter '%s' (size=%d)\n", value, size);
+		agent_setup_caller_filter(value, triggers);
+		break;
+
 	default:
 		ret = -1;
 	}
@@ -1965,7 +1982,7 @@ static int agent_apply_option(int opt, void *value, size_t size, struct rb_root 
 static bool triggers_needs_copy(int opt)
 {
 	bool ret;
-#define MATCHING_OPTIONS UFTRACE_AGENT_OPT_FILTER
+#define MATCHING_OPTIONS (UFTRACE_AGENT_OPT_FILTER | UFTRACE_AGENT_OPT_CALLER)
 	ret = opt & MATCHING_OPTIONS;
 #undef MATCHING_OPTIONS
 	return ret;

--- a/libmcount/mcount.h
+++ b/libmcount/mcount.h
@@ -13,6 +13,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "utils/rbtree.h"
+
 #define UFTRACE_DIR_NAME "uftrace.data"
 
 #define MCOUNT_RSTACK_MAX OPT_RSTACK_DEFAULT
@@ -61,6 +63,19 @@ struct mcount_ret_stack {
 	struct plthook_data *pd;
 	/* set arg_spec at function entry and use it at exit */
 	struct list_head *pargs;
+};
+
+struct mcount_triggers_info {
+	/* filters, trigger actions, arg/retval specs */
+	/* container type: struct uftrace_filter */
+	struct rb_root root;
+
+	/* count of registered opt-in filters (-F) */
+	int filter_count;
+	/* count of registered caller filters */
+	int caller_count;
+	/* count of registered opt-in location filters (-L) */
+	int loc_count;
 };
 
 void __monstartup(unsigned long low, unsigned long high);

--- a/tests/s-agent.c
+++ b/tests/s-agent.c
@@ -11,6 +11,7 @@
 #include <unistd.h>
 
 static int func(int depth);
+static int trigger(int depth);
 static int a(int depth);
 static int b(int depth);
 static int c(int depth);
@@ -84,6 +85,9 @@ int main(int argc, char *argv[])
 		if (!strcmp(argv[i], "--delay"))
 			use_delay = 1;
 	}
+
+	if (depth <= 0)
+		depth = 1;
 
 	do {
 		func(depth);

--- a/tests/t273_agent_basic.py
+++ b/tests/t273_agent_basic.py
@@ -34,7 +34,10 @@ class TestCase(TestBase):
         sleep(.05)              # time for the agent to start
         if self.client_send_command(record_p.pid, '') != 0:
             return TestBase.TEST_NONZERO_RETURN
+        record_p.stdin.write(b'0')
+
         record_p.stdin.close()
+        record_p.wait()
 
         return TestBase.TEST_SUCCESS
 

--- a/tests/t284_agent_filter.py
+++ b/tests/t284_agent_filter.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+import subprocess as sp
+from time import sleep
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    """Add and remove opt-in and opt-out filters at runtime from the agent.
+
+    The target runs a loop, and starts with leaf function c() filtered out. We
+    remove the filter, expecting c() to appear in the trace. Then we apply two
+    filters, and remove them one by one.
+    """
+
+    def __init__(self):
+        TestBase.__init__(self, 'agent', """
+# DURATION     TID     FUNCTION
+            [ 24808] | main() {
+            [ 24808] |   func() {
+            [ 24808] |     a() {
+   2.115 ms [ 24808] |       b();
+   3.178 ms [ 24808] |     } /* a */
+   3.179 ms [ 24808] |   } /* func */
+            [ 24808] |   func() {
+            [ 24808] |     a() {
+            [ 24808] |       b() {
+   1.058 ms [ 24808] |         c();
+   2.122 ms [ 24808] |       } /* b */
+   3.195 ms [ 24808] |     } /* a */
+   3.196 ms [ 24808] |   } /* func */
+   2.124 ms [ 24808] |   b();
+            [ 24808] |   func() {
+            [ 24808] |     a() {
+   2.135 ms [ 24808] |       b();
+   3.207 ms [ 24808] |     } /* a */
+   3.208 ms [ 24808] |   } /* func */
+            [ 24808] |   func() {
+            [ 24808] |     a() {
+            [ 24808] |       b() {
+   1.068 ms [ 24808] |         c();
+   2.137 ms [ 24808] |       } /* b */
+   3.206 ms [ 24808] |     } /* a */
+   3.206 ms [ 24808] |   } /* func */
+  58.216 ms [ 24808] | } /* main */
+""")
+
+
+    def client_send_command(self, pid, option):
+        self.subcmd = 'live'
+        self.option = '-p %d %s' % (pid, option)
+        self.exearg = ''
+        client_cmd = self.runcmd()
+        self.pr_debug('prerun command: ' + client_cmd)
+        client_p = sp.run(client_cmd.split())
+        return client_p.returncode
+
+    def prerun(self, timeout):
+        self.subcmd = 'record'
+        self.option  = '--keep-pid'
+        self.option += ' --no-libcall'
+        self.option += ' --agent'
+        self.option += ' -N c'
+        self.exearg = 't-' + self.name
+        record_cmd  = self.runcmd()
+        self.pr_debug("prerun command: " + record_cmd)
+        # bufsize=0 to write characters one by one
+        record_p = sp.Popen(record_cmd.split(), stdin=sp.PIPE, stderr=sp.PIPE, bufsize=0)
+
+        sleep(.05)              # time for the agent to start
+
+        if self.client_send_command(record_p.pid, '-F c@clear') != 0:
+            return TestBase.TEST_NONZERO_RETURN
+        record_p.stdin.write(b'0')
+
+        if self.client_send_command(record_p.pid, '-F b -N c') != 0:
+            return TestBase.TEST_NONZERO_RETURN
+        record_p.stdin.write(b'0')
+
+        if self.client_send_command(record_p.pid, '-F b@clear') != 0:
+            return TestBase.TEST_NONZERO_RETURN
+        record_p.stdin.write(b'0')
+
+        if self.client_send_command(record_p.pid, '-F c@clear') != 0:
+            return TestBase.TEST_NONZERO_RETURN
+        record_p.stdin.write(b'0')
+
+        record_p.stdin.close()
+        record_p.wait()
+
+        return TestBase.TEST_SUCCESS
+
+    def setup(self):
+        self.subcmd = 'replay'
+        self.option = ''
+        self.exearg = ''

--- a/tests/t285_agent_caller_filter.py
+++ b/tests/t285_agent_caller_filter.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+import subprocess as sp
+from time import sleep
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    """Add and remove caller filters at runtime from the agent.
+
+    The target runs a loop, and starts with a caller filter on b(). We add one
+    on c() so all functions appear in the trace. Then we proceed to leave only a
+    caller filter on a() so it appears as a leaf in the trace.
+    """
+
+    def __init__(self):
+        TestBase.__init__(self, 'agent', """
+# DURATION     TID     FUNCTION
+            [ 30262] | main() {
+            [ 30262] |   func() {
+            [ 30262] |     a() {
+   2.092 ms [ 30262] |       b();
+   3.160 ms [ 30262] |     } /* a */
+   3.160 ms [ 30262] |   } /* func */
+            [ 30262] |   func() {
+            [ 30262] |     a() {
+            [ 30262] |       b() {
+   1.075 ms [ 30262] |         c();
+   2.152 ms [ 30262] |       } /* b */
+   3.222 ms [ 30262] |     } /* a */
+   3.223 ms [ 30262] |   } /* func */
+            [ 30262] |   func() {
+            [ 30262] |     a() {
+            [ 30262] |       b() {
+   1.063 ms [ 30262] |         c();
+   2.128 ms [ 30262] |       } /* b */
+   3.200 ms [ 30262] |     } /* a */
+   3.200 ms [ 30262] |   } /* func */
+            [ 30262] |   func() {
+            [ 30262] |     a();
+   3.198 ms [ 30262] |   } /* func */
+  37.973 ms [ 30262] | } /* main */
+""")
+
+
+    def client_send_command(self, pid, option):
+        self.subcmd = 'live'
+        self.option = '-p %d %s' % (pid, option)
+        self.exearg = ''
+        client_cmd = self.runcmd()
+        self.pr_debug('prerun command: ' + client_cmd)
+        client_p = sp.run(client_cmd.split())
+        return client_p.returncode
+
+    def prerun(self, timeout):
+        self.subcmd = 'record'
+        self.option  = '--keep-pid'
+        self.option += ' --no-libcall'
+        self.option += ' --agent'
+        self.option += ' -C b'
+        self.exearg = 't-' + self.name
+        record_cmd  = self.runcmd()
+        self.pr_debug("prerun command: " + record_cmd)
+        # bufsize=0 to write characters one by one
+        record_p = sp.Popen(record_cmd.split(), stdin=sp.PIPE, stderr=sp.PIPE, bufsize=0)
+
+        sleep(.05)              # time for the agent to start
+
+        if self.client_send_command(record_p.pid, '-C c') != 0:
+            return TestBase.TEST_NONZERO_RETURN
+        record_p.stdin.write(b'0')
+
+        if self.client_send_command(record_p.pid, '-C b@clear -C a') != 0:
+            return TestBase.TEST_NONZERO_RETURN
+        record_p.stdin.write(b'0')
+
+        if self.client_send_command(record_p.pid, '-C c@clear') != 0:
+            return TestBase.TEST_NONZERO_RETURN
+        record_p.stdin.write(b'0')
+
+        record_p.stdin.close()
+        record_p.wait()
+
+        return TestBase.TEST_SUCCESS
+
+    def setup(self):
+        self.subcmd = 'replay'
+        self.option = ''
+        self.exearg = ''

--- a/uftrace.h
+++ b/uftrace.h
@@ -464,6 +464,7 @@ enum uftrace_agent_opt {
 	UFTRACE_AGENT_OPT_THRESHOLD = (1U << 2), /* mcount time filter */
 	UFTRACE_AGENT_OPT_PATTERN = (1U << 3), /* pattern match type */
 	UFTRACE_AGENT_OPT_FILTER = (1U << 4), /* tracing filters */
+	UFTRACE_AGENT_OPT_CALLER = (1U << 5), /* tracing caller filters */
 };
 
 extern struct uftrace_session *first_session;

--- a/uftrace.h
+++ b/uftrace.h
@@ -463,6 +463,7 @@ enum uftrace_agent_opt {
 	UFTRACE_AGENT_OPT_DEPTH = (1U << 1), /* mcount depth filter */
 	UFTRACE_AGENT_OPT_THRESHOLD = (1U << 2), /* mcount time filter */
 	UFTRACE_AGENT_OPT_PATTERN = (1U << 3), /* pattern match type */
+	UFTRACE_AGENT_OPT_FILTER = (1U << 4), /* tracing filters */
 };
 
 extern struct uftrace_session *first_session;

--- a/uftrace.h
+++ b/uftrace.h
@@ -462,6 +462,7 @@ enum uftrace_agent_opt {
 	UFTRACE_AGENT_OPT_TRACE = (1U << 0), /* turn tracing on/off */
 	UFTRACE_AGENT_OPT_DEPTH = (1U << 1), /* mcount depth filter */
 	UFTRACE_AGENT_OPT_THRESHOLD = (1U << 2), /* mcount time filter */
+	UFTRACE_AGENT_OPT_PATTERN = (1U << 3), /* pattern match type */
 };
 
 extern struct uftrace_session *first_session;

--- a/utils/auto-args.c
+++ b/utils/auto-args.c
@@ -20,8 +20,8 @@ static struct rb_root auto_argspec = RB_ROOT;
 static struct rb_root auto_retspec = RB_ROOT;
 static struct rb_root auto_enum = RB_ROOT;
 
-extern void add_trigger(struct uftrace_filter *filter, struct uftrace_trigger *tr,
-			bool exact_match);
+extern void update_trigger(struct uftrace_filter *filter, struct uftrace_trigger *tr,
+			   bool exact_match);
 extern int setup_trigger_action(char *str, struct uftrace_trigger *tr, char **module,
 				unsigned long orig_flags, struct uftrace_filter_setting *setting);
 
@@ -41,7 +41,7 @@ static void add_auto_args(struct rb_root *root, struct uftrace_filter *entry,
 
 		cmp = strcmp(iter->name, entry->name);
 		if (cmp == 0) {
-			add_trigger(iter, tr, true);
+			update_trigger(iter, tr, true);
 			return;
 		}
 
@@ -57,7 +57,7 @@ static void add_auto_args(struct rb_root *root, struct uftrace_filter *entry,
 	INIT_LIST_HEAD(&new->args);
 	new->trigger.pargs = &new->args;
 
-	add_trigger(new, tr, true);
+	update_trigger(new, tr, true);
 
 	rb_link_node(&new->node, parent, p);
 	rb_insert_color(&new->node, root);

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -842,7 +842,7 @@ static const struct trigger_action_parser actions[] = {
 	{
 		"clear",
 		parse_clear_action,
-		TRIGGER_FL_FILTER,
+		TRIGGER_FL_FILTER | TRIGGER_FL_CALLER,
 	},
 };
 
@@ -1061,7 +1061,10 @@ static void setup_trigger(char *filter_str, struct uftrace_sym_info *sinfo,
 		}
 
 		if (ret > 0 && (tr.flags & TRIGGER_FL_CALLER)) {
-			triggers->caller_count += ret;
+			if (tr.flags & TRIGGER_FL_CLEAR)
+				triggers->caller_count -= ret;
+			else
+				triggers->caller_count += ret;
 			pr_dbg4("caller filter count: %d\n", triggers->caller_count);
 		}
 

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -917,8 +917,7 @@ static int update_trigger_entry(struct rb_root *root, struct uftrace_pattern *pa
  * @setting - filter settings
  */
 static void setup_trigger(char *filter_str, struct uftrace_sym_info *sinfo, struct rb_root *root,
-			  unsigned long flags, enum filter_mode *fmode, int *count,
-			  struct uftrace_filter_setting *setting)
+			  unsigned long flags, int *count, struct uftrace_filter_setting *setting)
 {
 	struct strv filters = STRV_INIT;
 	char *name;
@@ -1014,11 +1013,9 @@ static void setup_trigger(char *filter_str, struct uftrace_sym_info *sinfo, stru
 			pr_dbg4("filter IN count: %d\n", *count);
 		}
 
-		if (ret > 0 && (tr.flags & TRIGGER_FL_LOC) && fmode) {
+		if (ret > 0 && (tr.flags & TRIGGER_FL_LOC) && count) {
 			if (tr.lmode == FILTER_MODE_IN)
-				*fmode = FILTER_MODE_IN;
-			else if (*fmode == FILTER_MODE_NONE)
-				*fmode = FILTER_MODE_OUT;
+				*count += ret;
 		}
 
 next:
@@ -1046,7 +1043,7 @@ next:
 void uftrace_setup_filter(char *filter_str, struct uftrace_sym_info *sinfo, struct rb_root *root,
 			  int *count, struct uftrace_filter_setting *setting)
 {
-	setup_trigger(filter_str, sinfo, root, TRIGGER_FL_FILTER, NULL, count, setting);
+	setup_trigger(filter_str, sinfo, root, TRIGGER_FL_FILTER, count, setting);
 }
 
 /**
@@ -1060,7 +1057,7 @@ void uftrace_setup_filter(char *filter_str, struct uftrace_sym_info *sinfo, stru
 void uftrace_setup_trigger(char *trigger_str, struct uftrace_sym_info *sinfo, struct rb_root *root,
 			   int *count, struct uftrace_filter_setting *setting)
 {
-	setup_trigger(trigger_str, sinfo, root, 0, NULL, count, setting);
+	setup_trigger(trigger_str, sinfo, root, 0, count, setting);
 }
 
 /**
@@ -1078,7 +1075,7 @@ void uftrace_setup_argument(char *args_str, struct uftrace_sym_info *sinfo, stru
 	if (setting->auto_args)
 		flags |= TRIGGER_FL_AUTO_ARGS;
 
-	setup_trigger(args_str, sinfo, root, flags, NULL, NULL, setting);
+	setup_trigger(args_str, sinfo, root, flags, NULL, setting);
 }
 
 /**
@@ -1096,7 +1093,7 @@ void uftrace_setup_retval(char *retval_str, struct uftrace_sym_info *sinfo, stru
 	if (setting->auto_args)
 		flags |= TRIGGER_FL_AUTO_ARGS;
 
-	setup_trigger(retval_str, sinfo, root, flags, NULL, NULL, setting);
+	setup_trigger(retval_str, sinfo, root, flags, NULL, setting);
 }
 
 /**
@@ -1109,7 +1106,7 @@ void uftrace_setup_retval(char *retval_str, struct uftrace_sym_info *sinfo, stru
 void uftrace_setup_caller_filter(char *filter_str, struct uftrace_sym_info *sinfo,
 				 struct rb_root *root, struct uftrace_filter_setting *setting)
 {
-	setup_trigger(filter_str, sinfo, root, TRIGGER_FL_CALLER, NULL, NULL, setting);
+	setup_trigger(filter_str, sinfo, root, TRIGGER_FL_CALLER, NULL, setting);
 }
 
 /**
@@ -1122,7 +1119,7 @@ void uftrace_setup_caller_filter(char *filter_str, struct uftrace_sym_info *sinf
 void uftrace_setup_hide_filter(char *filter_str, struct uftrace_sym_info *sinfo,
 			       struct rb_root *root, struct uftrace_filter_setting *setting)
 {
-	setup_trigger(filter_str, sinfo, root, TRIGGER_FL_HIDE, NULL, NULL, setting);
+	setup_trigger(filter_str, sinfo, root, TRIGGER_FL_HIDE, NULL, setting);
 }
 
 /**
@@ -1130,14 +1127,14 @@ void uftrace_setup_hide_filter(char *filter_str, struct uftrace_sym_info *sinfo,
  * @filter_str - CSV of filter string
  * @sinfo      - symbol information to find symbol address
  * @root       - root of resulting rbtree
- * @mode       - filter mode: opt-in (-L) or opt-out (-L with '@hide' suffix)
+ * @count      - opt-in loc filter count
  * @setting    - filter settings
  */
 void uftrace_setup_loc_filter(char *filter_str, struct uftrace_sym_info *sinfo,
-			      struct rb_root *root, enum filter_mode *mode,
+			      struct rb_root *root, int *count,
 			      struct uftrace_filter_setting *setting)
 {
-	setup_trigger(filter_str, sinfo, root, TRIGGER_FL_LOC, mode, NULL, setting);
+	setup_trigger(filter_str, sinfo, root, TRIGGER_FL_LOC, count, setting);
 }
 
 /**

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -1252,6 +1252,18 @@ void uftrace_cleanup_filter(struct rb_root *root)
 }
 
 /**
+ * uftrace_cleanup_triggers - delete filters and reset counters
+ * @triggers - triggers info
+ */
+void uftrace_cleanup_triggers(struct mcount_triggers_info *triggers)
+{
+	uftrace_cleanup_filter(&triggers->root);
+	triggers->filter_count = 0;
+	triggers->caller_count = 0;
+	triggers->loc_count = 0;
+}
+
+/**
  * uftrace_print_filter - print all filters in rbtree
  * @root - root of the filter rbtree
  */
@@ -1375,7 +1387,7 @@ TEST_CASE(filter_setup_simple)
 	TEST_EQ(filter->start, 0x6000UL);
 	TEST_EQ(filter->end, 0x6000UL + 0x1000UL);
 
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	pr_dbg("checking unknown symbol\n");
@@ -1430,7 +1442,7 @@ TEST_CASE(filter_setup_regex)
 	TEST_EQ(filter->end, 0x5000UL + 0x1000UL);
 
 	pr_dbg("found 4 symbols. done\n");
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	return TEST_OK;
@@ -1481,7 +1493,7 @@ TEST_CASE(filter_setup_glob)
 	TEST_EQ(filter->end, 0x5000UL + 0x1000UL);
 
 	pr_dbg("found 4 symbols. done\n");
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	return TEST_OK;
@@ -1529,7 +1541,7 @@ TEST_CASE(filter_setup_notrace)
 	TEST_EQ(filter->trigger.flags, TRIGGER_FL_FILTER);
 	TEST_EQ(filter->trigger.fmode, FILTER_MODE_IN);
 
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	return TEST_OK;
@@ -1576,7 +1588,7 @@ TEST_CASE(filter_match)
 	TEST_EQ(uftrace_match_filter(0x2000, &triggers.root, &tr), NULL);
 	TEST_NE(tr.flags, TRIGGER_FL_FILTER);
 
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	return TEST_OK;
@@ -1632,7 +1644,7 @@ TEST_CASE(trigger_setup_actions)
 	TEST_NE(uftrace_match_filter(0x4200, &triggers.root, &tr), NULL);
 	TEST_EQ(tr.flags, TRIGGER_FL_CALLER);
 
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	return TEST_OK;
@@ -1689,7 +1701,7 @@ TEST_CASE(trigger_setup_filters)
 	TEST_NE(uftrace_match_filter(0x5000, &triggers.root, &tr), NULL);
 	TEST_EQ(tr.flags, TRIGGER_FL_CALLER);
 
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	return TEST_OK;
@@ -1897,7 +1909,7 @@ TEST_CASE(trigger_setup_args)
 	}
 	TEST_EQ(count, 4);
 
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	return TEST_OK;
@@ -2026,7 +2038,7 @@ TEST_CASE(locfilter_setup_simple)
 	TEST_EQ(filter->start, 0x2000UL);
 	TEST_EQ(filter->end, 0x2000UL + 0x1000UL);
 
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	pr_dbg("checking base name match\n");
@@ -2038,7 +2050,7 @@ TEST_CASE(locfilter_setup_simple)
 	TEST_STREQ(filter->name, "command_dump");
 	TEST_EQ(filter->start, 0x1000UL);
 	TEST_EQ(filter->end, 0x1000UL + 0x1000UL);
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	pr_dbg("checking unknown symbol\n");
@@ -2089,7 +2101,7 @@ TEST_CASE(locfilter_setup_regex)
 	TEST_EQ(rb_next(node), NULL);
 
 	pr_dbg("found 3 symbols. done\n");
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	return TEST_OK;
@@ -2136,7 +2148,7 @@ TEST_CASE(locfilter_setup_glob)
 	TEST_EQ(rb_next(node), NULL);
 
 	pr_dbg("found 3 symbols. done\n");
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	return TEST_OK;
@@ -2184,7 +2196,7 @@ TEST_CASE(locfilter_setup_dir_simple)
 	TEST_EQ(rb_next(node), NULL);
 
 	pr_dbg("found 3 symbols. done\n");
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	pr_dbg("try to match directory with pattern: /cmds\n");
@@ -2202,7 +2214,7 @@ TEST_CASE(locfilter_setup_dir_simple)
 	TEST_EQ(node = rb_next(node), NULL);
 
 	pr_dbg("found 3 symbols. done\n");
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	pr_dbg("try to match directory with pattern: cmds/\n");
@@ -2220,7 +2232,7 @@ TEST_CASE(locfilter_setup_dir_simple)
 	TEST_EQ(node = rb_next(node), NULL);
 
 	pr_dbg("found 3 symbols. done\n");
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	pr_dbg("try to match directory with pattern: /uftrace/cmds/\n");
@@ -2238,7 +2250,7 @@ TEST_CASE(locfilter_setup_dir_simple)
 	TEST_EQ(node = rb_next(node), NULL);
 
 	pr_dbg("found 3 symbols. done\n");
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	pr_dbg("try to match directory with pattern: uftrace/cmds/\n");
@@ -2256,7 +2268,7 @@ TEST_CASE(locfilter_setup_dir_simple)
 	TEST_EQ(node = rb_next(node), NULL);
 
 	pr_dbg("found 3 symbols. done\n");
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	pr_dbg("try to match directory with pattern: /uftrace\n");
@@ -2300,7 +2312,7 @@ TEST_CASE(locfilter_setup_dir_simple)
 	TEST_EQ(filter->end, 0xb000UL + 0x1000UL);
 
 	pr_dbg("found 6 symbols. done\n");
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	pr_dbg("checking invalid directory match\n");
@@ -2351,7 +2363,7 @@ TEST_CASE(locfilter_setup_dir_regex)
 	TEST_EQ(rb_next(node), NULL);
 
 	pr_dbg("found 3 symbols. done\n");
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	pr_dbg("checking invalid directory match\n");
@@ -2402,7 +2414,7 @@ TEST_CASE(locfilter_setup_dir_glob)
 	TEST_EQ(rb_next(node), NULL);
 
 	pr_dbg("found 3 symbols. done\n");
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	return TEST_OK;
@@ -2449,7 +2461,7 @@ TEST_CASE(locfilter_match)
 	TEST_EQ(uftrace_match_filter(0xa000, &triggers.root, &tr), NULL);
 	TEST_NE(tr.flags, TRIGGER_FL_FILTER);
 
-	uftrace_cleanup_filter(&triggers.root);
+	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
 
 	return TEST_OK;

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -118,25 +118,31 @@ struct uftrace_filter_setting {
 typedef void (*trigger_fn_t)(struct uftrace_trigger *tr, void *arg);
 
 struct uftrace_sym_info;
+struct mcount_triggers_info;
 
-void uftrace_setup_filter(char *filter_str, struct uftrace_sym_info *sinfo, struct rb_root *root,
-			  int *count, struct uftrace_filter_setting *setting);
-void uftrace_setup_trigger(char *trigger_str, struct uftrace_sym_info *sinfo, struct rb_root *root,
-			   int *count, struct uftrace_filter_setting *setting);
-void uftrace_setup_argument(char *trigger_str, struct uftrace_sym_info *sinfo, struct rb_root *root,
+void uftrace_setup_filter(char *filter_str, struct uftrace_sym_info *sinfo,
+			  struct mcount_triggers_info *triggers,
+			  struct uftrace_filter_setting *setting);
+void uftrace_setup_trigger(char *trigger_str, struct uftrace_sym_info *sinfo,
+			   struct mcount_triggers_info *triggers,
+			   struct uftrace_filter_setting *setting);
+void uftrace_setup_argument(char *args_str, struct uftrace_sym_info *sinfo,
+			    struct mcount_triggers_info *triggers,
 			    struct uftrace_filter_setting *setting);
-void uftrace_setup_retval(char *trigger_str, struct uftrace_sym_info *sinfo, struct rb_root *root,
+void uftrace_setup_retval(char *retval_str, struct uftrace_sym_info *sinfo,
+			  struct mcount_triggers_info *triggers,
 			  struct uftrace_filter_setting *setting);
 void uftrace_setup_caller_filter(char *filter_str, struct uftrace_sym_info *sinfo,
-				 struct rb_root *root, int *count,
+				 struct mcount_triggers_info *triggers,
 				 struct uftrace_filter_setting *setting);
 void uftrace_setup_hide_filter(char *filter_str, struct uftrace_sym_info *sinfo,
-			       struct rb_root *root, struct uftrace_filter_setting *setting);
+			       struct mcount_triggers_info *triggers,
+			       struct uftrace_filter_setting *setting);
 void uftrace_setup_loc_filter(char *filter_str, struct uftrace_sym_info *sinfo,
-			      struct rb_root *root, int *count,
+			      struct mcount_triggers_info *triggers,
 			      struct uftrace_filter_setting *setting);
 
-struct rb_root uftrace_deep_copy_triggers(struct rb_root *src);
+struct mcount_triggers_info uftrace_deep_copy_triggers(struct mcount_triggers_info *src);
 struct uftrace_filter *uftrace_match_filter(uint64_t ip, struct rb_root *root,
 					    struct uftrace_trigger *tr);
 void uftrace_cleanup_filter(struct rb_root *root);

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -128,7 +128,8 @@ void uftrace_setup_argument(char *trigger_str, struct uftrace_sym_info *sinfo, s
 void uftrace_setup_retval(char *trigger_str, struct uftrace_sym_info *sinfo, struct rb_root *root,
 			  struct uftrace_filter_setting *setting);
 void uftrace_setup_caller_filter(char *filter_str, struct uftrace_sym_info *sinfo,
-				 struct rb_root *root, struct uftrace_filter_setting *setting);
+				 struct rb_root *root, int *count,
+				 struct uftrace_filter_setting *setting);
 void uftrace_setup_hide_filter(char *filter_str, struct uftrace_sym_info *sinfo,
 			       struct rb_root *root, struct uftrace_filter_setting *setting);
 void uftrace_setup_loc_filter(char *filter_str, struct uftrace_sym_info *sinfo,

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -38,6 +38,7 @@ enum trigger_flag {
 	TRIGGER_FL_HIDE = (1U << 17),
 	TRIGGER_FL_LOC = (1U << 18),
 	TRIGGER_FL_SIZE_FILTER = (1U << 19),
+	TRIGGER_FL_CLEAR = (1U << 20), /* Reverse other flags when set */
 };
 
 /**

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -146,6 +146,7 @@ struct mcount_triggers_info uftrace_deep_copy_triggers(struct mcount_triggers_in
 struct uftrace_filter *uftrace_match_filter(uint64_t ip, struct rb_root *root,
 					    struct uftrace_trigger *tr);
 void uftrace_cleanup_filter(struct rb_root *root);
+void uftrace_cleanup_triggers(struct mcount_triggers_info *triggers);
 void uftrace_print_filter(struct rb_root *root);
 int uftrace_count_filter(struct rb_root *root, unsigned long flag);
 

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -132,7 +132,7 @@ void uftrace_setup_caller_filter(char *filter_str, struct uftrace_sym_info *sinf
 void uftrace_setup_hide_filter(char *filter_str, struct uftrace_sym_info *sinfo,
 			       struct rb_root *root, struct uftrace_filter_setting *setting);
 void uftrace_setup_loc_filter(char *filter_str, struct uftrace_sym_info *sinfo,
-			      struct rb_root *root, enum filter_mode *mode,
+			      struct rb_root *root, int *count,
 			      struct uftrace_filter_setting *setting);
 
 struct rb_root uftrace_deep_copy_triggers(struct rb_root *src);

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -40,6 +40,15 @@ enum trigger_flag {
 	TRIGGER_FL_SIZE_FILTER = (1U << 19),
 };
 
+/**
+ * filter_mode - opt-in or opt-out mode
+ *
+ * When in opt-in mode, only trace functions that have an explicit filter. When
+ * in opt-out mode, trace all but explicitly excluded functions.
+
+ * @FILTER_MODE_NONE is neutral and is only used for initialization in the
+ * location filter.
+ */
 enum filter_mode {
 	FILTER_MODE_NONE,
 	FILTER_MODE_IN,
@@ -111,9 +120,9 @@ typedef void (*trigger_fn_t)(struct uftrace_trigger *tr, void *arg);
 struct uftrace_sym_info;
 
 void uftrace_setup_filter(char *filter_str, struct uftrace_sym_info *sinfo, struct rb_root *root,
-			  enum filter_mode *mode, struct uftrace_filter_setting *setting);
+			  int *count, struct uftrace_filter_setting *setting);
 void uftrace_setup_trigger(char *trigger_str, struct uftrace_sym_info *sinfo, struct rb_root *root,
-			   enum filter_mode *mode, struct uftrace_filter_setting *setting);
+			   int *count, struct uftrace_filter_setting *setting);
 void uftrace_setup_argument(char *trigger_str, struct uftrace_sym_info *sinfo, struct rb_root *root,
 			    struct uftrace_filter_setting *setting);
 void uftrace_setup_retval(char *trigger_str, struct uftrace_sym_info *sinfo, struct rb_root *root,

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -21,17 +21,18 @@
 bool fstack_enabled = true;
 bool live_disabled = false;
 
-static int fstack_filter_count;
-static int fstack_loc_count;
+static struct mcount_triggers_info fstack_triggers;
 
 static inline int fstack_get_filter_mode()
 {
-	return fstack_filter_count > 0 ? FILTER_MODE_IN : FILTER_MODE_OUT;
+	int filter_count = fstack_triggers.filter_count;
+	return filter_count > 0 ? FILTER_MODE_IN : FILTER_MODE_OUT;
 }
 
 static inline int fstack_get_loc_mode()
 {
-	return fstack_loc_count > 0 ? FILTER_MODE_IN : FILTER_MODE_OUT;
+	int loc_count = fstack_triggers.loc_count;
+	return loc_count > 0 ? FILTER_MODE_IN : FILTER_MODE_OUT;
 }
 
 static int __read_task_ustack(struct uftrace_task_reader *task);
@@ -227,43 +228,67 @@ setup:
 static int setup_filters(struct uftrace_session *s, void *arg)
 {
 	struct uftrace_filter_setting *setting = arg;
+	struct mcount_triggers_info triggers = {
+		.root = s->filters,
+		.filter_count = 0,
+	};
 
-	uftrace_setup_filter(setting->info_str, &s->sym_info, &s->filters, &fstack_filter_count,
-			     setting);
+	uftrace_setup_filter(setting->info_str, &s->sym_info, &triggers, setting);
+	s->filters = triggers.root;
+	fstack_triggers.filter_count = triggers.filter_count;
 	return 0;
 }
 
 static int setup_trigger(struct uftrace_session *s, void *arg)
 {
 	struct uftrace_filter_setting *setting = arg;
+	struct mcount_triggers_info triggers = {
+		.root = s->filters,
+	};
 
-	uftrace_setup_trigger(setting->info_str, &s->sym_info, &s->filters, &fstack_filter_count,
-			      setting);
+	uftrace_setup_trigger(setting->info_str, &s->sym_info, &triggers, setting);
+	s->filters = triggers.root;
 	return 0;
 }
 
 static int setup_callers(struct uftrace_session *s, void *arg)
 {
 	struct uftrace_filter_setting *setting = arg;
+	struct mcount_triggers_info triggers = {
+		.root = s->filters,
+		.filter_count = 0,
+	};
 
-	uftrace_setup_caller_filter(setting->info_str, &s->sym_info, &s->filters, NULL, setting);
+	uftrace_setup_caller_filter(setting->info_str, &s->sym_info, &triggers, setting);
+	s->filters = triggers.root;
+	fstack_triggers.caller_count = triggers.caller_count;
 	return 0;
 }
 
 static int setup_hides(struct uftrace_session *s, void *arg)
 {
 	struct uftrace_filter_setting *setting = arg;
+	struct mcount_triggers_info triggers = {
+		.root = s->filters,
+	};
 
-	uftrace_setup_hide_filter(setting->info_str, &s->sym_info, &s->filters, setting);
+	uftrace_setup_hide_filter(setting->info_str, &s->sym_info, &triggers, setting);
+	s->filters = triggers.root;
+	fstack_triggers.loc_count = triggers.loc_count;
 	return 0;
 }
 
 static int setup_locs(struct uftrace_session *s, void *arg)
 {
 	struct uftrace_filter_setting *setting = arg;
+	struct mcount_triggers_info triggers = {
+		.root = s->filters,
+		.loc_count = 0,
+	};
 
-	uftrace_setup_loc_filter(setting->info_str, &s->sym_info, &s->filters, &fstack_loc_count,
-				 setting);
+	uftrace_setup_loc_filter(setting->info_str, &s->sym_info, &triggers, setting);
+	s->filters = triggers.root;
+	fstack_triggers.loc_count = triggers.loc_count;
 	return 0;
 }
 
@@ -406,13 +431,16 @@ static int build_fixup_filter(struct uftrace_session *s, void *arg)
 		.ptype = PATT_SIMPLE,
 		.auto_args = false,
 	};
+	struct mcount_triggers_info fixups = {
+		.root = s->fixups,
+	};
 
 	pr_dbg("fixup for some special functions\n");
 
 	for (i = 0; i < ARRAY_SIZE(fixup_syms); i++) {
-		uftrace_setup_trigger((char *)fixup_syms[i], &s->sym_info, &s->fixups, NULL,
-				      &setting);
+		uftrace_setup_trigger((char *)fixup_syms[i], &s->sym_info, &fixups, &setting);
 	}
+	s->fixups = fixups.root;
 	return 0;
 }
 
@@ -431,9 +459,14 @@ static void fstack_prepare_fixup(struct uftrace_data *handle)
 static int build_arg_spec(struct uftrace_session *s, void *arg)
 {
 	struct uftrace_filter_setting *setting = arg;
+	struct mcount_triggers_info triggers = {
+		.root = s->filters,
+	};
 
-	if (setting->info_str)
-		uftrace_setup_argument(setting->info_str, &s->sym_info, &s->filters, setting);
+	if (setting->info_str) {
+		uftrace_setup_argument(setting->info_str, &s->sym_info, &triggers, setting);
+		s->filters = triggers.root;
+	}
 
 	return 0;
 }
@@ -441,9 +474,14 @@ static int build_arg_spec(struct uftrace_session *s, void *arg)
 static int build_ret_spec(struct uftrace_session *s, void *arg)
 {
 	struct uftrace_filter_setting *setting = arg;
+	struct mcount_triggers_info triggers = {
+		.root = s->filters,
+	};
 
-	if (setting->info_str)
-		uftrace_setup_retval(setting->info_str, &s->sym_info, &s->filters, setting);
+	if (setting->info_str) {
+		uftrace_setup_retval(setting->info_str, &s->sym_info, &triggers, setting);
+		s->filters = triggers.root;
+	}
 
 	return 0;
 }
@@ -665,7 +703,7 @@ int fstack_entry(struct uftrace_task_reader *task, struct uftrace_record *rstack
 		}
 	}
 	else {
-		if (fstack_get_loc_mode() == FILTER_MODE_IN) {
+		if (fstack_get_loc_mode(&sess->filters) == FILTER_MODE_IN) {
 			fstack->flags |= FSTACK_FL_NORECORD;
 			return -1;
 		}
@@ -848,8 +886,8 @@ static int fstack_check_skip(struct uftrace_task_reader *task, struct uftrace_re
 		if (tr.fmode == FILTER_MODE_OUT)
 			return -1;
 	}
-	else if ((fstack_get_filter_mode() == FILTER_MODE_IN ||
-		  fstack_get_loc_mode() == FILTER_MODE_IN) &&
+	else if ((fstack_get_filter_mode(&sess->filters) == FILTER_MODE_IN ||
+		  fstack_get_loc_mode(&sess->filters) == FILTER_MODE_IN) &&
 		 task->filter.in_count == 0) {
 		return -1;
 	}
@@ -986,7 +1024,8 @@ bool fstack_check_filter(struct uftrace_task_reader *task)
 	else if (task->rstack->type == UFTRACE_EVENT) {
 		/* don't change filter state, just check it */
 		if (task->filter.out_count > 0 || task->filter.depth <= 0 ||
-		    (fstack_get_filter_mode() == FILTER_MODE_IN && task->filter.in_count == 0))
+		    (fstack_get_filter_mode(&fstack_triggers) == FILTER_MODE_IN &&
+		     task->filter.in_count == 0))
 			return false;
 
 		if (task->rstack->addr == EVENT_ID_PERF_SCHED_IN ||

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -246,7 +246,7 @@ static int setup_callers(struct uftrace_session *s, void *arg)
 {
 	struct uftrace_filter_setting *setting = arg;
 
-	uftrace_setup_caller_filter(setting->info_str, &s->sym_info, &s->filters, setting);
+	uftrace_setup_caller_filter(setting->info_str, &s->sym_info, &s->filters, NULL, setting);
 	return 0;
 }
 

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -22,11 +22,16 @@ bool fstack_enabled = true;
 bool live_disabled = false;
 
 static int fstack_filter_count;
-static enum filter_mode fstack_loc_mode = FILTER_MODE_NONE;
+static int fstack_loc_count;
 
 static inline int fstack_get_filter_mode()
 {
 	return fstack_filter_count > 0 ? FILTER_MODE_IN : FILTER_MODE_OUT;
+}
+
+static inline int fstack_get_loc_mode()
+{
+	return fstack_loc_count > 0 ? FILTER_MODE_IN : FILTER_MODE_OUT;
 }
 
 static int __read_task_ustack(struct uftrace_task_reader *task);
@@ -257,7 +262,7 @@ static int setup_locs(struct uftrace_session *s, void *arg)
 {
 	struct uftrace_filter_setting *setting = arg;
 
-	uftrace_setup_loc_filter(setting->info_str, &s->sym_info, &s->filters, &fstack_loc_mode,
+	uftrace_setup_loc_filter(setting->info_str, &s->sym_info, &s->filters, &fstack_loc_count,
 				 setting);
 	return 0;
 }
@@ -660,7 +665,7 @@ int fstack_entry(struct uftrace_task_reader *task, struct uftrace_record *rstack
 		}
 	}
 	else {
-		if (fstack_loc_mode == FILTER_MODE_IN) {
+		if (fstack_get_loc_mode() == FILTER_MODE_IN) {
 			fstack->flags |= FSTACK_FL_NORECORD;
 			return -1;
 		}
@@ -844,7 +849,7 @@ static int fstack_check_skip(struct uftrace_task_reader *task, struct uftrace_re
 			return -1;
 	}
 	else if ((fstack_get_filter_mode() == FILTER_MODE_IN ||
-		  fstack_loc_mode == FILTER_MODE_IN) &&
+		  fstack_get_loc_mode() == FILTER_MODE_IN) &&
 		 task->filter.in_count == 0) {
 		return -1;
 	}


### PR DESCRIPTION
These commits give the user full control over tracing filters at runtime. It
applies to the following filters:
 - opt-in filters set by `-F/--filter`
 - opt-out filters set by `-N/--notrace`
 - caller filters set by `-C/--caller-filter`

It allows the user to control the target process from the client as follows:
 - add or update an opt-in name filter
   - `$ uftrace -p PID -F func`
 - add or update an opt-out name filter
   - `$ uftrace -p PID -N func`
 - remove an opt-in or opt-out name filter
   - `$ uftrace -p PID -F func@clear`
 - add a caller filter
   - `$ uftrace -p PID -C func`
 - delete a caller filter
   - `$ uftrace -p PID -C func@clear`
 - set the pattern matching type
   - `$ uftrace -p PID --match <simple|regex|glob>`


 We also introduce an internal agent command `AGENT_CAPABILITIES`. It prompts
 the agent to indicate what features it supports.