### PR TITLE
Control triggers at runtime

### DIFF
--- a/cmds/live.c
+++ b/cmds/live.c
@@ -360,7 +360,8 @@ static int forward_options(struct uftrace_opts *opts)
 			goto close;
 	}
 
-	if (opts->filter || opts->caller) { /* provide a pattern type for options that need it */
+	/* provide a pattern type for options that need it */
+	if (opts->filter || opts->caller || opts->trigger) {
 		status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_PATTERN,
 					&opts->patt_type, sizeof(opts->patt_type));
 		if (status < 0)
@@ -377,6 +378,13 @@ static int forward_options(struct uftrace_opts *opts)
 	if (opts->caller) {
 		status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_CALLER, opts->caller,
 					strlen(opts->caller) + 1);
+		if (status < 0)
+			goto close;
+	}
+
+	if (opts->trigger) {
+		status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_TRIGGER, opts->trigger,
+					strlen(opts->trigger) + 1);
 		if (status < 0)
 			goto close;
 	}

--- a/tests/t286_agent_trigger.py
+++ b/tests/t286_agent_trigger.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+import subprocess as sp
+from time import sleep
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    """Add and remove triggers at runtime from the client.
+
+    The target runs a loop and waits for input from this script. The agent is
+    enabled. Calls to a(), b() and c() include a sleep period so we can test time
+    filters.
+
+    The client adds then removes a depth filter. Then adds a time filter. And
+    adds then removes an opt-out filter. """
+
+    def __init__(self):
+        TestBase.__init__(self, 'agent', """
+# DURATION     TID     FUNCTION
+            [  6999] | main() {
+            [  6999] |   func() {
+            [  6999] |     a() {
+            [  6999] |       b() {
+   1.056 ms [  6999] |         c();
+   2.113 ms [  6999] |       } /* b */
+   3.175 ms [  6999] |     } /* a */
+   3.175 ms [  6999] |   } /* func */
+            [  6999] |   func() {
+            [  6999] |     a() {
+   2.110 ms [  6999] |       b();
+   3.181 ms [  6999] |     } /* a */
+   3.182 ms [  6999] |   } /* func */
+            [  6999] |   func() {
+   3.178 ms [  6999] |     a();
+   3.179 ms [  6999] |   } /* func */
+   3.177 ms [  6999] |   func();
+            [  6999] |   func() {
+            [  6999] |     a() {
+            [  6999] |       b() {
+   1.057 ms [  6999] |         c();
+   2.119 ms [  6999] |       } /* b */
+   3.185 ms [  6999] |     } /* a */
+   3.185 ms [  6999] |   } /* func */
+  55.835 ms [  6999] | } /* main */
+""")
+
+
+    def client_send_command(self, pid, option):
+        self.subcmd = 'live'
+        self.option = '-p %d %s' % (pid, option)
+        self.exearg = ''
+        client_cmd = self.runcmd()
+        self.pr_debug('prerun command: ' + client_cmd)
+        client_p = sp.run(client_cmd.split())
+        return client_p.returncode
+
+    def prerun(self, timeout):
+        self.subcmd = 'record'
+        self.option  = '--keep-pid'
+        self.option += ' --no-libcall'
+        self.option += ' --agent'
+        self.exearg  = 't-' + self.name
+        self.exearg += ' --delay'
+        record_cmd  = self.runcmd()
+        self.pr_debug("prerun command: " + record_cmd)
+        # bufsize=0 to write characters one by one
+        record_p = sp.Popen(record_cmd.split(), stdin=sp.PIPE, stderr=sp.PIPE, bufsize=0)
+
+        sleep(.05)              # time for the agent to start
+
+        if self.client_send_command(record_p.pid, '-T func@depth=3') != 0:
+            return TestBase.TEST_NONZERO_RETURN
+        record_p.stdin.write(b'0')
+
+        if self.client_send_command(record_p.pid, '-T func@clear=depth,time=3ms') != 0:
+            return TestBase.TEST_NONZERO_RETURN
+        record_p.stdin.write(b'0')
+
+        if self.client_send_command(record_p.pid, '-T a@notrace') != 0:
+            return TestBase.TEST_NONZERO_RETURN
+        record_p.stdin.write(b'0')
+
+        if self.client_send_command(record_p.pid, '-T a@clear -T func@clear') != 0:
+            return TestBase.TEST_NONZERO_RETURN
+        record_p.stdin.write(b'0')
+
+        record_p.stdin.close()
+        record_p.wait()
+
+        return TestBase.TEST_SUCCESS
+
+    def setup(self):
+        self.subcmd = 'replay'
+        self.option = ''
+        self.exearg = ''

--- a/uftrace.c
+++ b/uftrace.c
@@ -258,6 +258,7 @@ static const struct option uftrace_options[] = {
 	REQ_ARG(time-filter, 't'),
 	REQ_ARG(caller-filter, 'C'),
 	REQ_ARG(argument, 'A'),
+	REQ_ARG(trigger, 'T'),
 	REQ_ARG(retval, 'R'),
 	NO_ARG(auto-args, 'a'),
 	NO_ARG(no-args, OPT_no_args),

--- a/uftrace.h
+++ b/uftrace.h
@@ -465,6 +465,7 @@ enum uftrace_agent_opt {
 	UFTRACE_AGENT_OPT_PATTERN = (1U << 3), /* pattern match type */
 	UFTRACE_AGENT_OPT_FILTER = (1U << 4), /* tracing filters */
 	UFTRACE_AGENT_OPT_CALLER = (1U << 5), /* tracing caller filters */
+	UFTRACE_AGENT_OPT_TRIGGER = (1U << 6), /* tracing trigger actions */
 };
 
 extern struct uftrace_session *first_session;

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -755,7 +755,7 @@ struct trigger_action_parser {
 	const char *name;
 	int (*parse)(char *action, struct uftrace_trigger *tr,
 		     struct uftrace_filter_setting *setting);
-	unsigned long flags;
+	enum trigger_flag compat_flags; /* flags the action is restricted to */
 };
 
 static const struct trigger_action_parser actions[] = {
@@ -871,7 +871,7 @@ int setup_trigger_action(char *str, struct uftrace_trigger *tr, char **module,
 			if (strncasecmp(pos, action->name, strlen(action->name)))
 				continue;
 
-			if (orig_flags && !(orig_flags & action->flags))
+			if (orig_flags && !(orig_flags & action->compat_flags))
 				break; /* ignore incompatible actions */
 
 			if (action->parse(pos, tr, setting) < 0)

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -67,6 +67,7 @@ enum trigger_read_type {
 
 struct uftrace_trigger {
 	enum trigger_flag flags;
+	enum trigger_flag clear_flags;
 	int depth;
 	char color;
 	uint64_t time;


### PR DESCRIPTION
These commits give the user full control over triggers at runtime. It applies to
all actions.

It allows the user to control the target process from the client as follows:
 - add or update trigger actions
   - `$ uftrace -p PID -T func@act1[,act2]`
 - delete one or more trigger actions
   - `$ uftrace -p PID -T func@act1[,act2],clear`
 - delete all trigger actions for a symbol
   - `$ uftrace -p PID -T func@clear`

Trigger parameters can be omitted when deleting actions. For example:
- `$ uftrace -p PID -T func@depth,clear`
- `$ uftrace -p PID -T func@time,read,clear`

We also fix the `--trigger` option which was actually not implemented.

Based on #1645.