### PR TITLE
Allow customizing the bash completions dir for system-RPM installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ libdir = $(prefix)/lib/uftrace
 etcdir = $(prefix)/etc
 mandir = $(prefix)/share/man
 docdir = $(srcdir)/doc
+completiondir = $(etcdir)/bash_completion.d
 
 ifeq ($(DOCLANG), ko)
   docdir = $(srcdir)/doc/ko
@@ -361,7 +362,7 @@ endif
 install: all
 	$(Q)$(INSTALL) -d -m 755 $(DESTDIR)$(bindir)
 	$(Q)$(INSTALL) -d -m 755 $(DESTDIR)$(libdir)
-	$(Q)$(INSTALL) -d -m 755 $(DESTDIR)$(etcdir)/bash_completion.d
+	$(Q)$(INSTALL) -d -m 755 $(DESTDIR)$(completiondir)
 ifneq ($(wildcard $(elfdir)/lib/libelf.so),)
 ifeq ($(wildcard $(prefix)/lib/libelf.so),)
 	# install libelf only when it's not in the install directory.
@@ -383,7 +384,7 @@ ifneq ($(findstring HAVE_LIBPYTHON, $(COMMON_CFLAGS)), )
 	$(Q)$(INSTALL) $(objdir)/python/uftrace_python.so  $(DESTDIR)$(libdir)/uftrace_python.so
 endif
 	$(call QUIET_INSTALL, bash-completion)
-	$(Q)$(INSTALL) -m 644 $(srcdir)/misc/bash-completion.sh $(DESTDIR)$(etcdir)/bash_completion.d/uftrace
+	$(Q)$(INSTALL) -m 644 $(srcdir)/misc/bash-completion.sh $(DESTDIR)$(completiondir)/uftrace
 	@$(MAKE) -sC $(docdir) install DESTDIR=$(DESTDIR)$(mandir)
 	@if [ `id -u` = 0 ]; then ldconfig $(DESTDIR)$(libdir) || echo "ldconfig failed"; fi
 
@@ -406,7 +407,7 @@ ifneq ($(findstring HAVE_LIBPYTHON, $(COMMON_CFLAGS)), )
 	$(Q)$(RM) $(DESTDIR)$(libdir)/uftrace_python.so
 endif
 	$(call QUIET_UNINSTALL, bash-completion)
-	$(Q)$(RM) $(DESTDIR)$(etcdir)/bash_completion.d/uftrace
+	$(Q)$(RM) $(DESTDIR)$(completiondir)/uftrace
 	@$(MAKE) -sC $(docdir) uninstall DESTDIR=$(DESTDIR)$(mandir)
 
 test: all


### PR DESCRIPTION
@namhyung :

Fedora packaging dictates that `/etc` is dedicated for bash completions installed and managed by the system admin and bash completions installed by the packages shall live in `/usr/share` (referenced by `%{_datadir}`)

Support packaging for distros by using a common variable at all locations where we install the bash completions script, which distribution packages can override.