### PR TITLE
Catch IndexError from self.sort in test/runtest.py

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -626,8 +626,12 @@ class TestBase:
             timed_out = True
         signal.alarm(0)
 
-        result_expect = self.sort(self.result)
-        result_tested = self.sort(result_origin)  # for python3
+        try:
+            result_tested = self.sort(result_origin)  # for python3, mail fail!
+            result_expect = self.sort(self.result)
+        except IndexError:
+            result_tested = result_origin
+            result_expect = self.result
 
         # strip trailing whitespace for each line.
         result_expect = '\n'.join([line.rstrip() for line in result_expect.split('\n')])
@@ -656,8 +660,11 @@ class TestBase:
             return TestBase.TEST_DIFF_RESULT, dif
 
         if result_expect != result_tested:
-            result_expect = self.sort(self.fixup(cflags, self.result))
-            ret = TestBase.TEST_SUCCESS_FIXED
+            try:
+                result_expect = self.sort(self.fixup(cflags, self.result))
+                ret = TestBase.TEST_SUCCESS_FIXED
+            except IndexError:
+                return TestBase.TEST_DIFF_RESULT, "Internal error: Expected more results"
 
         if result_expect != result_tested:
             if diff:


### PR DESCRIPTION
@namhyung :

When packaging `uftrace` for Fedora using the Copr build service, I enabled running the test suite for checking the build.

I found that on some CentOS 8 build targets, a few tests caused `test/runtest.py` to crash because they referenced an `variable[1]` without first checking if `variable[1]` can be indexed.

Catch this exception in runtest.py and (hopefully) handle it correctly as a diff in the test case result.