### PR TITLE
aarch64/runtest.py: Fix tests where gcc/clang emits memcpy()

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -300,6 +300,13 @@ class TestBase:
         if '-P' in self.option:
             self.p_flag = ''
 
+        # On aarch64, gcc and clang emit calls to memcpy() to pass and return structs.
+        # This depends on a number of factors (gcc, clang, size and optimisation levels).
+        # For now, it affects all tests tracing s-arg.c:pass() and return.c:return_large().
+        # Any test can be affected by it and it may change from compiler to compiler.
+        # To prevent inconsistencies, filter all calls to memcpy() for all tests:
+        self.option += ' -N memcpy'
+
         return '%s %s %s %s %s %s' % (TestBase.uftrace_cmd, self.subcmd, \
                                    TestBase.default_opt, self.p_flag, self.option, self.exearg)
 

--- a/tests/t002_argument.py
+++ b/tests/t002_argument.py
@@ -24,7 +24,3 @@ class TestCase(TestBase):
    0.427 us [16325] |   } /* pass */
   42.161 us [16325] | } /* main */
 """)
-
-    def setup(self):
-        # to avoid unexpected memcpy in aarch64
-        self.option = '-N memcpy '

--- a/tests/t051_return.py
+++ b/tests/t051_return.py
@@ -14,7 +14,3 @@ class TestCase(TestBase):
    0.157 us [12703] |   return_long_double();
    4.097 us [12703] | } /* main */
 """)
-
-    def setup(self):
-        # to avoid unexpected memcpy in aarch64
-        self.option = '-N memcpy '


### PR DESCRIPTION
This fixes about a dozen test case failures using the s-arg.c and s-return.c files on aarch64:

On aarch64 (depending on a number of factors including size and optimisation level) gcc and clang use `memcpy()` to pass and `return` big `structs` to and from function calls.

For large 4k returns, `gcc` may emit `memcpy()` for all optimization level, while for other smaller structs, gcc and clang may emit memcpy() this only for lower optimisation levels.
For smaller structs, gcc and clang may emit memcpy() only    for lower optimisation levels.
In additon, it may change from one compiler version to the next.

It affects all tests tracing s-arg.c:pass() / return.c:return_large()

Two test cases did already filter memcpy(), but about a dozen other test failures were caused by unexpected memcpy() in the output.

Because emitting memcpy varies by different factors and can change from compiler to compiler, pass -N memcpy to exclude it from all traces.

memcpy() is not not expected in any test output yet, so the change to suppress memcpy is limited to tests/runtest.py.