### PR TITLE
doc/uftrace-live.md and doc/uftrace-record.md: Update -P FUNC: regex/glob

### DIFF
--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -103,7 +103,10 @@ RECORD OPTIONS
 
 -P *FUNC*, \--patch=*FUNC*
 :   Patch FUNC dynamically.  This is only applicable binaries built by
-    gcc with `-pg -mfentry -mnop-mcount` or clang with `-fxray-instrument`.
+    gcc with `-pg`, `-mfentry`, `-mnop-mcount` or by clang with `-fxray-instrument`.
+    By default, *FUNC* is a regex. For example `-P.` matches every function to patch
+    every function in the program, so it is a quick shorthand to patch all functions.
+    Alternativley, `--match=glob` can be used to to switch to wildcard-based function matching.
     This option can be used more than once.  See *DYNAMIC TRACING*.
 
 -U *FUNC*, \--unpatch=*FUNC*

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -32,8 +32,12 @@ RECORD OPTIONS
     Implies \--srcline.  See *ARGUMENTS*.
 
 -P *FUNC*, \--patch=*FUNC*
-:   Patch FUNC dynamically.  This option can be used more than once.
-    See *DYNAMIC TRACING*.
+:   Patch FUNC dynamically.  This is only applicable binaries built by
+    gcc with `-pg`, `-mfentry`, `-mnop-mcount` or by clang with `-fxray-instrument`.
+    By default, *FUNC* is a regex. For example `-P.` matches every function to patch
+    every function in the program, so it is a quick shorthand to patch all functions.
+    Alternativley, `--match=glob` can be used to to switch to wildcard-based function matching.
+    This option can be used more than once.  See *DYNAMIC TRACING* for details.
 
 -U *FUNC*, \--unpatch=*FUNC*
 :   Do not apply dynamic patching for FUNC.  This option can be used more than once.


### PR DESCRIPTION
As mentioned in https://github.com/namhyung/uftrace/pull/1653#discussion_r1151424388 add that in -P *FUNC*, *FUNC* is actually a regular expression, and that it can be switched to using wildcards using --match=glob:

```ecmarkdown
 -P *FUNC*, \--patch=*FUNC*
 :   Patch FUNC dynamically.  This is only applicable binaries built by
    gcc with `-pg`, `-mfentry`, `-mnop-mcount` or by clang with `-fxray-instrument`.
    By default, *FUNC* is a regex. For example `-P.` matches every function to patch
    every function in the program, so it is a quick shorthand to patch all functions.
    Alternativley, `--match=glob` can be used to to switch to wildcard-based function matching.
    This option can be used more than once.  See *DYNAMIC TRACING* for details.
```