### PR TITLE
Implement client/agent protocol

### DIFF
--- a/cmds/live.c
+++ b/cmds/live.c
@@ -210,22 +210,22 @@ static int forward_options(struct uftrace_opts *opts)
 	struct sockaddr_un addr;
 	int ret = 0;
 
-	sfd = socket_create(&addr, opts->pid);
+	sfd = agent_socket_create(&addr, opts->pid);
 	if (sfd == -1)
 		return -1;
 
-	if (socket_connect(sfd, &addr) == -1) {
+	if (agent_connect(sfd, &addr) == -1) {
 		ret = -1;
 		goto socket_error;
 	}
 
-	if (socket_send_option(sfd, UFTRACE_DOPT_CLOSE, NULL, 0) == -1) {
+	if (agent_message_send(sfd, UFTRACE_MSG_AGENT_CLOSE, NULL, 0) == -1) {
 		pr_warn("cannot terminate agent connection\n");
 		ret = -1;
 	}
 	else {
-		enum uftrace_dopt ack;
-		if (read(sfd, &ack, sizeof(enum uftrace_dopt)) < 0 || ack != UFTRACE_DOPT_CLOSE)
+		int ack;
+		if (read(sfd, &ack, sizeof(ack)) < 0 || ack != UFTRACE_MSG_AGENT_CLOSE)
 			ret = -1;
 	}
 

--- a/cmds/live.c
+++ b/cmds/live.c
@@ -208,6 +208,7 @@ static int forward_options(struct uftrace_opts *opts)
 {
 	int sfd;
 	struct sockaddr_un addr;
+	struct uftrace_msg ack;
 	int status = 0;
 	int status_close = 0;
 
@@ -222,6 +223,15 @@ static int forward_options(struct uftrace_opts *opts)
 	/* FIXME Forward user options and set status */
 
 	status_close = agent_message_send(sfd, UFTRACE_MSG_AGENT_CLOSE, NULL, 0);
+	if (status_close == 0) {
+		status_close = agent_message_read_response(sfd, &ack);
+		if (status_close == 0) {
+			if (ack.type == UFTRACE_MSG_AGENT_OK)
+				pr_dbg("disconnected from agent\n");
+			else
+				status_close = -1;
+		}
+	}
 	if (status_close < 0)
 		pr_dbg("agent connection not closed properly\n");
 

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -106,6 +106,8 @@ static pthread_t agent;
 /* state flag for the agent */
 static volatile bool agent_run = false;
 
+#define MCOUNT_AGENT_CAPABILITIES 0
+
 __weak void dynamic_return(void)
 {
 }
@@ -1849,6 +1851,13 @@ void *agent_apply_commands(void *arg)
 
 			/* parse message body */
 			switch (msg.type) {
+			case UFTRACE_MSG_AGENT_QUERY:
+				status = MCOUNT_AGENT_CAPABILITIES;
+				pr_dbg3("send capabilities to client\n");
+				agent_message_send(cfd, UFTRACE_MSG_AGENT_OK, &status,
+						   sizeof(status));
+				break;
+
 			case UFTRACE_MSG_AGENT_CLOSE:
 				close_connection = true;
 				agent_message_send(cfd, UFTRACE_MSG_AGENT_OK, NULL, 0);

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -1925,6 +1925,11 @@ void *agent_apply_commands(void *arg)
 							   sizeof(status));
 				break;
 
+			case UFTRACE_MSG_AGENT_GET_OPT:
+				/* TODO send data */
+				agent_message_send(cfd, UFTRACE_MSG_AGENT_OK, NULL, 0);
+				break;
+
 			case UFTRACE_MSG_AGENT_CLOSE:
 				close_connection = true;
 				agent_message_send(cfd, UFTRACE_MSG_AGENT_OK, NULL, 0);

--- a/uftrace.h
+++ b/uftrace.h
@@ -420,6 +420,7 @@ enum uftrace_msg_type {
 
 	UFTRACE_MSG_AGENT_CLOSE = 200, /* close the connection */
 	UFTRACE_MSG_AGENT_QUERY, /* perform connection handshake */
+	UFTRACE_MSG_AGENT_SET_OPT, /* set new option value */
 	UFTRACE_MSG_AGENT_OK, /* ack previous message */
 	UFTRACE_MSG_AGENT_ERR, /* signal error on previous message */
 };
@@ -453,6 +454,10 @@ struct uftrace_msg_dlopen {
 	int unused;
 	int namelen;
 	char exename[];
+};
+
+enum uftrace_agent_opt {
+	UFTRACE_AGENT_OPT_XXX,
 };
 
 extern struct uftrace_session *first_session;

--- a/uftrace.h
+++ b/uftrace.h
@@ -424,7 +424,7 @@ enum uftrace_msg_type {
 /* msg format for communicating by pipe */
 struct uftrace_msg {
 	unsigned short magic; /* UFTRACE_MSG_MAGIC */
-	unsigned short type; /* UFTRACE_MSG_REC_* */
+	unsigned short type; /* UFTRACE_MSG_* */
 	unsigned int len;
 	unsigned char data[];
 };

--- a/uftrace.h
+++ b/uftrace.h
@@ -419,6 +419,7 @@ enum uftrace_msg_type {
 	UFTRACE_MSG_SEND_END,
 
 	UFTRACE_MSG_AGENT_CLOSE = 200, /* close the connection */
+	UFTRACE_MSG_AGENT_QUERY, /* perform connection handshake */
 	UFTRACE_MSG_AGENT_OK, /* ack previous message */
 	UFTRACE_MSG_AGENT_ERR, /* signal error on previous message */
 };

--- a/uftrace.h
+++ b/uftrace.h
@@ -417,11 +417,8 @@ enum uftrace_msg_type {
 	UFTRACE_MSG_SEND_INFO,
 	UFTRACE_MSG_SEND_META_DATA,
 	UFTRACE_MSG_SEND_END,
-};
 
-/* Dynamic options sent by the client to the agent */
-enum uftrace_dopt {
-	UFTRACE_DOPT_CLOSE, /* Close the connection with the client */
+	UFTRACE_MSG_AGENT_CLOSE = 200, /* close the connection */
 };
 
 /* msg format for communicating by pipe */

--- a/uftrace.h
+++ b/uftrace.h
@@ -420,6 +420,7 @@ enum uftrace_msg_type {
 
 	UFTRACE_MSG_AGENT_CLOSE = 200, /* close the connection */
 	UFTRACE_MSG_AGENT_QUERY, /* perform connection handshake */
+	UFTRACE_MSG_AGENT_GET_OPT, /* get current option value */
 	UFTRACE_MSG_AGENT_SET_OPT, /* set new option value */
 	UFTRACE_MSG_AGENT_OK, /* ack previous message */
 	UFTRACE_MSG_AGENT_ERR, /* signal error on previous message */

--- a/uftrace.h
+++ b/uftrace.h
@@ -419,6 +419,8 @@ enum uftrace_msg_type {
 	UFTRACE_MSG_SEND_END,
 
 	UFTRACE_MSG_AGENT_CLOSE = 200, /* close the connection */
+	UFTRACE_MSG_AGENT_OK, /* ack previous message */
+	UFTRACE_MSG_AGENT_ERR, /* signal error on previous message */
 };
 
 /* msg format for communicating by pipe */

--- a/utils/socket.c
+++ b/utils/socket.c
@@ -18,7 +18,7 @@ void socket_unlink(struct sockaddr_un *addr)
 }
 
 /* Create socket for communication between the client and the agent */
-int socket_create(struct sockaddr_un *addr, pid_t pid)
+int agent_socket_create(struct sockaddr_un *addr, pid_t pid)
 {
 	int fd;
 	char *channel = NULL;
@@ -37,7 +37,7 @@ int socket_create(struct sockaddr_un *addr, pid_t pid)
 }
 
 /* Setup socket on agent side so it can accept client connection */
-int socket_listen(int fd, struct sockaddr_un *addr)
+int agent_listen(int fd, struct sockaddr_un *addr)
 {
 	if (bind(fd, (struct sockaddr *)addr, sizeof(struct sockaddr_un)) == -1) {
 		pr_warn("cannot bind to socket %s: %s\n", addr->sun_path, strerror(errno));
@@ -53,16 +53,16 @@ int socket_listen(int fd, struct sockaddr_un *addr)
 }
 
 /* Send a single option to the agent through its socket */
-int socket_send_option(int fd, enum uftrace_dopt opt, void *value, size_t size)
+int agent_message_send(int fd, int opt, void *value, size_t size)
 {
-	if (!write(fd, &opt, sizeof(enum uftrace_dopt)))
+	if (!write(fd, &opt, sizeof(opt)))
 		return -1;
 	if (value)
 		return write(fd, value, size);
 	return 0;
 }
 
-int socket_connect(int fd, struct sockaddr_un *addr)
+int agent_connect(int fd, struct sockaddr_un *addr)
 {
 	if (connect(fd, (struct sockaddr *)addr, sizeof(struct sockaddr_un)) == -1) {
 		pr_warn("cannot connect to socket '%s': %s\n", addr->sun_path, strerror(errno));
@@ -71,7 +71,7 @@ int socket_connect(int fd, struct sockaddr_un *addr)
 	return 0;
 }
 
-int socket_accept(int fd)
+int agent_accept(int fd)
 {
 	return accept(fd, NULL, NULL);
 }

--- a/utils/socket.c
+++ b/utils/socket.c
@@ -7,13 +7,12 @@
 #include "utils/socket.h"
 #include "utils/utils.h"
 
-/* unlink socket file if it exists */
+/* Unlink socket file if it exists */
 void socket_unlink(struct sockaddr_un *addr)
 {
 	if (unlink(addr->sun_path) == -1) {
-		if (errno != ENOENT) {
-			pr_dbg("cannot unlink %s\n", addr->sun_path);
-		}
+		if (errno != ENOENT)
+			pr_dbg("cannot unlink socket '%s'\n", addr->sun_path);
 	}
 }
 
@@ -40,12 +39,13 @@ int agent_socket_create(struct sockaddr_un *addr, pid_t pid)
 int agent_listen(int fd, struct sockaddr_un *addr)
 {
 	if (bind(fd, (struct sockaddr *)addr, sizeof(struct sockaddr_un)) == -1) {
-		pr_warn("cannot bind to socket %s: %s\n", addr->sun_path, strerror(errno));
+		pr_warn("cannot bind to socket '%s': %s\n", addr->sun_path, strerror(errno));
 		close(fd);
 		return -1;
 	}
+
 	if (listen(fd, 1) == -1) {
-		pr_warn("cannot listen to socket %s\n", addr->sun_path);
+		pr_warn("cannot listen to socket '%s': %s\n", addr->sun_path, strerror(errno));
 		close(fd);
 		return -1;
 	}
@@ -62,15 +62,18 @@ int agent_message_send(int fd, int opt, void *value, size_t size)
 	return 0;
 }
 
+/* Client side: connect to an agent socket */
 int agent_connect(int fd, struct sockaddr_un *addr)
 {
 	if (connect(fd, (struct sockaddr *)addr, sizeof(struct sockaddr_un)) == -1) {
 		pr_warn("cannot connect to socket '%s': %s\n", addr->sun_path, strerror(errno));
 		return -1;
 	}
+
 	return 0;
 }
 
+/* Agent side: accept incoming client connection */
 int agent_accept(int fd)
 {
 	return accept(fd, NULL, NULL);

--- a/utils/socket.c
+++ b/utils/socket.c
@@ -126,3 +126,28 @@ int agent_message_read_head(int fd, struct uftrace_msg *msg)
 
 	return 0;
 }
+
+/**
+ * agent_message_read_response - read agent ack
+ * @fd - socket file descriptor
+ * @response - ack from agent
+ * @return - status: data or error code, negative on error
+ */
+int agent_message_read_response(int fd, struct uftrace_msg *response)
+{
+	int status = 0;
+
+	if (agent_message_read_head(fd, response) < 0)
+		return -1;
+
+	if (response->len > sizeof(status))
+		return -1;
+
+	if (read_all(fd, &status, response->len) < 0) {
+		pr_dbg3("error reading agent socket\n");
+		return -1;
+	}
+	pr_dbg4("read agent response [%d] (size=%d)\n", response->type, response->len);
+
+	return status;
+}

--- a/utils/socket.h
+++ b/utils/socket.h
@@ -5,13 +5,11 @@
 
 #define MCOUNT_AGENT_SOCKET_DIR "/tmp/uftrace"
 
-enum uftrace_dopt;
-
 void socket_unlink(struct sockaddr_un *addr);
-int socket_create(struct sockaddr_un *addr, pid_t pid);
-int socket_listen(int fd, struct sockaddr_un *addr);
-int socket_connect(int fd, struct sockaddr_un *addr);
-int socket_accept(int fd);
-int socket_send_option(int fd, enum uftrace_dopt opt, void *value, size_t size);
+int agent_socket_create(struct sockaddr_un *addr, pid_t pid);
+int agent_listen(int fd, struct sockaddr_un *addr);
+int agent_connect(int fd, struct sockaddr_un *addr);
+int agent_accept(int fd);
+int agent_message_send(int fd, int opt, void *value, size_t size);
 
 #endif // UFTRACE_SOCKET_H

--- a/utils/socket.h
+++ b/utils/socket.h
@@ -10,6 +10,7 @@ int agent_socket_create(struct sockaddr_un *addr, pid_t pid);
 int agent_listen(int fd, struct sockaddr_un *addr);
 int agent_connect(int fd, struct sockaddr_un *addr);
 int agent_accept(int fd);
-int agent_message_send(int fd, int opt, void *value, size_t size);
+int agent_message_send(int fd, int type, void *data, size_t size);
+int agent_message_read_head(int fd, struct uftrace_msg *msg);
 
 #endif // UFTRACE_SOCKET_H

--- a/utils/socket.h
+++ b/utils/socket.h
@@ -12,5 +12,6 @@ int agent_connect(int fd, struct sockaddr_un *addr);
 int agent_accept(int fd);
 int agent_message_send(int fd, int type, void *data, size_t size);
 int agent_message_read_head(int fd, struct uftrace_msg *msg);
+int agent_message_read_response(int fd, struct uftrace_msg *response);
 
 #endif // UFTRACE_SOCKET_H


### PR DESCRIPTION
Hi Namhyung,

I reworked the client/agent protocol, as discussed in #1652.

This PR doesn't implement any option in the client, it is only about the protocol.

Two things to notice:
- the `forward_option()` function is unused because we do not send options yet
- I added a `GET_OPT` message but its action is not implemented (only a placeholder for now)

Closes: #1652