### PR TITLE
README.md: Fix duplicated "with"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ It was heavily inspired by the ftrace framework of the Linux kernel and
 the name uftrace stems from the combination of user and ftrace.
 
 It can record data from:
-- User space C/C++/Rust functions (by dynamically patching functions at runtime,
-  or with code compiled with with `-pg`, `-finstrument-functions` or using
-  `-fpatchable-function-entry=N` for selective NOP patching)
+- User space C/C++/Rust functions, by either dynamically patching functions
+  using `-P.`, or else selective NOP patching using code compiled with `-pg`,
+  `-finstrument-functions` or `-fpatchable-function-entry=N`.
 - C/C++/Rust Library functions (through PLT hooking)
 - Python functions (using Python's trace/profile infrastructure)
 - Kernel functions (using the ftrace framework in Linux kernel)


### PR DESCRIPTION
Fix a duplicated "with" and even with it fixed, the sentence was not clear and easy to read.

Therefore, split the description of tracing possibilities into two:
- One for dynamic tracing, mentioning or `-P.`
- one for tracing by using instrumentation.

While at it, I also recoginzed that the part regarding `-fxray-instrument` can be made clearer and that the readability of the options by adding a space after `-f` (even tough we'd normally omit the space of course), when so many of the are given in one long sentence.