### PR TITLE
Obsolete Draft: RFC for split debuginfo using libdw's frontend API

### DIFF
--- a/utils/dwarf.h
+++ b/utils/dwarf.h
@@ -11,7 +11,7 @@
 struct uftrace_sym_info;
 
 #ifdef HAVE_LIBDW
-#include <elfutils/libdw.h>
+#include <elfutils/libdwfl.h>
 #else
 #define Dwarf void
 #endif
@@ -34,8 +34,9 @@ struct uftrace_dbg_loc {
 };
 
 struct uftrace_dbg_info {
-	/* opaque DWARF info pointer */
-	Dwarf *dw;
+	/* opaque DWARF frontend library pointers */
+	Dwfl *dwfl;
+	Dwfl_Module *dwfl_module;
 	/* start address in memory for this module */
 	uint64_t offset;
 	/* rb tree of arguments */
@@ -60,6 +61,15 @@ struct uftrace_dbg_info {
 	bool loaded;
 	/* name of common directory path for source files (can be %NULL) */
 	char *base_dir;
+};
+
+// arg struct for passing infos to and from build_dwarf_info_cb():
+struct dwarf_info_args {
+	struct uftrace_dbg_info *dinfo;
+	struct uftrace_symtab *symtab;
+	enum uftrace_pattern_type ptype;
+	struct strv *args;
+	struct strv *rets;
 };
 
 extern void prepare_debug_info(struct uftrace_sym_info *sinfo, enum uftrace_pattern_type ptype,


### PR DESCRIPTION
Update: This was only a first attempt to serve as a request for comments! - Thanks!

I plan to submit a new PR based on a new example (which I have to test first).

See my answer to the review of this PR for more information:  https://github.com/namhyung/uftrace/pull/1671#issuecomment-1505403698 

----
First step towards supporting split or separate DWARF debuginfo!

Convert dwarf/debug.c to use libdwfl (dwarf frontend lib) functions of libdw. uftrace now loads DWARF debuginfo from executables created with:
```ini
cp $exe $exe.full
objcopy --add-gnu-debuglink=$exe.full $exe
strip -g $exe
```
Using "strip $exe" instead of "strip -g $exe" is not yet supported, but could be after further investigation. For now this means that the DWARF debuginfo for programs shipped by most Linux distro is not yet used, but should be possible later.

TODO: Need to compare the test suite before/after this change.

In order to support showing stripped symbols, further updates appear to be needed.
As far as i can see, uftrace currently uses the ELF symbol table exclusively to generate the `uftrace.data/filename.sym` files and this excludes stripped debug info of functions which aren't in the ELF symbol table:
https://github.com/namhyung/uftrace/blob/master/utils/dwarf.c#L1486

This would likely have to be changed to generate the content of the symtab array from the debug symbols, I guess.