### PR TITLE
dynamic: Print dynamic patch stats for skipped

### DIFF
--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -669,7 +669,7 @@ int mcount_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 
 	ret = do_dynamic_update(sinfo, patch_funcs, ptype);
 
-	if (stats.total && stats.failed) {
+	if (stats.total && (stats.failed || stats.skipped)) {
 		int success = stats.total - stats.failed - stats.skipped;
 		int r, q;
 


### PR DESCRIPTION
Currently, dynamic patch stat info is not printed when there is skipped functions without failed one.

This patch also checks whether there is a skipped function to print dynamic patched function stats.
```
  $ uftrace record --debug-domain dynamic:1 -P. -Z 10 a.out
  dynamic: dynamic patch type: a.out: 0 (none)
  dynamic: patched all (4) functions in 'a.out'
```
Before:
```
  $ uftrace record --debug-domain dynamic:1 -P. -Z 30 a.out
  dynamic: dynamic patch type: a.out: 0 (none)
```
After:
```
  $ uftrace record --debug-domain dynamic:1 -P. -Z 30 a.out
  dynamic: dynamic patch type: a.out: 0 (none)
  dynamic: dynamic patch stats for 'a.out'
  dynamic:    total:        4
  dynamic:  patched:        2 (50.00%)
  dynamic:   failed:        0 ( 0.00%)
  dynamic:  skipped:        2 (50.00%)
  dynamic: no match:        0
```