### PR TITLE
kernel: Add "exit_to_user_mode_prepare" in kernel skip list

### DIFF
--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -459,6 +459,7 @@ static void skip_kernel_functions(struct uftrace_kernel_writer *kernel)
 		/* Disable syscall tracing in the kernel */
 		"syscall_trace_enter_phase1",
 		"syscall_slow_exit_work",
+		"exit_to_user_mode_prepare",
 #ifdef __aarch64__
 		/*
 		 * TTBR is for page table setting and it is needed for security


### PR DESCRIPTION
exit_to_user_mode_prepare tends to be shown unnecessarily many times in kernel tracing result as follows.
```
  $ cat hello.c
  #include <stdio.h>

  int main()
  {
          printf("Hello World\n");
          fflush(stdout);
          return 0;
  }

  $ gcc -pg -o hello hello.c

  $ sudo ./uftrace -F main -k hello
  Hello World
  # DURATION     TID     FUNCTION
              [ 18510] | main() {
              [ 18510] |   puts() {
     0.177 us [ 18510] |     down_read_trylock();
     0.147 us [ 18510] |     __cond_resched();
     0.334 us [ 18510] |     find_vma();
     2.159 us [ 18510] |     handle_mm_fault();
     0.150 us [ 18510] |     up_read();
     0.216 us [ 18510] |     exit_to_user_mode_prepare();
     4.651 us [ 18510] |     __x64_sys_newfstatat();
     0.219 us [ 18510] |     exit_to_user_mode_prepare();
    11.518 us [ 18510] |     __x64_sys_write();
     0.218 us [ 18510] |     exit_to_user_mode_prepare();
    24.233 us [ 18510] |   } /* puts */
     0.201 us [ 18510] |   fflush();
    24.869 us [ 18510] | } /* main */
```
So it'd be better to hide it.