### PR TITLE
python: Fix source location missing problem

### DIFF
--- a/python/trace-python.c
+++ b/python/trace-python.c
@@ -596,6 +596,7 @@ static void init_uftrace(void)
 	}
 
 	if (getenv("UFTRACE_SRCLINE") || need_dbg_info) {
+		/* read UFTRACE_PYMAIN, which was set in uftrace.py. */
 		main_file = getenv("UFTRACE_PYMAIN");
 		need_dbg_info = true;
 	}

--- a/python/uftrace.py
+++ b/python/uftrace.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import uftrace_python
 
 sys.argv = sys.argv[1:len(sys.argv)]
 
@@ -22,6 +21,9 @@ else:
             break
         except OSError:
             continue
+
+# UFTRACE_PYMAIN must be set before importing uftrace_python
+import uftrace_python
 
 new_globals = globals()
 new_globals["__file__"] = pathname


### PR DESCRIPTION
The following commit moved import uftrace_python at the top of script.

  e26f74c8 python: Set __file__ attribute properly

But it makes the source location info missing as follows.
```
  $ uftrace --srcline ./p-abc.py
  # DURATION     TID     FUNCTION [SOURCE]
              [ 43034] | __main__.<module>() { /* (null):1 */
              [ 43034] |   a() { /* (null):11 */
              [ 43034] |     b() { /* (null):8 */
              [ 43034] |       c() { /* (null):5 */
     1.255 us [ 43034] |         posix.getpid();
     5.577 us [ 43034] |       } /* c */
     8.690 us [ 43034] |     } /* b */
    11.348 us [ 43034] |   } /* a */
    16.299 us [ 43034] | } /* __main__.<module> */
```
The source file name is set to UFTRACE_PYMAIN environment variable and get the env inside uftrace_python.so.

So the import statement has to be moved below to UFTRACE_PYMAIN set. After moving it below, the source file name looks fine now.
```
  $ uftrace --srcline ./p-abc.py
  # DURATION     TID     FUNCTION [SOURCE]
              [ 42923] | __main__.<module>() { /* ./p-abc.py:1 */
              [ 42923] |   a() { /* ./p-abc.py:11 */
              [ 42923] |     b() { /* ./p-abc.py:8 */
              [ 42923] |       c() { /* ./p-abc.py:5 */
     1.174 us [ 42923] |         posix.getpid();
     4.915 us [ 42923] |       } /* c */
     7.836 us [ 42923] |     } /* b */
    10.484 us [ 42923] |   } /* a */
    15.490 us [ 42923] | } /* __main__.<module> */
```