### PR TITLE
record: Honour --report option to record command

### DIFF
--- a/cmds/live.c
+++ b/cmds/live.c
@@ -426,6 +426,7 @@ int command_live(int argc, char *argv[], struct uftrace_opts *opts)
 		return forward_options(opts);
 
 	ret = command_record(argc, argv, opts);
+	pr_dbg("live-record finished.. \n");
 	if (!can_skip_replay(opts, ret)) {
 		int ret2;
 
@@ -433,16 +434,6 @@ int command_live(int argc, char *argv[], struct uftrace_opts *opts)
 
 		if (opts->use_pager)
 			start_pager(setup_pager());
-
-		pr_dbg("live-record finished.. \n");
-		if (opts->report) {
-			pr_out("#\n# uftrace report\n#\n");
-			ret2 = command_report(argc, argv, opts);
-			if (ret == UFTRACE_EXIT_SUCCESS)
-				ret = ret2;
-
-			pr_out("\n#\n# uftrace replay\n#\n");
-		}
 
 		pr_dbg("start live-replaying...\n");
 		ret2 = command_replay(argc, argv, opts);

--- a/cmds/record.c
+++ b/cmds/record.c
@@ -2303,5 +2303,9 @@ int command_record(int argc, char *argv[], struct uftrace_opts *opts)
 		unlink(channel);
 		free(channel);
 	}
+
+	if (ret == UFTRACE_EXIT_SUCCESS && opts->report)
+		ret = command_report(argc, argv, opts);
+
 	return ret;
 }

--- a/doc/ko/uftrace-record.md
+++ b/doc/ko/uftrace-record.md
@@ -222,6 +222,9 @@ RECORD 설정 옵션
 \--srcline
 :   디버그 정보에 레코드한 소스 줄번호를 표시한다.
 
+\--report
+:   record 작업이 끝난 후에 report 결과를 출력한다.
+
 
 FILTERS
 =======

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -222,6 +222,9 @@ RECORD CONFIG OPTIONS
 \--srcline
 :   Enable recording source line in the debug info.
 
+\--report
+:   Show report when the record is done.
+
 
 FILTERS
 =======


### PR DESCRIPTION
The current --report option is only used in live command, but it's more useful when users want to see only report result without running uftrace record and uftrace report twice.

The simple usage is as follows.
```
  $ uftrace record --report t-abc
    Total time   Self time       Calls  Function
    ==========  ==========  ==========  ====================
      1.480 us    0.170 us           1  main
      1.310 us    0.141 us           1  a
      1.169 us    0.157 us           1  b
      1.012 us    0.309 us           1  c
      0.703 us    0.703 us           1  getpid
      0.666 us    0.666 us           1  __monstartup
      0.132 us    0.132 us           1  __cxa_atexit
```