### PR TITLE
doc: Change the chat from gitter to discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ duration for analysis of program execution and performance.
 
  * Homepage: https://github.com/namhyung/uftrace
  * Tutorial: https://github.com/namhyung/uftrace/wiki/Tutorial
- * Chat: https://gitter.im/uftrace/uftrace
+ * Chat: https://discord.gg/MENMKaCWqD (Discord)
  * Mailing list: [uftrace@googlegroups.com](https://groups.google.com/forum/#!forum/uftrace)
  * Lightning talk: https://youtu.be/LNav5qvyK7I
 


### PR DESCRIPTION
We've had gitter for chat room but it'd be better to switch it to discord.

I hope many more people to join the community and let's talk in discord.