### PR TITLE
dynamic: Runtime dynamic instrumentation on x86_64

### DIFF
--- a/arch/aarch64/mcount-insn.c
+++ b/arch/aarch64/mcount-insn.c
@@ -8,10 +8,19 @@
 #include <capstone/capstone.h>
 #include <capstone/platform.h>
 
+/**
+ * mcount_disasm_init - initialize the capstone engine once
+ * @disasm - mcount disassembly engine
+ */
 void mcount_disasm_init(struct mcount_disasm_engine *disasm)
 {
+	if (disasm->engine)
+		return;
+
+	pr_dbg2("initialize disassembly engine\n");
+
 	if (cs_open(CS_ARCH_ARM64, CS_MODE_ARM, &disasm->engine) != CS_ERR_OK) {
-		pr_dbg("failed to init Capstone disasm engine\n");
+		pr_dbg("failed to init capstone disasm engine\n");
 		return;
 	}
 

--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -1,6 +1,14 @@
+#include <errno.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
+
+#if HAVE_MEMBARRIER
+#include <linux/membarrier.h>
+#else
+#include <cpuid.h>
+#include <semaphore.h>
+#endif
 
 /* This should be defined before #include "utils.h" */
 #define PR_FMT "dynamic"
@@ -121,6 +129,120 @@ static int configure_sigtrap_handler()
 	return 0;
 }
 
+#if HAVE_MEMBARRIER
+
+/**
+ * setup_synchronization_mechanism - register intent to use the 'private
+ * expedited sync core' membarrier to synchronize instruction pipelines and
+ * caches across cores, for safe cross-modification.
+ * @return - negative on error, 0 on success
+ */
+static int setup_synchronization_mechanism()
+{
+	int ret =
+		syscall(__NR_membarrier, MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_SYNC_CORE, 0, 0);
+	if (ret < 0)
+		pr_dbg2("failed to register membarrier intent: %s\n", strerror(errno));
+	return ret;
+}
+
+/**
+ * synchronize_all_cores - use membarrier to perform cache and pipeline
+ * synchronization across cores executing cross-modified code
+ * @return - negative on error, 0 on success
+ */
+static int synchronize_all_cores()
+{
+	int ret = syscall(__NR_membarrier, MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE, 0, 0);
+	if (ret < 0)
+		pr_dbg2("failed to use membarrier: %s\n", strerror(errno));
+	return ret;
+}
+
+#else /* HAVE_MEMBARRIER */
+
+/* signal used to perform cache and pipeline synchronization across cores */
+static int sig_sync_cores;
+
+/* counter for the threads that have performed serialization when a signal is
+   issued */
+static sem_t sem_sync_cores;
+
+/**
+ * serialize_instruction_execution - execute core serialize instruction
+ *
+ * According to Intel manual, CPUID is a serializing instruction.
+ */
+static void serialize_instruction_execution()
+{
+	int _;
+	__cpuid(_, _, _, _, _);
+	sem_post(&sem_sync_cores);
+}
+
+/**
+ * setup_synchronization_mechanism - setup real-time signal and its handler to
+ * perform core synchronization across all threads
+ * @return - 0 on success, -1 on failure
+ */
+static int setup_synchronization_mechanism()
+{
+	struct sigaction act;
+
+	if (sig_sync_cores > 0)
+		return 0;
+
+	sig_sync_cores = find_unused_sigrt();
+	if (sig_sync_cores == -1)
+		return -1;
+
+	sem_init(&sem_sync_cores, 0, 0);
+
+	act.sa_sigaction = serialize_instruction_execution;
+	act.sa_flags = 0;
+
+	if (sigaction(sig_sync_cores, &act, NULL) < 0) {
+		pr_dbg("failed to configure core synchronization signal handler\n");
+		return -1;
+	}
+
+	pr_dbg("configured core synchronization signal (SIGRT%d) handler\n", sig_sync_cores);
+	return 0;
+}
+
+/**
+ * serialize_instruction_cache - send RT signals to perform cache and pipeline
+ * synchronization across cores executing cross-modified code.
+ * @return - -1 on error, 0 on success
+ */
+static int synchronize_all_cores()
+{
+	int signal_count;
+	int sync_count = 0;
+	struct timespec ts;
+
+	ASSERT(sig_sync_cores >= SIGRTMIN);
+
+	signal_count = thread_broadcast_signal(sig_sync_cores);
+
+	if (clock_gettime(CLOCK_REALTIME, &ts) == -1)
+		return -1;
+	ts.tv_sec += 1;
+
+	for (int i = 0; i < signal_count; i++) {
+		if (sem_timedwait(&sem_sync_cores, &ts) == -1) {
+			if (errno == EINTR)
+				i--;
+		}
+		else
+			sync_count++;
+	}
+	pr_dbg3("synced core in %d/%d thread(s)\n", sync_count, signal_count);
+
+	return 0;
+}
+
+#endif /* HAVE_MEMBARRIER */
 /**
  * mcount_arch_dynamic_init - initialize arch-specific data structures to
  * perform runtime dynamic instrumentation
@@ -137,8 +259,12 @@ int mcount_arch_dynamic_init()
 	if (configure_sigtrap_handler() < 0)
 		return -1;
 
+	if (setup_synchronization_mechanism() < 0)
+		return -1;
+
 	return 0;
 }
+
 int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
 {
 	unsigned char trampoline[] = { 0x3e, 0xff, 0x25, 0x01, 0x00, 0x00, 0x00, 0xcc };
@@ -549,11 +675,16 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 	 *     0xb: <other instructions>
 	 *
 	 * The trap will emulate a call to the trampoline while in place.
+	 *
+	 * We ensure that every core sees the trap before patching the critical
+	 * zone, by synchronizing the them.
 	 */
 
 	if (register_trap(origin_code_addr, (void *)mdi->trampoline) == -1)
 		return INSTRUMENT_FAILED;
 	((uint8_t *)origin_code_addr)[0] = 0xcc;
+
+	synchronize_all_cores();
 
 	/*
 	 * We fill the remaining part of the patching region with nops.

--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -9,6 +9,7 @@
 #include "libmcount/dynamic.h"
 #include "libmcount/internal.h"
 #include "mcount-arch.h"
+#include "utils/hashmap.h"
 #include "utils/symbol.h"
 #include "utils/utils.h"
 
@@ -19,6 +20,125 @@ static const unsigned char patchable_clang_nop[] = { 0x0f, 0x1f, 0x44, 0x00, 0x0
 
 static const unsigned char endbr64[] = { 0xf3, 0x0f, 0x1e, 0xfa };
 
+/*
+ * Hashmap of trampoline locations for every installed int3 trap. The traps are
+ * used when patching and unpatching functions: they prevent threads from
+ * entering the critical zone. When a trap is reached, the trap handler fetches
+ * the trampoline location from the hmap, and emulates a call to the trampoline,
+ * to mimic regular instrumentation.
+ *
+ * (void *int3_location -> void *trampoline)
+ */
+static struct Hashmap *int3_hmap;
+
+/**
+ * register_trap - save trampoline associated to a trap
+ * @trap     - trap address
+ * @call_loc - address of the symbol to emulate a call to
+ * @return   - -1 on error, 0 on success
+ */
+static int register_trap(void *trap, void *call_loc)
+{
+	if (!hashmap_put(int3_hmap, trap, call_loc))
+		return -1;
+
+	return 0;
+}
+
+/**
+ * unregister_trap - remove trap entry from hmap
+ * @trap     - trap address
+ * @return   - -1 on error, 0 on success
+ */
+static int unregister_trap(void *trap)
+{
+	if (hashmap_remove(int3_hmap, trap))
+		return 0;
+
+	return -1;
+}
+
+/**
+ * emulate_trampoline_call - SIGTRAP handler, emulates a call to the trampoline
+ * associated with the trap location
+ *
+ * When the trap handler is executed, it changes the program counter to point to
+ * <trampoline>. When the trap handler exits, the code at <trampoline> will
+ * execute (which is __dentry__ defined in dynamic.S).
+ *
+ * As __dentry__ is expected to be called like a function, it depends on the
+ * address of the caller to know which tracepoint was executed. The address is
+ * expected to be found on the stack. Therefore, the trap handler actually needs
+ * to emulate a call instruction entirely (moving the instruction pointer is not
+ * enough).
+ *
+ * To do so, the trap handler will also push on the stack the next instruction
+ * pointer that would be used if the executed instruction was a call instead of
+ * a trap.
+ *
+ * @sig      - signal caught
+ * @info     - (unused)
+ * @ucontext - user context, containing registers
+ */
+static void emulate_trampoline_call(int sig, siginfo_t *info, void *ucontext)
+{
+	ucontext_t *uctx = ucontext;
+	mcontext_t *mctx = &uctx->uc_mcontext;
+	void *int3_addr;
+	unsigned long trampoline;
+	unsigned long child_addr; /* probe location for mcount_entry */
+
+	ASSERT(sig == SIGTRAP);
+
+	__atomic_signal_fence(__ATOMIC_SEQ_CST);
+	int3_addr = (void *)mctx->gregs[REG_RIP] - 1; /* int3 size = 1 */
+	trampoline = (unsigned long)hashmap_get(int3_hmap, int3_addr);
+
+	child_addr = (unsigned long)int3_addr + CALL_INSN_SIZE;
+
+	mctx->gregs[REG_RSP] -= 8;
+	memcpy((void *)mctx->gregs[REG_RSP], &child_addr, 8);
+	mctx->gregs[REG_RIP] = trampoline;
+}
+
+/**
+ * configure_sigtrap_handler - emulate call to trampoline on SIGTRAP
+ * @return - -1 on failure, 0 on success
+ */
+static int configure_sigtrap_handler()
+{
+	struct sigaction act;
+
+	act.sa_sigaction = emulate_trampoline_call;
+	act.sa_flags = SA_SIGINFO;
+
+	if (sigaction(SIGTRAP, &act, NULL) < 0) {
+		pr_err("failed to configure SIGTRAP handler\n");
+		return -1;
+	}
+
+	pr_dbg2("configured SIGTRAP handler\n");
+	return 0;
+}
+
+/**
+ * mcount_arch_dynamic_init - initialize arch-specific data structures to
+ * perform runtime dynamic instrumentation
+ */
+int mcount_arch_dynamic_init()
+{
+	if (!int3_hmap) {
+		int3_hmap = hashmap_create(4, hashmap_ptr_hash, hashmap_ptr_equals);
+		if (!int3_hmap) {
+			pr_dbg("failed to create int3 hashmap\n");
+			return -1;
+		}
+	}
+	if (configure_sigtrap_handler() < 0)
+		return -1;
+
+	return 0;
+}
 int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
 {
 	unsigned char trampoline[] = { 0x3e, 0xff, 0x25, 0x01, 0x00, 0x00, 0x00, 0xcc };
@@ -419,11 +539,22 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 
 	trampoline_rel_addr = (void *)get_trampoline_offset(mdi, (unsigned long)origin_code_addr);
 
-	/*
+	/* The first step is to insert a 1-byte trap-based probe point (atomic).
+	 * This will prevent threads to enter the critical zone while we patch it,
+	 * so no core will see partial modifications.
 	 *
+	 *     0x0: int3                  <= origin_code_addr
+	 *     0x1: mov  %rsp,%rbp
+	 *     0x4: lea  0xeb0(%rip),%rdi
+	 *     0xb: <other instructions>
 	 *
-	 *
+	 * The trap will emulate a call to the trampoline while in place.
 	 */
+
+	if (register_trap(origin_code_addr, (void *)mdi->trampoline) == -1)
+		return INSTRUMENT_FAILED;
+	((uint8_t *)origin_code_addr)[0] = 0xcc;
+
 	/*
 	 * We fill the remaining part of the patching region with nops.
 	 *
@@ -444,6 +575,7 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 	 */
 
 	((uint8_t *)origin_code_addr)[0] = 0xe8;
+	unregister_trap(origin_code_addr);
 
 	return INSTRUMENT_SUCCESS;
 }

--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -398,12 +398,13 @@ int setup_clear_patch_region()
 	return 0;
 }
 
-/* This list is used to store functions that need to be optimized or cleaned up
- * later in the code. In both case, a SIGRTMIN+n must be send. By optimizing or
- * cleaning all of them up at the same time, we only need to send one signal per
- * thread.
+/* These two lists are used to store functions that need to be optimized or
+ * cleaned up later in the code. In both case, a SIGRTMIN+n must be send. By
+ * optimizing or cleaning all of them up at the same time, we only need to send
+ * one signal per thread.
  */
 LIST_HEAD(normal_funcs_patch);
+LIST_HEAD(normal_funcs_unpatch);
 
 struct patch_dynamic_info {
 	struct list_head list;
@@ -935,7 +936,6 @@ static void patch_region_unlock(struct mcount_disasm_info *info)
 	 *     0x5: <nop instructions>
 	 *     0xb: <other instructions>
 	 */
-
 	((uint8_t *)origin_code_addr)[0] = 0xe8;
 }
 
@@ -1045,13 +1045,45 @@ void mcount_patch_normal_func_fini()
 extern int check_endbr64(unsigned long addr);
 
 /**
- * unpatch_normal_func - remove full-dynamic instrumentation from a function
- * entry and restore original instructions
+ * unpatch_code - restore original instructions except the trap at the beginning
+ * @info   - mcount disassembly info
+ * @return - -1 on error, 0 on success
+ */
+int unpatch_code(struct mcount_disasm_info *info)
+{
+	uint8_t *origin_code = info->insns;
+	uint8_t *origin_code_addr = (uint8_t *)info->addr;
+	int orig_size = info->orig_size;
+
+	/*
+	 * The second step is to restore the bytes after the trap instruction.
+	 *
+	 *     0x0: int3
+	 *     0x1: mov  %rsp,%rbp
+	 *     0x4: lea  0xeb0(%rip),%rdi
+	 *     0xb: <other instructions>
+	 *
+	 * Before restoring the last byte, a serialization instruction must be
+	 * executed in order to synchronize the instruction cache of each processor.
+	 * The easiest method is to execute a membarrier system call with
+	 * MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE. It will send a
+	 * inter-processor interrupt that will execute the required serialization.
+	 */
+
+	memcpy(&origin_code_addr[1], &origin_code[1], orig_size - 1);
+
+	return 0;
+}
+
+/**
+ * unpatch_normal_func_init - perform the initial steps of the unpatching
+ * process, awaiting for core synchronization. This step is batched with
+ * subsequent ones.
  * @mdi    - mcount dynamic info for the current module
  * @sym    - symbol to patch
  * @return - instrumentation status
  */
-static int unpatch_normal_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym)
+static int unpatch_normal_func_init(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym)
 {
 	/*
 	 * Let assume that we have the following instructions.
@@ -1074,6 +1106,7 @@ static int unpatch_normal_func(struct mcount_dynamic_info *mdi, struct uftrace_s
 	struct mcount_orig_insn *orig;
 	uint8_t *origin_code;
 	int orig_size;
+	struct mcount_disasm_info *info;
 
 	origin_code_addr = mdi->map->start + sym->addr;
 	if (check_endbr64(origin_code_addr))
@@ -1098,27 +1131,30 @@ static int unpatch_normal_func(struct mcount_dynamic_info *mdi, struct uftrace_s
 	 *     0xb: <other instructions>
 	 */
 
+	register_trap((void *)origin_code_addr, (void *)mdi->trampoline);
 	((uint8_t *)origin_code_addr)[0] = 0xcc;
 
-	/*
-	 * The second step is to restore the bytes after the trap instruction.
-	 *
-	 *     0x0: int3
-	 *     0x1: mov  %rsp,%rbp
-	 *     0x4: lea  0xeb0(%rip),%rdi
-	 *     0xb: <other instructions>
-	 *
-	 * Before restoring the last byte, a serialization instruction must be
-	 * executed in order to synchronize the instruction cache of each processor.
-	 * The easiest method is to execute a membarrier system call with
-	 * MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE. It will send a
-	 * inter-processor interrupt that will execute the required serialization.
-	 */
+	info = xmalloc(sizeof(*info));
+	memset(info, 0, sizeof(*info));
+	info->sym = sym;
+	info->addr = mdi->map->start + sym->addr;
+	ASSERT(orig_size < 64); /* fit into info->insns */
+	memcpy(info->insns, origin_code, orig_size);
+	info->orig_size = orig_size;
+	commit_normal_func(&normal_funcs_unpatch, mdi, info);
 
-	synchronize_all_cores();
+	return 0;
+}
 
-	if (!memcpy(&((uint8_t *)origin_code_addr)[1], &origin_code[1], orig_size - 1))
-		return -1;
+/**
+ * unpatch_region_unlock - remove the trap at the start of the unpatched region
+ * @info   - mcount disassembly info
+ * @return - 0
+ */
+int unpatch_region_unlock(struct mcount_disasm_info *info)
+{
+	uint8_t *origin_code = info->insns;
+	uint8_t *origin_code_addr = (uint8_t *)info->addr;
 
 	/*
 	 * The third step is to restore the last byte.
@@ -1129,21 +1165,32 @@ static int unpatch_normal_func(struct mcount_dynamic_info *mdi, struct uftrace_s
 	 *     0xb: <other instructions>
 	 */
 
-	((uint8_t *)origin_code_addr)[0] = origin_code[0];
+	origin_code_addr[0] = origin_code[0];
 
-	/*
-	 * The fourth and last step is to move all thread that are currently
-	 * executing in the modified instructions to the original instructions at
-	 * the end of the trampoline. This is needed in order to free the memory
-	 * allocated for the trampoline without any race condition.
-	 *
-	 * The method used to move the threads is to send the SIGRTMIN+n signal to
-	 * all other threads. When their thread handler executes, it will check if
-	 * the next instruction pointer is in the patching region. If it is, will
-	 * move the next instruction pointer to the equivalent modified instruction.
-	 */
+	return 0;
+}
 
-	return INSTRUMENT_SUCCESS;
+/**
+ * mcount_unpatch_normal_func_fini - perform the final steps of the unpatching
+ * process and cleanup
+ */
+void mcount_unpatch_normal_func_fini()
+{
+	struct patch_dynamic_info *pdi, *tmp;
+
+	if (list_empty(&normal_funcs_unpatch))
+		return;
+
+	synchronize_all_cores();
+
+	list_for_each_entry_safe(pdi, tmp, &normal_funcs_unpatch, list) {
+		unpatch_code(pdi->info);
+		write_memory_barrier();
+		unpatch_region_unlock(pdi->info);
+		list_del(&pdi->list);
+		free(pdi->info);
+		free(pdi);
+	}
 }
 
 static int unpatch_func(uint8_t *insn, char *name)
@@ -1255,7 +1302,7 @@ int mcount_unpatch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *
 		break;
 
 	case DYNAMIC_NONE:
-		result = unpatch_normal_func(mdi, sym);
+		result = unpatch_normal_func_init(mdi, sym);
 		break;
 
 	default:

--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -1042,6 +1042,110 @@ void mcount_patch_normal_func_fini()
 	}
 }
 
+extern int check_endbr64(unsigned long addr);
+
+/**
+ * unpatch_normal_func - remove full-dynamic instrumentation from a function
+ * entry and restore original instructions
+ * @mdi    - mcount dynamic info for the current module
+ * @sym    - symbol to patch
+ * @return - instrumentation status
+ */
+static int unpatch_normal_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym)
+{
+	/*
+	 * Let assume that we have the following instructions.
+	 *
+	 *     0x0: call <trampoline>
+	 *     0x5: <nop instructions>
+	 *     0xb: <other instructions>
+	 *
+	 * The goal is to modify the instructions in order to get the following
+	 * instructions.
+	 *
+	 *     0x0: push %rbp
+	 *     0x1: mov  %rsp,%rbp
+	 *     0x4: lea  0xeb0(%rip),%rdi
+	 *     0xb: <other instructions>
+	 */
+
+	unsigned long origin_code_addr;
+	unsigned call_offset = CALL_INSN_SIZE;
+	struct mcount_orig_insn *orig;
+	uint8_t *origin_code;
+	int orig_size;
+
+	origin_code_addr = mdi->map->start + sym->addr;
+	if (check_endbr64(origin_code_addr))
+		origin_code_addr += ENDBR_INSN_SIZE;
+	orig = mcount_find_insn(origin_code_addr + call_offset);
+	if (!orig) {
+		pr_dbg("cannot find original instructions for '%s' at %#lx\n",
+		       origin_code_addr + call_offset, sym->name);
+		return -1;
+	}
+	origin_code = orig->orig;
+	orig_size = orig->orig_size;
+
+	pr_dbg2("unpatch normal func: %s (patch size: %d)\n", sym->name, orig_size);
+
+	/*
+	 * The first step is to insert a trap.
+	 *
+	 *     0x0: int3
+	 *     0x1: <trampoline>
+	 *     0x5: <nop instructions>
+	 *     0xb: <other instructions>
+	 */
+
+	((uint8_t *)origin_code_addr)[0] = 0xcc;
+
+	/*
+	 * The second step is to restore the bytes after the trap instruction.
+	 *
+	 *     0x0: int3
+	 *     0x1: mov  %rsp,%rbp
+	 *     0x4: lea  0xeb0(%rip),%rdi
+	 *     0xb: <other instructions>
+	 *
+	 * Before restoring the last byte, a serialization instruction must be
+	 * executed in order to synchronize the instruction cache of each processor.
+	 * The easiest method is to execute a membarrier system call with
+	 * MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE. It will send a
+	 * inter-processor interrupt that will execute the required serialization.
+	 */
+
+	synchronize_all_cores();
+
+	if (!memcpy(&((uint8_t *)origin_code_addr)[1], &origin_code[1], orig_size - 1))
+		return -1;
+
+	/*
+	 * The third step is to restore the last byte.
+	 *
+	 *     0x0: push %rbp
+	 *     0x1: mov  %rsp,%rbp
+	 *     0x4: lea  0xeb0(%rip),%rdi
+	 *     0xb: <other instructions>
+	 */
+
+	((uint8_t *)origin_code_addr)[0] = origin_code[0];
+
+	/*
+	 * The fourth and last step is to move all thread that are currently
+	 * executing in the modified instructions to the original instructions at
+	 * the end of the trampoline. This is needed in order to free the memory
+	 * allocated for the trampoline without any race condition.
+	 *
+	 * The method used to move the threads is to send the SIGRTMIN+n signal to
+	 * all other threads. When their thread handler executes, it will check if
+	 * the next instruction pointer is in the patching region. If it is, will
+	 * move the next instruction pointer to the equivalent modified instruction.
+	 */
+
+	return INSTRUMENT_SUCCESS;
+}
+
 static int unpatch_func(uint8_t *insn, char *name)
 {
 	uint8_t nop5[] = { 0x0f, 0x1f, 0x44, 0x00, 0x00 };
@@ -1137,8 +1241,7 @@ int mcount_patch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sy
 	return result;
 }
 
-int mcount_unpatch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym,
-			struct mcount_disasm_engine *disasm)
+int mcount_unpatch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym)
 {
 	int result = INSTRUMENT_SKIPPED;
 
@@ -1149,6 +1252,10 @@ int mcount_unpatch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *
 
 	case DYNAMIC_PG:
 		result = unpatch_mcount_func(mdi, sym);
+		break;
+
+	case DYNAMIC_NONE:
+		result = unpatch_normal_func(mdi, sym);
 		break;
 
 	default:

--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -28,6 +28,8 @@ static const unsigned char patchable_clang_nop[] = { 0x0f, 0x1f, 0x44, 0x00, 0x0
 
 static const unsigned char endbr64[] = { 0xf3, 0x0f, 0x1e, 0xfa };
 
+extern bool mcount_target_running;
+
 /*
  * Hashmap of trampoline locations for every installed int3 trap. The traps are
  * used when patching and unpatching functions: they prevent threads from
@@ -997,8 +999,14 @@ static int patch_normal_func_init(struct mcount_dynamic_info *mdi, struct uftrac
 	else
 		mcount_save_code(info, call_offset, jmp_insn, sizeof(jmp_insn));
 
-	state = patch_region_lock(mdi, info);
-	commit_normal_func(&normal_funcs_patch, mdi, info);
+	if (mcount_target_running) {
+		state = patch_region_lock(mdi, info);
+		commit_normal_func(&normal_funcs_patch, mdi, info);
+	}
+	else {
+		patch_code(mdi, info);
+		patch_region_unlock(info);
+	}
 
 	return state;
 }
@@ -1010,6 +1018,9 @@ static int patch_normal_func_init(struct mcount_dynamic_info *mdi, struct uftrac
 void mcount_patch_normal_func_fini()
 {
 	struct patch_dynamic_info *pdi, *tmp;
+
+	if (!mcount_target_running)
+		return;
 
 	if (list_empty(&normal_funcs_patch))
 		return;
@@ -1122,26 +1133,32 @@ static int unpatch_normal_func_init(struct mcount_dynamic_info *mdi, struct uftr
 
 	pr_dbg2("unpatch normal func: %s (patch size: %d)\n", sym->name, orig_size);
 
-	/*
-	 * The first step is to insert a trap.
-	 *
-	 *     0x0: int3
-	 *     0x1: <trampoline>
-	 *     0x5: <nop instructions>
-	 *     0xb: <other instructions>
-	 */
+	if (mcount_target_running) {
+		info = xmalloc(sizeof(*info));
+		memset(info, 0, sizeof(*info));
+		info->sym = sym;
+		info->addr = mdi->map->start + sym->addr;
+		ASSERT(orig_size < 64); /* fit into info->insns */
+		memcpy(info->insns, origin_code, orig_size);
+		info->orig_size = orig_size;
 
-	register_trap((void *)origin_code_addr, (void *)mdi->trampoline);
-	((uint8_t *)origin_code_addr)[0] = 0xcc;
+		/* The first step is to insert a trap.
+		 *
+		 *     0x0: int3
+		 *     0x1: <trampoline>
+		 *     0x5: <nop instructions>
+		 *     0xb: <other instructions>
+		 */
 
-	info = xmalloc(sizeof(*info));
-	memset(info, 0, sizeof(*info));
-	info->sym = sym;
-	info->addr = mdi->map->start + sym->addr;
-	ASSERT(orig_size < 64); /* fit into info->insns */
-	memcpy(info->insns, origin_code, orig_size);
-	info->orig_size = orig_size;
-	commit_normal_func(&normal_funcs_unpatch, mdi, info);
+		register_trap((void *)origin_code_addr, (void *)mdi->trampoline);
+		((uint8_t *)origin_code_addr)[0] = 0xcc;
+
+		commit_normal_func(&normal_funcs_unpatch, mdi, info);
+	}
+	else {
+		if (!memcpy((uint8_t *)origin_code_addr, origin_code, orig_size))
+			return INSTRUMENT_FAILED;
+	}
 
 	return 0;
 }
@@ -1177,6 +1194,9 @@ int unpatch_region_unlock(struct mcount_disasm_info *info)
 void mcount_unpatch_normal_func_fini()
 {
 	struct patch_dynamic_info *pdi, *tmp;
+
+	if (!mcount_target_running)
+		return;
 
 	if (list_empty(&normal_funcs_unpatch))
 		return;

--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -327,10 +327,10 @@ static void leave_patch_region(int sig, siginfo_t *info, void *ucontext)
 }
 
 /**
- * clear_patch_region - move threads that are in a patching region out of line
+ * clear_patch_regions - move threads that are in a patching region out of line
  * @return - 0
  */
-static int clear_patch_region()
+static int clear_patch_regions()
 {
 	int signal_count;
 	int move_count = 0;
@@ -396,6 +396,32 @@ int setup_clear_patch_region()
 
 	pr_dbg("configured clear signal (SIGRT%d) handler\n", sig_clear_patch_region);
 	return 0;
+}
+
+/* This list is used to store functions that need to be optimized or cleaned up
+ * later in the code. In both case, a SIGRTMIN+n must be send. By optimizing or
+ * cleaning all of them up at the same time, we only need to send one signal per
+ * thread.
+ */
+LIST_HEAD(normal_funcs_patch);
+
+struct patch_dynamic_info {
+	struct list_head list;
+	struct mcount_dynamic_info *mdi;
+	struct mcount_disasm_info *info;
+};
+
+static void commit_normal_func(struct list_head *list, struct mcount_dynamic_info *mdi,
+			       struct mcount_disasm_info *info)
+{
+	struct patch_dynamic_info *pdi;
+	pdi = xmalloc(sizeof(*pdi));
+
+	pdi->mdi = mdi;
+	pdi->info = info;
+	INIT_LIST_HEAD(&pdi->list);
+
+	list_add(&pdi->list, list);
 }
 
 /**
@@ -790,12 +816,14 @@ static int patch_xray_func(struct mcount_dynamic_info *mdi, struct uftrace_symbo
 }
 
 /**
- * patch_code - inject a call to an instrumentation trampoline
- * @mdi    - dynamic info about the concerned module
- * @info   - disassembly info (instructions address and size)
- * @return - instrumentation status
+ * patch_region_lock - insert a trap at the beginning of a patching region so no
+ * new incoming thread will execute it, and register the region as critical for
+ * next step
+ * @mdi    - mcount dynamic info
+ * @info   - disassembly info for the patched symbol
+ * @return - INSTRUMENT_SUCCESS
  */
-static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info *info)
+static int patch_region_lock(struct mcount_dynamic_info *mdi, struct mcount_disasm_info *info)
 {
 	/*
 	 * Let's assume we have the following instructions.
@@ -814,13 +842,10 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 	 */
 
 	void *origin_code_addr;
-	void *trampoline_rel_addr;
 
 	origin_code_addr = (void *)info->addr;
 	if (info->has_intel_cet)
 		origin_code_addr += ENDBR_INSN_SIZE;
-
-	trampoline_rel_addr = (void *)get_trampoline_offset(mdi, (unsigned long)origin_code_addr);
 
 	/* The first step is to insert a 1-byte trap-based probe point (atomic).
 	 * This will prevent threads to enter the critical zone while we patch it,
@@ -832,19 +857,13 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 	 *     0xb: <other instructions>
 	 *
 	 * The trap will emulate a call to the trampoline while in place.
-	 *
-	 * We ensure that every core sees the trap before patching the critical
-	 * zone, by synchronizing the them.
 	 */
 
 	if (register_trap(origin_code_addr, (void *)mdi->trampoline) == -1)
 		return INSTRUMENT_FAILED;
 	((uint8_t *)origin_code_addr)[0] = 0xcc;
 
-	synchronize_all_cores();
-
-	/*
-	 * The second step is to move any thread out of the critical zone if still
+	/* The second step is to move any thread out of the critical zone if still
 	 * present. Threads in the critical zone resume execution out of line, in
 	 * their dedicated OLX region.
 	 *
@@ -856,8 +875,26 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 
 	if (register_patch_region(origin_code_addr, info->orig_size) == -1)
 		pr_dbg3("failed to register patch region\n");
-	clear_patch_region();
-	unregister_patch_region(origin_code_addr, info->orig_size);
+
+	return INSTRUMENT_SUCCESS;
+}
+
+/**
+ * patch_code - patch a region of the code with the operand of the call
+ * instruction used to probe a function. The call opcode needs to be inserted
+ * later.
+ * @mdi  - mcount dynamic info for the current module
+ * @info - disassembly info for the patched symbol
+ */
+static void patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info *info)
+{
+	void *trampoline_rel_addr;
+	void *origin_code_addr;
+
+	origin_code_addr = (void *)info->addr;
+	if (info->has_intel_cet)
+		origin_code_addr += ENDBR_INSN_SIZE;
+	trampoline_rel_addr = (void *)get_trampoline_offset(mdi, (unsigned long)origin_code_addr);
 
 	/* The third step is to write the target address of the call. From the
 	 * processor view the 4-bytes address can be any garbage instructions.
@@ -873,7 +910,23 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 	memcpy(&((uint8_t *)origin_code_addr)[1], &trampoline_rel_addr, CALL_INSN_SIZE - 1);
 	memset(origin_code_addr + CALL_INSN_SIZE, 0x90, /* NOP */
 	       info->orig_size - CALL_INSN_SIZE);
-	/* FIXME Need to sync cores? Store membarrier? */
+}
+
+/**
+ * patch_region_unlock - unmark a region as critical and remove the trap that
+ * prevents execution.
+ * @info   - disassembly info for the patched symbol
+ */
+static void patch_region_unlock(struct mcount_disasm_info *info)
+{
+	void *origin_code_addr;
+
+	origin_code_addr = (void *)info->addr;
+	if (info->has_intel_cet)
+		origin_code_addr += ENDBR_INSN_SIZE;
+
+	if (unregister_patch_region(origin_code_addr, info->orig_size) == -1)
+		pr_dbg3("failed to unregister patch region\n");
 
 	/*
 	 * The fourth and last step is to replace the trap with the call opcode.
@@ -884,13 +937,19 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 	 */
 
 	((uint8_t *)origin_code_addr)[0] = 0xe8;
-	unregister_trap(origin_code_addr);
-
-	return INSTRUMENT_SUCCESS;
 }
 
-static int patch_normal_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym,
-			     struct mcount_disasm_engine *disasm)
+/**
+ * patch_normal_func_init - perform the initial steps of the patching process,
+ * awaiting for sanitization of the critical region. This step is batched with
+ * subsequent ones.
+ * @mdi    - mcount dynamic info for the current module
+ * @sym    - symbol to patch
+ * @disasm - disassembly engine
+ * @return - instrumentation status
+ */
+static int patch_normal_func_init(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym,
+				  struct mcount_disasm_engine *disasm)
 {
 	uint8_t jmp_insn[15] = {
 		0x3e,
@@ -898,20 +957,22 @@ static int patch_normal_func(struct mcount_dynamic_info *mdi, struct uftrace_sym
 		0x25,
 	};
 	uint64_t jmp_target;
-	struct mcount_disasm_info info = {
-		.sym = sym,
-		.addr = mdi->map->start + sym->addr,
-	};
+	struct mcount_disasm_info *info;
 	unsigned call_offset = CALL_INSN_SIZE;
 	int state;
 
-	state = disasm_check_insns(disasm, mdi, &info);
+	info = xmalloc(sizeof(*info));
+	memset(info, 0, sizeof(*info));
+	info->sym = sym;
+	info->addr = mdi->map->start + sym->addr;
+
+	state = disasm_check_insns(disasm, mdi, info);
 	if (state != INSTRUMENT_SUCCESS) {
 		pr_dbg3("  >> %s: %s\n", state == INSTRUMENT_FAILED ? "FAIL" : "SKIP", sym->name);
 		return state;
 	}
 
-	pr_dbg2("force patch normal func: %s (patch size: %d)\n", sym->name, info.orig_size);
+	pr_dbg2("force patch normal func: %s (patch size: %d)\n", sym->name, info->orig_size);
 
 	/*
 	 *  stored origin instruction block:
@@ -923,20 +984,62 @@ static int patch_normal_func(struct mcount_dynamic_info *mdi, struct uftrace_sym
 	 *  | [Return   address] |
 	 *  ----------------------
 	 */
-	jmp_target = info.addr + info.orig_size;
-	if (info.has_intel_cet) {
+	jmp_target = info->addr + info->orig_size;
+	if (info->has_intel_cet) {
 		jmp_target += ENDBR_INSN_SIZE;
 		call_offset += ENDBR_INSN_SIZE;
 	}
 
 	memcpy(jmp_insn + CET_JMP_INSN_SIZE, &jmp_target, sizeof(jmp_target));
 
-	if (info.has_jump)
-		mcount_save_code(&info, call_offset, jmp_insn, 0);
+	if (info->has_jump)
+		mcount_save_code(info, call_offset, jmp_insn, 0);
 	else
-		mcount_save_code(&info, call_offset, jmp_insn, sizeof(jmp_insn));
+		mcount_save_code(info, call_offset, jmp_insn, sizeof(jmp_insn));
 
-	return patch_code(mdi, &info);
+	state = patch_region_lock(mdi, info);
+	commit_normal_func(&normal_funcs_patch, mdi, info);
+
+	return state;
+}
+
+/**
+ * mcount_patch_normal_func_fini - perform the final step of the patching process and cleanup
+ * @return - 0
+ */
+void mcount_patch_normal_func_fini()
+{
+	struct patch_dynamic_info *pdi, *tmp;
+
+	if (list_empty(&normal_funcs_patch))
+		return;
+
+	/* We ensure that every core sees the trap before patching the critical
+	 * zone, by synchronizing the them.
+	 */
+	synchronize_all_cores();
+	clear_patch_regions();
+
+	list_for_each_entry_safe(pdi, tmp, &normal_funcs_patch, list) {
+		patch_code(pdi->mdi, pdi->info);
+		write_memory_barrier();
+		patch_region_unlock(pdi->info);
+	}
+
+	synchronize_all_cores();
+
+	list_for_each_entry_safe(pdi, tmp, &normal_funcs_patch, list) {
+		void *origin_code_addr;
+
+		origin_code_addr = (void *)pdi->info->addr;
+		if (pdi->info->has_intel_cet)
+			origin_code_addr += ENDBR_INSN_SIZE;
+
+		unregister_trap(origin_code_addr);
+		list_del(&pdi->list);
+		free(pdi->info);
+		free(pdi);
+	}
 }
 
 static int unpatch_func(uint8_t *insn, char *name)
@@ -1025,7 +1128,7 @@ int mcount_patch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sy
 		break;
 
 	case DYNAMIC_NONE:
-		result = patch_normal_func(mdi, sym, disasm);
+		result = patch_normal_func_init(mdi, sym, disasm);
 		break;
 
 	default:

--- a/arch/x86_64/mcount-insn.c
+++ b/arch/x86_64/mcount-insn.c
@@ -19,8 +19,17 @@ struct disasm_check_data {
 	uint32_t size;
 };
 
+/**
+ * mcount_disasm_init - initialize the capstone engine once
+ * @disasm - mcount disassembly engine
+ */
 void mcount_disasm_init(struct mcount_disasm_engine *disasm)
 {
+	if (disasm->engine)
+		return;
+
+	pr_dbg2("initialize disassembly engine\n");
+
 	if (cs_open(CS_ARCH_X86, CS_MODE_64, &disasm->engine) != CS_ERR_OK) {
 		pr_dbg("failed to init capstone disasm engine\n");
 		return;
@@ -653,7 +662,7 @@ TEST_CASE(dynamic_x86_handle_lea)
 		.addr = 0x3000,
 		.size = 32,
 	};
-	struct mcount_disasm_engine disasm;
+	struct mcount_disasm_engine disasm = { 0 };
 	struct mcount_disasm_info info = {
 		.sym = &sym,
 		.addr = ORIGINAL_BASE + sym.addr,
@@ -724,7 +733,7 @@ TEST_CASE(dynamic_x86_handle_call)
 		.addr = 0x4000,
 		.size = 32,
 	};
-	struct mcount_disasm_engine disasm;
+	struct mcount_disasm_engine disasm = { 0 };
 	struct mcount_disasm_info info = {
 		.sym = &sym1,
 		.addr = ORIGINAL_BASE + sym1.addr,
@@ -802,7 +811,7 @@ TEST_CASE(dynamic_x86_handle_jmp)
 		.addr = 0x3000,
 		.size = 32,
 	};
-	struct mcount_disasm_engine disasm;
+	struct mcount_disasm_engine disasm = { 0 };
 	struct mcount_disasm_info info = {
 		.sym = &sym,
 		.addr = ORIGINAL_BASE + sym.addr,
@@ -906,7 +915,7 @@ TEST_CASE(dynamic_x86_handle_jcc)
 		.addr = 0x3000,
 		.size = 32,
 	};
-	struct mcount_disasm_engine disasm;
+	struct mcount_disasm_engine disasm = { 0 };
 	struct mcount_disasm_info info = {
 		.sym = &sym,
 		.addr = ORIGINAL_BASE + sym.addr,
@@ -1015,7 +1024,7 @@ TEST_CASE(dynamic_x86_handle_mov_load)
 		.addr = 0x3000,
 		.size = 32,
 	};
-	struct mcount_disasm_engine disasm;
+	struct mcount_disasm_engine disasm = { 0 };
 	struct mcount_disasm_info info = {
 		.sym = &sym,
 		.addr = ORIGINAL_BASE + sym.addr,

--- a/arch/x86_64/mcount-insn.c
+++ b/arch/x86_64/mcount-insn.c
@@ -578,8 +578,11 @@ int disasm_check_insns(struct mcount_disasm_engine *disasm, struct mcount_dynami
 	cs_insn *insn = NULL;
 	uint32_t count, i, size;
 	uint8_t endbr64[] = { 0xf3, 0x0f, 0x1e, 0xfa };
+	void *trampoline_addr;
+	uint8_t *operand;
 	struct dynamic_bad_symbol *badsym;
 	unsigned long addr = info->addr;
+	bool is_call, is_trampoline;
 
 	badsym = mcount_find_badsym(mdi, info->addr);
 	if (badsym != NULL) {
@@ -610,6 +613,20 @@ int disasm_check_insns(struct mcount_disasm_engine *disasm, struct mcount_dynami
 	count = cs_disasm(disasm->engine, (void *)addr, size, addr, 0, &insn);
 	if (count == 0)
 		return INSTRUMENT_FAILED;
+
+	/* Check for pre-existing dynamic instrumentation
+	  1. check if opcode is call
+	  2. check operand is trampoline address */
+	operand = &((uint8_t *)info->addr)[1];
+	trampoline_addr = (void *)mdi->trampoline - (info->addr + CALL_INSN_SIZE);
+	is_call = ((uint8_t *)info->addr)[0] == 0xe8;
+	if (is_call) {
+		is_trampoline = !memcmp(operand, &trampoline_addr, CALL_INSN_SIZE - 1);
+		if (is_trampoline) {
+			pr_dbg2("skip dynamically patched func: %s\n", info->sym->name);
+			return INSTRUMENT_SKIPPED;
+		}
+	}
 
 	for (i = 0; i < count; i++) {
 		uint8_t insns_byte[32] = {

--- a/check-deps/Makefile
+++ b/check-deps/Makefile
@@ -14,6 +14,7 @@ CHECK_LIST += have_libdw
 CHECK_LIST += have_libunwind
 CHECK_LIST += have_libcapstone
 CHECK_LIST += cc_has_minline_all_stringops
+CHECK_LIST += have_membarrier
 
 #
 # This is needed for checking build dependency

--- a/check-deps/Makefile.check
+++ b/check-deps/Makefile.check
@@ -82,3 +82,7 @@ endif
 ifneq ($(wildcard $(objdir)/check-deps/cc_has_minline_all_stringops),)
   LIB_CFLAGS += -minline-all-stringops
 endif
+
+ifneq ($(wildcard $(objdir)/check-deps/have_membarrier),)
+  LIB_CFLAGS += -DHAVE_MEMBARRIER
+endif

--- a/check-deps/__have_membarrier.c
+++ b/check-deps/__have_membarrier.c
@@ -1,0 +1,10 @@
+#include <linux/membarrier.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+int main()
+{
+	syscall(__NR_membarrier, MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED_SYNC_CORE, 0, 0);
+	syscall(__NR_membarrier, MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE, 0, 0);
+	return 0;
+}

--- a/cmds/live.c
+++ b/cmds/live.c
@@ -340,9 +340,10 @@ static int forward_options(struct uftrace_opts *opts)
 	if (capabilities < 0)
 		goto close;
 
-	/* FIXME Forward user options and set status */
-	if (0)
-		status = forward_option(sfd, capabilities, 0, NULL, 0);
+	status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_PATTERN, &opts->patt_type,
+				sizeof(opts->patt_type));
+	if (status < 0)
+		goto close;
 
 close:
 	status_close = agent_message_send(sfd, UFTRACE_MSG_AGENT_CLOSE, NULL, 0);

--- a/cmds/live.c
+++ b/cmds/live.c
@@ -340,10 +340,19 @@ static int forward_options(struct uftrace_opts *opts)
 	if (capabilities < 0)
 		goto close;
 
-	status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_PATTERN, &opts->patt_type,
-				sizeof(opts->patt_type));
-	if (status < 0)
-		goto close;
+	if (opts->patch) { /* provide a pattern type for options that need it */
+		status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_PATTERN,
+					&opts->patt_type, sizeof(opts->patt_type));
+		if (status < 0)
+			goto close;
+	}
+
+	if (opts->patch) {
+		status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_PATCH, opts->patch,
+					strlen(opts->patch) + 1);
+		if (status < 0)
+			goto close;
+	}
 
 close:
 	status_close = agent_message_send(sfd, UFTRACE_MSG_AGENT_CLOSE, NULL, 0);

--- a/configure
+++ b/configure
@@ -35,6 +35,7 @@ usage() {
   --without-capstone    build without libcapstone            (even if found on the system)
   --without-perf        build without perf event             (even if available)
   --without-schedule    build without scheduler event        (even if available)
+  --without-membarrier  build without membarriers            (even if available)
 
   --arch=<ARCH>         set target architecture              (default: system default arch)
                         e.g. x86_64, aarch64, i386, or arm
@@ -198,6 +199,7 @@ for dep in $IGNORE; do
         capstone)    TARGET=have_libcapstone   ;;
         perf*)       TARGET=perf_clockid       ;;
         sched*)      TARGET=perf_context_switch;;
+        membarrier)  TARGET=have_membarrier    ;;
         *)           ;;
     esac
     if [ ! -z "$TARGET" ]; then
@@ -265,6 +267,7 @@ print_feature "perf_event" "perf_clockid" "perf (PMU) event support"
 print_feature "schedule" "perf_context_switch" "scheduler event support"
 print_feature "capstone" "have_libcapstone" "full dynamic tracing support"
 print_feature "libunwind" "have_libunwind" "stacktrace support (optional for debugging)"
+print_feature "membarrier" "have_membarrier" "membarrier support (requires Linux 4.16.0)"
 
 cat >$output <<EOF
 # this file is generated automatically

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -515,11 +515,8 @@ static bool skip_sym(struct uftrace_symbol *sym, struct mcount_dynamic_info *mdi
 	if (sym->type != ST_LOCAL_FUNC && sym->type != ST_GLOBAL_FUNC && sym->type != ST_WEAK_FUNC)
 		return true;
 
-	if (!match_pattern_list(map, soname, sym->name)) {
-		if (mcount_unpatch_func(mdi, sym, &disasm) == 0)
-			stats.unpatch++;
+	if (!match_pattern_list(map, soname, sym->name))
 		return true;
-	}
 
 	return false;
 }

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -652,6 +652,8 @@ static int do_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 		patch_func_matched(mdi, map);
 	}
 
+	release_pattern_list();
+
 	if (stats.failed + stats.skipped + stats.nomatch == 0) {
 		pr_dbg("patched all (%d) functions in '%s'\n", stats.total,
 		       basename(sinfo->filename));

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -231,6 +231,10 @@ __weak void mcount_patch_normal_func_fini()
 {
 }
 
+__weak void mcount_unpatch_normal_func_fini()
+{
+}
+
 __weak int mcount_unpatch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym)
 {
 	return -1;
@@ -624,6 +628,7 @@ static void patch_normal_func_matched(struct mcount_dynamic_info *mdi, struct uf
 		stats.nomatch++;
 
 	mcount_patch_normal_func_fini();
+	mcount_unpatch_normal_func_fini();
 
 	free(soname);
 }

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -355,6 +355,21 @@ static void prepare_dynamic_update(struct uftrace_sym_info *sinfo, bool needs_mo
 	dl_iterate_phdr(find_dynamic_module, &fmd);
 }
 
+/**
+ * setup_size_filter - initialize size filter if not set
+ */
+void setup_size_filter()
+{
+	char *size_filter;
+
+	if (min_size)
+		return;
+
+	size_filter = getenv("UFTRACE_MIN_SIZE");
+	if (size_filter)
+		min_size = strtoul(size_filter, NULL, 0);
+}
+
 struct mcount_dynamic_info *setup_trampoline(struct uftrace_mmap *map)
 {
 	struct mcount_dynamic_info *mdi;
@@ -676,16 +691,13 @@ int mcount_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 			  enum uftrace_pattern_type ptype)
 {
 	int ret = 0;
-	char *size_filter;
 	bool needs_modules = !!strchr(patch_funcs, '@');
 
 	mcount_disasm_init(&disasm);
 
 	prepare_dynamic_update(sinfo, needs_modules);
 
-	size_filter = getenv("UFTRACE_MIN_SIZE");
-	if (size_filter != NULL)
-		min_size = strtoul(size_filter, NULL, 0);
+	setup_size_filter();
 
 	ret = do_dynamic_update(sinfo, patch_funcs, ptype);
 

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -294,8 +294,15 @@ static struct mcount_dynamic_info *create_mdi(struct dl_phdr_info *info)
 	return mdi;
 }
 
-/* callback for dl_iterate_phdr() */
-static int find_dynamic_module(struct dl_phdr_info *info, size_t sz, void *data)
+/**
+ * prepare_dynamic_module - store dynamic module info and install trampoline;
+ * callback for dl_iterate_phdr()
+ * @info   - module info
+ * @sz     - data size (unused)
+ * @data   - callback data: symbol info and module parsing flag
+ * @return - stop iteration on non-zero value
+ */
+static int prepare_dynamic_module(struct dl_phdr_info *info, size_t sz, void *data)
 {
 	struct mcount_dynamic_info *mdi;
 	struct find_module_data *fmd = data;
@@ -314,6 +321,9 @@ static int find_dynamic_module(struct dl_phdr_info *info, size_t sz, void *data)
 	if (map && map->mod) {
 		mdi->map = map;
 		mcount_arch_find_module(mdi, &map->mod->symtab);
+
+		if (mcount_setup_trampoline(mdi) < 0)
+			mdi->trampoline = 0;
 
 		mdi->next = mdinfo;
 		mdinfo = mdi;
@@ -352,7 +362,7 @@ static void prepare_dynamic_update(struct uftrace_sym_info *sinfo, bool needs_mo
 	else
 		return;
 
-	dl_iterate_phdr(find_dynamic_module, &fmd);
+	dl_iterate_phdr(prepare_dynamic_module, &fmd);
 }
 
 /**
@@ -629,10 +639,18 @@ static void patch_func_matched(struct mcount_dynamic_info *mdi, struct uftrace_m
 		patch_normal_func_matched(mdi, map);
 }
 
+/**
+ * do_dynamic_update - apply (un)patching across loaded modules' maps
+ * @sinfo       - dynamic symbol info
+ * @patch_funcs - spec of symbols to (un)patch
+ * @ptype       - matching pattern type
+ * @return      - 0 (unused)
+ */
 static int do_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 			     enum uftrace_pattern_type ptype)
 {
 	struct uftrace_mmap *map;
+	struct mcount_dynamic_info *mdi;
 	char *def_mod;
 
 	if (patch_funcs == NULL)
@@ -641,15 +659,11 @@ static int do_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 	def_mod = basename(sinfo->exec_map->libname);
 	parse_pattern_list(patch_funcs, def_mod, ptype);
 
-	for_each_map(sinfo, map) {
-		struct mcount_dynamic_info *mdi;
-
-		/* TODO: filter out unsuppported libs */
-		mdi = setup_trampoline(map);
-		if (mdi == NULL)
-			continue;
-
-		patch_func_matched(mdi, map);
+	/* TODO: filter out unsupported libs */
+	for (mdi = mdinfo; mdi != NULL; mdi = mdi->next) {
+		map = mdi->map;
+		if (mdi->trampoline)
+			patch_func_matched(mdi, map);
 	}
 
 	release_pattern_list();
@@ -660,24 +674,6 @@ static int do_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 	}
 
 	return 0;
-}
-
-static void freeze_dynamic_update(void)
-{
-	struct mcount_dynamic_info *mdi, *tmp;
-
-	mdi = mdinfo;
-	while (mdi) {
-		tmp = mdi->next;
-
-		mcount_arch_dynamic_recover(mdi, &disasm);
-		mcount_cleanup_trampoline(mdi);
-		free(mdi);
-
-		mdi = tmp;
-	}
-
-	mcount_freeze_code();
 }
 
 /* do not use floating-point in libmcount */
@@ -724,7 +720,7 @@ int mcount_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 		pr_dbg("no match: %8d\n", stats.nomatch);
 	}
 
-	freeze_dynamic_update();
+	mcount_freeze_code();
 	return ret;
 }
 
@@ -770,9 +766,29 @@ void mcount_dynamic_dlopen(struct uftrace_sym_info *sinfo, struct dl_phdr_info *
 	mcount_freeze_code();
 }
 
+/**
+ * mcount_free_mdinfo - free all dynamic info structures
+ */
+static void mcount_free_mdinfo(void)
+{
+	struct mcount_dynamic_info *mdi, *tmp;
+
+	mdi = mdinfo;
+	while (mdi) {
+		tmp = mdi->next;
+
+		mcount_arch_dynamic_recover(mdi, &disasm);
+		mcount_cleanup_trampoline(mdi);
+		free(mdi);
+
+		mdi = tmp;
+	}
+}
+
 void mcount_dynamic_finish(void)
 {
 	release_pattern_list();
+	mcount_free_mdinfo();
 	mcount_disasm_finish(&disasm);
 }
 

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -52,6 +52,7 @@ struct code_page {
 
 static LIST_HEAD(code_pages);
 
+/* contains out-of-line execution code (return address -> modified instructions ptr) */
 static struct Hashmap *code_hmap;
 
 /* minimum function size for dynamic update */

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -455,7 +455,6 @@ static void parse_pattern_list(char *patch_funcs, char *def_mod, enum uftrace_pa
 	char *name;
 	int j;
 	struct patt_list *pl;
-	bool all_negative = true;
 
 	strv_split(&funcs, patch_funcs, ";");
 
@@ -466,10 +465,8 @@ static void parse_pattern_list(char *patch_funcs, char *def_mod, enum uftrace_pa
 
 		if (name[0] == '!')
 			name++;
-		else {
+		else
 			pl->positive = true;
-			all_negative = false;
-		}
 
 		delim = strchr(name, '@');
 		if (delim == NULL) {
@@ -482,20 +479,6 @@ static void parse_pattern_list(char *patch_funcs, char *def_mod, enum uftrace_pa
 
 		init_filter_pattern(ptype, &pl->patt, name);
 		list_add_tail(&pl->list, &patterns);
-	}
-
-	/* prepend match-all pattern, if all patterns are negative */
-	if (all_negative) {
-		pl = xzalloc(sizeof(*pl));
-		pl->positive = true;
-		pl->module = xstrdup(def_mod);
-
-		if (ptype == PATT_REGEX)
-			init_filter_pattern(ptype, &pl->patt, ".");
-		else
-			init_filter_pattern(PATT_GLOB, &pl->patt, "*");
-
-		list_add(&pl->list, &patterns);
 	}
 
 	strv_free(&funcs);

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -227,6 +227,10 @@ __weak int mcount_patch_func(struct mcount_dynamic_info *mdi, struct uftrace_sym
 	return -1;
 }
 
+__weak void mcount_patch_normal_func_fini()
+{
+}
+
 __weak int mcount_unpatch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym,
 			       struct mcount_disasm_engine *disasm)
 {
@@ -619,6 +623,8 @@ static void patch_normal_func_matched(struct mcount_dynamic_info *mdi, struct uf
 
 	if (!found)
 		stats.nomatch++;
+
+	mcount_patch_normal_func_fini();
 
 	free(soname);
 }

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -689,6 +689,14 @@ static int calc_percent(int n, int total, int *rem)
 	return quot;
 }
 
+/**
+ * mcount_dynamic_update - prepare and perform dynamic patching or unpatching,
+ * then display statistics
+ * @sinfo       - dynamic symbol info
+ * @patch_funcs - spec of symbols to patch or unpatch
+ * @ptype       - matching pattern type
+ * @return      - 0 (unused)
+ */
 int mcount_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 			  enum uftrace_pattern_type ptype)
 {
@@ -696,9 +704,7 @@ int mcount_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 	bool needs_modules = !!strchr(patch_funcs, '@');
 
 	mcount_disasm_init(&disasm);
-
 	prepare_dynamic_update(sinfo, needs_modules);
-
 	setup_size_filter();
 
 	ret = do_dynamic_update(sinfo, patch_funcs, ptype);

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -231,8 +231,7 @@ __weak void mcount_patch_normal_func_fini()
 {
 }
 
-__weak int mcount_unpatch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym,
-			       struct mcount_disasm_engine *disasm)
+__weak int mcount_unpatch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym)
 {
 	return -1;
 }
@@ -618,7 +617,7 @@ static void patch_normal_func_matched(struct mcount_dynamic_info *mdi, struct uf
 		else if (match == 1)
 			mcount_patch_func_with_stats(mdi, sym);
 		else
-			mcount_unpatch_func(mdi, sym, NULL);
+			mcount_unpatch_func(mdi, sym);
 	}
 
 	if (!found)

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -60,6 +60,8 @@ static unsigned min_size;
 /* disassembly engine for dynamic code patch (for capstone) */
 static struct mcount_disasm_engine disasm;
 
+static bool mcount_dynamic_is_initialized;
+
 static struct mcount_orig_insn *create_code(struct Hashmap *map, unsigned long addr)
 {
 	struct mcount_orig_insn *entry;
@@ -245,6 +247,11 @@ __weak void mcount_disasm_init(struct mcount_disasm_engine *disasm)
 
 __weak void mcount_disasm_finish(struct mcount_disasm_engine *disasm)
 {
+}
+
+__weak int mcount_arch_dynamic_init(void)
+{
+	return -1;
 }
 
 __weak int mcount_arch_branch_table_size(struct mcount_disasm_info *info)
@@ -652,6 +659,13 @@ static int do_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 
 	/* TODO: filter out unsupported libs */
 	for (mdi = mdinfo; mdi != NULL; mdi = mdi->next) {
+		if (mdi->type == DYNAMIC_NONE && !mcount_dynamic_is_initialized) {
+			if (mcount_arch_dynamic_init() >= 0)
+				mcount_dynamic_is_initialized = true;
+			else
+				continue;
+		}
+
 		map = mdi->map;
 		if (mdi->trampoline)
 			patch_func_matched(mdi, map);

--- a/libmcount/dynamic.h
+++ b/libmcount/dynamic.h
@@ -68,6 +68,12 @@ struct mcount_disasm_engine {
 #define INSTRUMENT_FAILED -1
 #define INSTRUMENT_SKIPPED -2
 
+struct mcount_dynamic_stats {
+	int success;
+	int failed;
+	int skipped;
+};
+
 /*
  * Supposing the size of smallest conditional branch is 2 byte.
  * We can replace, at most, 3 of them by the instrumentation

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -113,7 +113,7 @@ static pthread_t agent;
 /* state flag for the agent */
 static volatile bool agent_run = false;
 
-#define MCOUNT_AGENT_CAPABILITIES (UFTRACE_AGENT_OPT_PATTERN)
+#define MCOUNT_AGENT_CAPABILITIES (UFTRACE_AGENT_OPT_PATTERN | UFTRACE_AGENT_OPT_PATCH)
 
 __weak void dynamic_return(void)
 {
@@ -1877,6 +1877,11 @@ static int agent_apply_option(int opt, void *value, size_t size, struct rb_root 
 			mcount_filter_setting.ptype = patt_type;
 			pr_dbg4("use pattern type %#x\n", patt_type);
 		}
+		break;
+
+	case UFTRACE_AGENT_OPT_PATCH:
+		pr_dbg4("apply patch '%s' (size=%d)\n", value, size);
+		mcount_dynamic_update(&mcount_sym_info, value, mcount_filter_setting.ptype);
 		break;
 
 	default:

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -76,6 +76,13 @@ int page_size_in_kb;
 /* call depth to filter */
 static int __maybe_unused mcount_depth = MCOUNT_DEFAULT_DEPTH;
 
+/* setting for all filter actions */
+static struct uftrace_filter_setting mcount_filter_setting = {
+	.ptype = PATT_REGEX,
+	.auto_args = false,
+	.allow_kernel = false,
+};
+
 /* boolean flag to turn on/off recording */
 static bool __maybe_unused mcount_enabled = true;
 
@@ -114,7 +121,7 @@ __weak void dynamic_return(void)
 
 #ifdef DISABLE_MCOUNT_FILTER
 
-static void mcount_filter_init(enum uftrace_pattern_type ptype, bool force)
+static void mcount_filter_init(struct uftrace_filter_setting *filter_setting, bool force)
 {
 	if (getenv("UFTRACE_SRCLINE") == NULL)
 		return;
@@ -122,7 +129,7 @@ static void mcount_filter_init(enum uftrace_pattern_type ptype, bool force)
 	load_module_symtabs(&mcount_sym_info);
 
 	/* use debug info if available */
-	prepare_debug_info(&mcount_sym_info, ptype, NULL, NULL, false, force);
+	prepare_debug_info(&mcount_sym_info, filter_setting->ptype, NULL, NULL, false, force);
 	save_debug_info(&mcount_sym_info, mcount_sym_info.dirname);
 }
 
@@ -366,7 +373,7 @@ static void mcount_signal_finish(void)
 	}
 }
 
-static void mcount_filter_init(enum uftrace_pattern_type ptype, bool force)
+static void mcount_filter_init(struct uftrace_filter_setting *filter_setting, bool force)
 {
 	char *filter_str = getenv("UFTRACE_FILTER");
 	char *trigger_str = getenv("UFTRACE_TRIGGER");
@@ -376,23 +383,19 @@ static void mcount_filter_init(enum uftrace_pattern_type ptype, bool force)
 	char *caller_str = getenv("UFTRACE_CALLER");
 	char *loc_str = getenv("UFTRACE_LOCATION");
 
-	struct uftrace_filter_setting filter_setting = {
-		.ptype = ptype,
-		.auto_args = false,
-		.allow_kernel = false,
-		.lp64 = host_is_lp64(),
-		.arch = host_cpu_arch(),
-	};
+	filter_setting->lp64 = host_is_lp64();
+	filter_setting->arch = host_cpu_arch();
+
 	bool needs_debug_info = false;
 
 	load_module_symtabs(&mcount_sym_info);
 
-	mcount_signal_init(getenv("UFTRACE_SIGNAL"), &filter_setting);
+	mcount_signal_init(getenv("UFTRACE_SIGNAL"), filter_setting);
 
 	/* setup auto-args only if argument/return value is used */
 	if (argument_str || retval_str || autoargs_str ||
 	    (trigger_str && (strstr(trigger_str, "arg") || strstr(trigger_str, "retval")))) {
-		setup_auto_args(&filter_setting);
+		setup_auto_args(filter_setting);
 		needs_debug_info = true;
 	}
 
@@ -401,28 +404,28 @@ static void mcount_filter_init(enum uftrace_pattern_type ptype, bool force)
 
 	/* use debug info if available */
 	if (needs_debug_info) {
-		prepare_debug_info(&mcount_sym_info, ptype, argument_str, retval_str,
-				   !!autoargs_str, force);
+		prepare_debug_info(&mcount_sym_info, filter_setting->ptype, argument_str,
+				   retval_str, !!autoargs_str, force);
 		save_debug_info(&mcount_sym_info, mcount_sym_info.dirname);
 	}
 
 	mcount_triggers = xmalloc(sizeof(*mcount_triggers));
 	*mcount_triggers = RB_ROOT;
 	uftrace_setup_filter(filter_str, &mcount_sym_info, mcount_triggers, &mcount_filter_mode,
-			     &filter_setting);
+			     filter_setting);
 	uftrace_setup_trigger(trigger_str, &mcount_sym_info, mcount_triggers, &mcount_filter_mode,
-			      &filter_setting);
-	uftrace_setup_argument(argument_str, &mcount_sym_info, mcount_triggers, &filter_setting);
-	uftrace_setup_retval(retval_str, &mcount_sym_info, mcount_triggers, &filter_setting);
+			      filter_setting);
+	uftrace_setup_argument(argument_str, &mcount_sym_info, mcount_triggers, filter_setting);
+	uftrace_setup_retval(retval_str, &mcount_sym_info, mcount_triggers, filter_setting);
 
 	if (needs_debug_info) {
 		uftrace_setup_loc_filter(loc_str, &mcount_sym_info, mcount_triggers,
-					 &mcount_loc_mode, &filter_setting);
+					 &mcount_loc_mode, filter_setting);
 	}
 
 	if (caller_str) {
 		uftrace_setup_caller_filter(caller_str, &mcount_sym_info, mcount_triggers,
-					    &filter_setting);
+					    filter_setting);
 	}
 
 	/* there might be caller triggers, count it separately */
@@ -433,13 +436,13 @@ static void mcount_filter_init(enum uftrace_pattern_type ptype, bool force)
 		char *autoarg = ".";
 		char *autoret = ".";
 
-		if (ptype == PATT_GLOB)
+		if (filter_setting->ptype == PATT_GLOB)
 			autoarg = autoret = "*";
 
-		filter_setting.auto_args = true;
+		filter_setting->auto_args = true;
 
-		uftrace_setup_argument(autoarg, &mcount_sym_info, mcount_triggers, &filter_setting);
-		uftrace_setup_retval(autoret, &mcount_sym_info, mcount_triggers, &filter_setting);
+		uftrace_setup_argument(autoarg, &mcount_sym_info, mcount_triggers, filter_setting);
+		uftrace_setup_retval(autoret, &mcount_sym_info, mcount_triggers, filter_setting);
 	}
 
 	if (getenv("UFTRACE_DEPTH"))
@@ -2060,7 +2063,6 @@ static __used void mcount_startup(void)
 	char *symdir_str;
 	struct stat statbuf;
 	bool nest_libcall;
-	enum uftrace_pattern_type patt_type = PATT_REGEX;
 
 	if (!(mcount_global_flags & MCOUNT_GFL_SETUP))
 		return;
@@ -2161,14 +2163,14 @@ static __used void mcount_startup(void)
 	record_proc_maps(dirname, mcount_session_name(), &mcount_sym_info);
 
 	if (pattern_str)
-		patt_type = parse_filter_pattern(pattern_str);
+		mcount_filter_setting.ptype = parse_filter_pattern(pattern_str);
 
 	if (patch_str)
 		mcount_return_fn = (unsigned long)dynamic_return;
 	else
 		mcount_return_fn = (unsigned long)mcount_return;
 
-	mcount_filter_init(patt_type, !!patch_str);
+	mcount_filter_init(&mcount_filter_setting, !!patch_str);
 	mcount_watch_init();
 
 	if (maxstack_str)
@@ -2181,10 +2183,10 @@ static __used void mcount_startup(void)
 		mcount_min_size = strtoul(minsize_str, NULL, 0);
 
 	if (patch_str)
-		mcount_dynamic_update(&mcount_sym_info, patch_str, patt_type);
+		mcount_dynamic_update(&mcount_sym_info, patch_str, mcount_filter_setting.ptype);
 
 	if (event_str)
-		mcount_setup_events(dirname, event_str, patt_type);
+		mcount_setup_events(dirname, event_str, mcount_filter_setting.ptype);
 
 	if (getenv("UFTRACE_KERNEL_PID_UPDATE"))
 		kernel_pid_update = true;
@@ -2209,7 +2211,7 @@ static __used void mcount_startup(void)
 
 	/* initialize script binding */
 	if (SCRIPT_ENABLED && script_str)
-		mcount_script_init(patt_type);
+		mcount_script_init(mcount_filter_setting.ptype);
 
 	compiler_barrier();
 	pr_dbg("mcount setup done\n");

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -52,6 +52,9 @@ bool mcount_auto_recover = ARCH_SUPPORT_AUTO_RECOVER;
 /* global flag to control mcount behavior */
 unsigned long mcount_global_flags = MCOUNT_GFL_SETUP;
 
+/* global to indicate if the target is executing */
+bool mcount_target_running = false;
+
 /* TSD key to save mtd below */
 pthread_key_t mtd_key = (pthread_key_t)-1;
 
@@ -2232,6 +2235,7 @@ static __used void mcount_startup(void)
 
 	mcount_global_flags &= ~MCOUNT_GFL_SETUP;
 	mtd.recursion_marker = false;
+	mcount_target_running = true;
 }
 
 static void mcount_cleanup(void)

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -113,7 +113,7 @@ static pthread_t agent;
 /* state flag for the agent */
 static volatile bool agent_run = false;
 
-#define MCOUNT_AGENT_CAPABILITIES 0
+#define MCOUNT_AGENT_CAPABILITIES (UFTRACE_AGENT_OPT_PATTERN)
 
 __weak void dynamic_return(void)
 {
@@ -1867,9 +1867,18 @@ static int agent_read_option(int fd, int *opt, void **value, size_t read_size)
  */
 static int agent_apply_option(int opt, void *value, size_t size, struct rb_root *triggers)
 {
+	enum uftrace_pattern_type patt_type;
 	int ret = 0;
 
 	switch (opt) {
+	case UFTRACE_AGENT_OPT_PATTERN:
+		patt_type = *((int *)value);
+		if (patt_type != mcount_filter_setting.ptype) {
+			mcount_filter_setting.ptype = patt_type;
+			pr_dbg4("use pattern type %#x\n", patt_type);
+		}
+		break;
+
 	default:
 		ret = -1;
 	}

--- a/uftrace.h
+++ b/uftrace.h
@@ -459,6 +459,7 @@ struct uftrace_msg_dlopen {
 
 enum uftrace_agent_opt {
 	UFTRACE_AGENT_OPT_PATTERN = (1U << 0), /* pattern match type */
+	UFTRACE_AGENT_OPT_PATCH = (1U << 1), /* patch string */
 };
 
 extern struct uftrace_session *first_session;

--- a/uftrace.h
+++ b/uftrace.h
@@ -458,7 +458,7 @@ struct uftrace_msg_dlopen {
 };
 
 enum uftrace_agent_opt {
-	UFTRACE_AGENT_OPT_XXX,
+	UFTRACE_AGENT_OPT_PATTERN = (1U << 0), /* pattern match type */
 };
 
 extern struct uftrace_session *first_session;

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/uio.h>
+#include <syscall.h>
 #include <unistd.h>
 
 #ifdef HAVE_LIBUNWIND
@@ -1000,6 +1001,31 @@ int copy_file(const char *path_in, const char *path_out)
 	fclose(ofp);
 	return 0;
 }
+
+#ifndef gettid
+/**
+ * gettid - gettid syscall wrapper (glibc < 2.30)
+  * @return - thread id
+ */
+pid_t gettid()
+{
+	return syscall(__NR_gettid);
+}
+#endif
+
+#ifndef tgkill
+/**
+ * tgkill - tgkill syscall wrapper (glibc < 2.30)
+ * @tgid   - thread group id
+ * @tid    - thread id
+ * @signal - signal to send
+ * @return - 0 on success, -1 on error
+ */
+int tgkill(pid_t tgid, pid_t tid, int signal)
+{
+	return syscall(SYS_tgkill, tgid, tid, signal);
+}
+#endif
 
 #ifdef UNIT_TEST
 TEST_CASE(utils_parse_cmdline)

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -1027,6 +1027,96 @@ int tgkill(pid_t tgid, pid_t tid, int signal)
 }
 #endif
 
+/**
+ * find_unused_sigrt - find a real-time signal with no associated action
+ * @return - unused RT signal, or -1 if none found
+ */
+int find_unused_sigrt()
+{
+	int sig;
+	struct sigaction oldact;
+
+	for (sig = SIGRTMIN; sig <= SIGRTMAX; sig++) {
+		if (sigaction(sig, NULL, &oldact) < 0) {
+			pr_dbg3("failed to check RT signal handler\n");
+			continue;
+		}
+
+		if (!oldact.sa_handler)
+			return sig;
+	}
+
+	pr_dbg2("failed to find unused SIGRT\n");
+	return -1;
+}
+
+/**
+ * thread_broadcast_signal - send a signal to all the other running threads in
+ * the process
+ * @sig - signal to send
+ * @return - number of signals sent, -1 on error
+ */
+int thread_broadcast_signal(int sig)
+{
+	char path[32];
+	DIR *dir;
+	struct dirent *dirent;
+	pid_t pid, tid, task;
+	int signal_count = 0;
+
+	pid = getpid();
+	tid = gettid();
+
+	snprintf(path, 32, "/proc/%u/task", pid);
+	dir = opendir(path);
+	if (!dir) {
+		pr_dbg("failed to open directory '%s'\n", path);
+		goto fail_open_dir;
+	}
+
+	errno = 0;
+	for (dirent = readdir(dir); dirent != NULL; dirent = readdir(dir)) {
+		/* skip "." and ".." directories */
+		if (dirent->d_name[0] == '.')
+			continue;
+
+		task = strtol(dirent->d_name, NULL, 10);
+		if (errno != 0 || task < 0) {
+			pr_dbg("failed to parse TID '%s'\n", dirent->d_name);
+			continue;
+		}
+
+		/* ignore our TID */
+		if (task == tid)
+			continue;
+
+		/*
+		 * By reading /proc/<pid>/task directory, there is the possibility of
+		 * a race condition where a thread exits before we send the signal.
+		 */
+		pr_dbg4("send SIGRT%d to %u\n", sig, task);
+		if (tgkill(pid, task, sig) < 0) {
+			if (errno != ESRCH) {
+				pr_dbg2("cannot signal thread %u: %s\n", task, strerror(errno));
+				errno = 0;
+			}
+		}
+		else
+			signal_count++;
+	}
+
+	if (errno != 0)
+		pr_dbg("failed to read directory entry\n");
+
+	if (closedir(dir) < 0)
+		pr_dbg2("failed to close directory\n");
+
+	return signal_count;
+
+fail_open_dir:
+	return -1;
+}
+
 #ifdef UNIT_TEST
 TEST_CASE(utils_parse_cmdline)
 {

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -432,4 +432,7 @@ int copy_file(const char *path_in, const char *path_out);
 pid_t gettid();
 int tgkill(pid_t tgid, pid_t tid, int signal);
 
+int find_unused_sigrt();
+int thread_broadcast_signal(int sig);
+
 #endif /* UFTRACE_UTILS_H */

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -429,4 +429,7 @@ void stacktrace(void);
 
 int copy_file(const char *path_in, const char *path_out);
 
+pid_t gettid();
+int tgkill(pid_t tgid, pid_t tid, int signal);
+
 #endif /* UFTRACE_UTILS_H */


### PR DESCRIPTION
Hello Namhyung and Honggyu,

This is a attempt to implement runtime dynamic instrumentation on x86_64 architecture. That is, performing full dynamic instrumentation on a live target.

This PR is long. If you want me to break it down, please advise me.

This feature, and technical details were already discussed in #1274 and #1369, so I'll be relying on this past material. Please ask me if you need me to elaborate on this PR.

It consists in 8 blocks of commits, as follows.

### 1. Refactor code for multiple runtime executions

The idea is that the agent will trigger the patching process at arbitrary moments, and an arbitrary amount of times. We refactor initialization and cleanup functions so they can be executed anytime at runtime, instead of when the target starts. We also make sure that they support multiple calls.

### 2. Add utils and wrappers

We introduce configuration options to use specific memory barriers when available. And also system call wrappers for older glibc versions. And last, we implement signal-related helpers.

### 3. Implement naive runtime dynamic patching

Core feature: we add safety mechanisms that allow to perform dynamic patching while code is executing. We make use of memory barriers or serializing instructions, and signals to ensure safe execution of cross-modifying code. This first implementation is based on the current patching process. We make heavy use of signals, and this has a strong negative impact on performance. We optimize the process later.

The patching process is seen as atomic regarding cores' execution. It follows these steps:
1. Critical region locking: insert a trap a the start of the patching region so no new thread can enter it
2. Serialization: synchronize execution across cores so each one is up to date on cross-modified instructions
3. Thread eviction: clear the critical region of thread that might have entered it before the previous step
4. Patching: move original code out of line at replace it with a relative call instruction (except the first byte, preserving the trap)
5. Critical region unlocking: replace the trap with the first byte of the call instruction

### 4. Optimize signal use

We batch operations in a way to minimize the amount of signals that are emitted. After the patching regions are locked, we issue a single signal to clear them all from threads that could still execute them. Another signal is used for serialization when the required membarrier is unavailable. Then we patch the locked regions.

This approach uses only one (or two depending on the kernel version) signal, but increases the amount of time during which traps are installed and can be executed.

### 5. Implement optimized unpatching

We implement unpatching in a similar way that we did for unpatching, but instrumentation is replaced by original instructions.

### 6. Trigger (un)patching from the agent

We hook the relevant to the agent so it can perform runtime dynamic instrumentation when running.

### 7. Preserve original behavior

We make sure that our new process in only used when the target is execution, falling back to the original behavior of uftrace when the target is instrumented before being executed.

### 8. Display stats

We eventually reset and display dynamic statistics every time patching or unpatching occurs.

Based on: #1274
Related: #1369 
See also: #870