### PR TITLE
python tracing can't have symbols with os._exit(0)

### DIFF
--- a/python/uftrace.py
+++ b/python/uftrace.py
@@ -31,5 +31,7 @@ sys.path.insert(0, os.path.dirname(pathname))
 
 code = open(sys.argv[0]).read()
 sys.setprofile(uftrace_python.trace)
+# Python tracing can't have symbols with os._exit(0), fix issue #1685
+code = code.replace("os._exit", "exit")
 exec(code, new_globals)
 sys.setprofile(None)


### PR DESCRIPTION
This patch use a tricky way by replace os._exit to python can trace symbol exit that fixed the problem.

Signed-off-by: Yi Hong [zouzou0208@gmail.com](mailto:zouzou0208@gmail.com)

Fixed: #1685