### PR TITLE
dynamic: Refactor logic to perform multiple updates

### DIFF
--- a/arch/aarch64/mcount-insn.c
+++ b/arch/aarch64/mcount-insn.c
@@ -8,10 +8,19 @@
 #include <capstone/capstone.h>
 #include <capstone/platform.h>
 
+/**
+ * mcount_disasm_init - initialize the capstone engine once
+ * @disasm - mcount disassembly engine
+ */
 void mcount_disasm_init(struct mcount_disasm_engine *disasm)
 {
+	if (disasm->engine)
+		return;
+
+	pr_dbg2("initialize disassembly engine\n");
+
 	if (cs_open(CS_ARCH_ARM64, CS_MODE_ARM, &disasm->engine) != CS_ERR_OK) {
-		pr_dbg("failed to init Capstone disasm engine\n");
+		pr_dbg("failed to init capstone disasm engine\n");
 		return;
 	}
 

--- a/arch/x86_64/mcount-insn.c
+++ b/arch/x86_64/mcount-insn.c
@@ -19,8 +19,17 @@ struct disasm_check_data {
 	uint32_t size;
 };
 
+/**
+ * mcount_disasm_init - initialize the capstone engine once
+ * @disasm - mcount disassembly engine
+ */
 void mcount_disasm_init(struct mcount_disasm_engine *disasm)
 {
+	if (disasm->engine)
+		return;
+
+	pr_dbg2("initialize disassembly engine\n");
+
 	if (cs_open(CS_ARCH_X86, CS_MODE_64, &disasm->engine) != CS_ERR_OK) {
 		pr_dbg("failed to init capstone disasm engine\n");
 		return;
@@ -653,7 +662,7 @@ TEST_CASE(dynamic_x86_handle_lea)
 		.addr = 0x3000,
 		.size = 32,
 	};
-	struct mcount_disasm_engine disasm;
+	struct mcount_disasm_engine disasm = { 0 };
 	struct mcount_disasm_info info = {
 		.sym = &sym,
 		.addr = ORIGINAL_BASE + sym.addr,
@@ -724,7 +733,7 @@ TEST_CASE(dynamic_x86_handle_call)
 		.addr = 0x4000,
 		.size = 32,
 	};
-	struct mcount_disasm_engine disasm;
+	struct mcount_disasm_engine disasm = { 0 };
 	struct mcount_disasm_info info = {
 		.sym = &sym1,
 		.addr = ORIGINAL_BASE + sym1.addr,
@@ -802,7 +811,7 @@ TEST_CASE(dynamic_x86_handle_jmp)
 		.addr = 0x3000,
 		.size = 32,
 	};
-	struct mcount_disasm_engine disasm;
+	struct mcount_disasm_engine disasm = { 0 };
 	struct mcount_disasm_info info = {
 		.sym = &sym,
 		.addr = ORIGINAL_BASE + sym.addr,
@@ -906,7 +915,7 @@ TEST_CASE(dynamic_x86_handle_jcc)
 		.addr = 0x3000,
 		.size = 32,
 	};
-	struct mcount_disasm_engine disasm;
+	struct mcount_disasm_engine disasm = { 0 };
 	struct mcount_disasm_info info = {
 		.sym = &sym,
 		.addr = ORIGINAL_BASE + sym.addr,
@@ -1015,7 +1024,7 @@ TEST_CASE(dynamic_x86_handle_mov_load)
 		.addr = 0x3000,
 		.size = 32,
 	};
-	struct mcount_disasm_engine disasm;
+	struct mcount_disasm_engine disasm = { 0 };
 	struct mcount_disasm_info info = {
 		.sym = &sym,
 		.addr = ORIGINAL_BASE + sym.addr,

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -652,6 +652,8 @@ static int do_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 		patch_func_matched(mdi, map);
 	}
 
+	release_pattern_list();
+
 	if (stats.failed + stats.skipped + stats.nomatch == 0) {
 		pr_dbg("patched all (%d) functions in '%s'\n", stats.total,
 		       basename(sinfo->filename));

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -355,6 +355,21 @@ static void prepare_dynamic_update(struct uftrace_sym_info *sinfo, bool needs_mo
 	dl_iterate_phdr(find_dynamic_module, &fmd);
 }
 
+/**
+ * setup_size_filter - initialize size filter if not set
+ */
+void setup_size_filter()
+{
+	char *size_filter;
+
+	if (min_size)
+		return;
+
+	size_filter = getenv("UFTRACE_MIN_SIZE");
+	if (size_filter)
+		min_size = strtoul(size_filter, NULL, 0);
+}
+
 struct mcount_dynamic_info *setup_trampoline(struct uftrace_mmap *map)
 {
 	struct mcount_dynamic_info *mdi;
@@ -676,16 +691,13 @@ int mcount_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 			  enum uftrace_pattern_type ptype)
 {
 	int ret = 0;
-	char *size_filter;
 	bool needs_modules = !!strchr(patch_funcs, '@');
 
 	mcount_disasm_init(&disasm);
 
 	prepare_dynamic_update(sinfo, needs_modules);
 
-	size_filter = getenv("UFTRACE_MIN_SIZE");
-	if (size_filter != NULL)
-		min_size = strtoul(size_filter, NULL, 0);
+	setup_size_filter();
 
 	ret = do_dynamic_update(sinfo, patch_funcs, ptype);
 

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -294,8 +294,15 @@ static struct mcount_dynamic_info *create_mdi(struct dl_phdr_info *info)
 	return mdi;
 }
 
-/* callback for dl_iterate_phdr() */
-static int find_dynamic_module(struct dl_phdr_info *info, size_t sz, void *data)
+/**
+ * prepare_dynamic_module - store dynamic module info and install trampoline;
+ * callback for dl_iterate_phdr()
+ * @info   - module info
+ * @sz     - data size (unused)
+ * @data   - callback data: symbol info and module parsing flag
+ * @return - stop iteration on non-zero value
+ */
+static int prepare_dynamic_module(struct dl_phdr_info *info, size_t sz, void *data)
 {
 	struct mcount_dynamic_info *mdi;
 	struct find_module_data *fmd = data;
@@ -314,6 +321,9 @@ static int find_dynamic_module(struct dl_phdr_info *info, size_t sz, void *data)
 	if (map && map->mod) {
 		mdi->map = map;
 		mcount_arch_find_module(mdi, &map->mod->symtab);
+
+		if (mcount_setup_trampoline(mdi) < 0)
+			mdi->trampoline = 0;
 
 		mdi->next = mdinfo;
 		mdinfo = mdi;
@@ -352,7 +362,7 @@ static void prepare_dynamic_update(struct uftrace_sym_info *sinfo, bool needs_mo
 	else
 		return;
 
-	dl_iterate_phdr(find_dynamic_module, &fmd);
+	dl_iterate_phdr(prepare_dynamic_module, &fmd);
 }
 
 /**
@@ -629,10 +639,18 @@ static void patch_func_matched(struct mcount_dynamic_info *mdi, struct uftrace_m
 		patch_normal_func_matched(mdi, map);
 }
 
+/**
+ * do_dynamic_update - apply (un)patching across loaded modules' maps
+ * @sinfo       - dynamic symbol info
+ * @patch_funcs - spec of symbols to (un)patch
+ * @ptype       - matching pattern type
+ * @return      - 0 (unused)
+ */
 static int do_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 			     enum uftrace_pattern_type ptype)
 {
 	struct uftrace_mmap *map;
+	struct mcount_dynamic_info *mdi;
 	char *def_mod;
 
 	if (patch_funcs == NULL)
@@ -641,15 +659,11 @@ static int do_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 	def_mod = basename(sinfo->exec_map->libname);
 	parse_pattern_list(patch_funcs, def_mod, ptype);
 
-	for_each_map(sinfo, map) {
-		struct mcount_dynamic_info *mdi;
-
-		/* TODO: filter out unsuppported libs */
-		mdi = setup_trampoline(map);
-		if (mdi == NULL)
-			continue;
-
-		patch_func_matched(mdi, map);
+	/* TODO: filter out unsupported libs */
+	for (mdi = mdinfo; mdi != NULL; mdi = mdi->next) {
+		map = mdi->map;
+		if (mdi->trampoline)
+			patch_func_matched(mdi, map);
 	}
 
 	release_pattern_list();
@@ -660,24 +674,6 @@ static int do_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 	}
 
 	return 0;
-}
-
-static void freeze_dynamic_update(void)
-{
-	struct mcount_dynamic_info *mdi, *tmp;
-
-	mdi = mdinfo;
-	while (mdi) {
-		tmp = mdi->next;
-
-		mcount_arch_dynamic_recover(mdi, &disasm);
-		mcount_cleanup_trampoline(mdi);
-		free(mdi);
-
-		mdi = tmp;
-	}
-
-	mcount_freeze_code();
 }
 
 /* do not use floating-point in libmcount */
@@ -724,7 +720,7 @@ int mcount_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 		pr_dbg("no match: %8d\n", stats.nomatch);
 	}
 
-	freeze_dynamic_update();
+	mcount_freeze_code();
 	return ret;
 }
 
@@ -770,9 +766,29 @@ void mcount_dynamic_dlopen(struct uftrace_sym_info *sinfo, struct dl_phdr_info *
 	mcount_freeze_code();
 }
 
+/**
+ * mcount_free_mdinfo - free all dynamic info structures
+ */
+static void mcount_free_mdinfo(void)
+{
+	struct mcount_dynamic_info *mdi, *tmp;
+
+	mdi = mdinfo;
+	while (mdi) {
+		tmp = mdi->next;
+
+		mcount_arch_dynamic_recover(mdi, &disasm);
+		mcount_cleanup_trampoline(mdi);
+		free(mdi);
+
+		mdi = tmp;
+	}
+}
+
 void mcount_dynamic_finish(void)
 {
 	release_pattern_list();
+	mcount_free_mdinfo();
 	mcount_disasm_finish(&disasm);
 }
 

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -689,6 +689,14 @@ static int calc_percent(int n, int total, int *rem)
 	return quot;
 }
 
+/**
+ * mcount_dynamic_update - prepare and perform dynamic patching or unpatching,
+ * then display statistics
+ * @sinfo       - dynamic symbol info
+ * @patch_funcs - spec of symbols to patch or unpatch
+ * @ptype       - matching pattern type
+ * @return      - 0 (unused)
+ */
 int mcount_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 			  enum uftrace_pattern_type ptype)
 {
@@ -696,9 +704,7 @@ int mcount_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 	bool needs_modules = !!strchr(patch_funcs, '@');
 
 	mcount_disasm_init(&disasm);
-
 	prepare_dynamic_update(sinfo, needs_modules);
-
 	setup_size_filter();
 
 	ret = do_dynamic_update(sinfo, patch_funcs, ptype);


### PR DESCRIPTION
This is the first PR of a series of patches intended to bring runtime dynamic tracing on x86_64 to uftrace.

First, we refactor the life cycle of dynamic structures so a dynamic update can be triggered at anytime during execution, any amount of times. This will allow the agent to call `mcount_dynamic_update()` multiple times at runtime.

Related: #1698