### PR TITLE
dynamic: Refactor patch pattern logic

### DIFF
--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -384,10 +384,17 @@ static bool match_pattern_module(char *pathname)
 	return ret;
 }
 
-static bool match_pattern_list(struct uftrace_mmap *map, char *soname, char *sym_name)
+/**
+ * match_pattern_list - match a symbol name against a pattern list
+ * @map - memory map of the symbol
+ * @soname - name of the module
+ * @sym_name - name of the symbol
+ * @return - -1 if match negative, 1 if match positive, 0 if no match
+ */
+static int match_pattern_list(struct uftrace_mmap *map, char *soname, char *sym_name)
 {
 	struct patt_list *pl;
-	bool ret = false;
+	int ret = 0;
 	char *libname = basename(map->libname);
 
 	list_for_each_entry(pl, &patterns, list) {
@@ -398,7 +405,7 @@ static bool match_pattern_list(struct uftrace_mmap *map, char *soname, char *sym
 			continue;
 
 		if (match_filter_pattern(&pl->patt, sym_name))
-			ret = pl->positive;
+			ret = pl->positive ? 1 : -1;
 	}
 
 	return ret;
@@ -470,9 +477,6 @@ static bool skip_sym(struct uftrace_symbol *sym, struct mcount_dynamic_info *mdi
 	if (sym->type != ST_LOCAL_FUNC && sym->type != ST_GLOBAL_FUNC && sym->type != ST_WEAK_FUNC)
 		return true;
 
-	if (!match_pattern_list(map, soname, sym->name))
-		return true;
-
 	return false;
 }
 
@@ -539,6 +543,7 @@ static void patch_normal_func_matched(struct mcount_dynamic_info *mdi, struct uf
 	unsigned i;
 	struct uftrace_symbol *sym;
 	bool found = false;
+	int match;
 	char *soname = get_soname(map->libname);
 
 	symtab = &map->mod->symtab;
@@ -548,9 +553,15 @@ static void patch_normal_func_matched(struct mcount_dynamic_info *mdi, struct uf
 
 		if (skip_sym(sym, mdi, map, soname))
 			continue;
-
 		found = true;
-		mcount_patch_func_with_stats(mdi, sym);
+
+		match = match_pattern_list(map, soname, sym->name);
+		if (!match)
+			continue;
+		else if (match == 1)
+			mcount_patch_func_with_stats(mdi, sym);
+		else
+			mcount_unpatch_func(mdi, sym, NULL);
 	}
 
 	if (!found)
@@ -826,27 +837,27 @@ TEST_CASE(dynamic_pattern_list)
 	pr_dbg("check simple match with default module\n");
 	parse_pattern_list("abc;!def", "main", PATT_SIMPLE);
 
-	TEST_EQ(match_pattern_list(main_map, NULL, "abc"), true);
-	TEST_EQ(match_pattern_list(main_map, NULL, "def"), false);
-	TEST_EQ(match_pattern_list(other_map, NULL, "xyz"), false);
+	TEST_EQ(match_pattern_list(main_map, NULL, "abc"), 1);
+	TEST_EQ(match_pattern_list(main_map, NULL, "def"), -1);
+	TEST_EQ(match_pattern_list(other_map, NULL, "xyz"), 0);
 
 	release_pattern_list();
 
 	pr_dbg("check negative regex match with default module\n");
 	parse_pattern_list("!^a", "main", PATT_REGEX);
 
-	TEST_EQ(match_pattern_list(main_map, NULL, "abc"), false);
-	TEST_EQ(match_pattern_list(main_map, NULL, "def"), true);
-	TEST_EQ(match_pattern_list(other_map, NULL, "xyz"), false);
+	TEST_EQ(match_pattern_list(main_map, NULL, "abc"), -1);
+	TEST_EQ(match_pattern_list(main_map, NULL, "def"), 0);
+	TEST_EQ(match_pattern_list(other_map, NULL, "xyz"), 0);
 
 	release_pattern_list();
 
 	pr_dbg("check wildcard match with other module\n");
 	parse_pattern_list("*@other", "main", PATT_GLOB);
 
-	TEST_EQ(match_pattern_list(main_map, NULL, "abc"), false);
-	TEST_EQ(match_pattern_list(main_map, NULL, "def"), false);
-	TEST_EQ(match_pattern_list(other_map, NULL, "xyz"), true);
+	TEST_EQ(match_pattern_list(main_map, NULL, "abc"), 0);
+	TEST_EQ(match_pattern_list(main_map, NULL, "def"), 0);
+	TEST_EQ(match_pattern_list(other_map, NULL, "xyz"), 1);
 
 	release_pattern_list();
 

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -410,7 +410,6 @@ static void parse_pattern_list(char *patch_funcs, char *def_mod, enum uftrace_pa
 	char *name;
 	int j;
 	struct patt_list *pl;
-	bool all_negative = true;
 
 	strv_split(&funcs, patch_funcs, ";");
 
@@ -421,10 +420,8 @@ static void parse_pattern_list(char *patch_funcs, char *def_mod, enum uftrace_pa
 
 		if (name[0] == '!')
 			name++;
-		else {
+		else
 			pl->positive = true;
-			all_negative = false;
-		}
 
 		delim = strchr(name, '@');
 		if (delim == NULL) {
@@ -437,20 +434,6 @@ static void parse_pattern_list(char *patch_funcs, char *def_mod, enum uftrace_pa
 
 		init_filter_pattern(ptype, &pl->patt, name);
 		list_add_tail(&pl->list, &patterns);
-	}
-
-	/* prepend match-all pattern, if all patterns are negative */
-	if (all_negative) {
-		pl = xzalloc(sizeof(*pl));
-		pl->positive = true;
-		pl->module = xstrdup(def_mod);
-
-		if (ptype == PATT_REGEX)
-			init_filter_pattern(ptype, &pl->patt, ".");
-		else
-			init_filter_pattern(PATT_GLOB, &pl->patt, "*");
-
-		list_add(&pl->list, &patterns);
 	}
 
 	strv_free(&funcs);

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -470,11 +470,8 @@ static bool skip_sym(struct uftrace_symbol *sym, struct mcount_dynamic_info *mdi
 	if (sym->type != ST_LOCAL_FUNC && sym->type != ST_GLOBAL_FUNC && sym->type != ST_WEAK_FUNC)
 		return true;
 
-	if (!match_pattern_list(map, soname, sym->name)) {
-		if (mcount_unpatch_func(mdi, sym, &disasm) == 0)
-			stats.unpatch++;
+	if (!match_pattern_list(map, soname, sym->name))
 		return true;
-	}
 
 	return false;
 }


### PR DESCRIPTION
This is the second PR in a series of patches intended to bring runtime dynamic tracing on x86_64 to uftrace.
1. #1702 
2. #1703 🠈
3. #1704
4. #1705
5. #1745
6. #1746
7. #1747
8. #1748
9. #1749
10. #1750
11. #1751

We redefine the pattern handling logic to remove default behaviors that conflict with runtime dynamic patching. We adapt it to runtime dynamic unpatching.

Related: #1698