### PR TITLE
compile: Fix compile error due to low libcapstone-dev package version

### DIFF
--- a/arch/x86_64/mcount-insn.c
+++ b/arch/x86_64/mcount-insn.c
@@ -473,9 +473,11 @@ static int check_instrumentable(struct mcount_disasm_engine *disasm, cs_insn *in
 		case CS_GRP_RET:
 		case CS_GRP_IRET:
 			return INSTRUMENT_FAIL_RET;
+#if CS_API_MAJOR >= 4
 		case CS_GRP_PRIVILEGE:
 		case CS_GRP_BRANCH_RELATIVE:
 			return INSTRUMENT_FAIL_NO_DETAIL;
+#endif
 		default:
 			/* do nothing for legit instructions. */
 			break;


### PR DESCRIPTION
In Ubuntu 20.04, latest libcapstone-dev package version is 3.0.5. However, CS_GRP_PRIVILEGE and CS_GRP_BRANCH_RELATIVE macros are declared in over 4.0.x version.
Add a macro to check CS_API_MAJOR version is over 4.

Fixed: https://github.com/namhyung/uftrace/issues/1712

Signed-off-by: Michelle Jin <shjy180909@gmail.com>