### PR TITLE
uftrace: Add 'void' to functions without arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ LIB_LDFLAGS        = $(COMMON_LDFLAGS) $(LDFLAGS_$@) $(LDFLAGS_lib) -Wl,--no-und
 TEST_LDFLAGS       = $(COMMON_LDFLAGS) -L$(objdir)/libtraceevent -ltraceevent
 
 ifeq ($(DEBUG), 1)
-  COMMON_CFLAGS += -O0 -g3 -DDEBUG_MODE=1
+  COMMON_CFLAGS += -O0 -g3 -DDEBUG_MODE=1 -Werror -Wstrict-prototypes
 else
   COMMON_CFLAGS += -O2 -g -DDEBUG_MODE=0
 endif

--- a/check-deps/__have_libcapstone.c
+++ b/check-deps/__have_libcapstone.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int main()
+int main(void)
 {
 	cs_insn insn;
 	printf("size: %zu\n", sizeof(insn));

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -841,7 +841,7 @@ extern void *get_argbuf(struct mcount_thread_data *, struct mcount_ret_stack *);
 /**
  * mcount_get_filter_mode - compute the filter mode from the filter count
  */
-static inline enum filter_mode mcount_get_filter_mode()
+static inline enum filter_mode mcount_get_filter_mode(void)
 {
 	return mcount_triggers->filter_count > 0 ? FILTER_MODE_IN : FILTER_MODE_OUT;
 }
@@ -849,7 +849,7 @@ static inline enum filter_mode mcount_get_filter_mode()
 /**
  * mcount_get_loc_mode - compute the location filter mode from the location count
  */
-static inline enum filter_mode mcount_get_loc_mode()
+static inline enum filter_mode mcount_get_loc_mode(void)
 {
 	return mcount_triggers->loc_count > 0 ? FILTER_MODE_IN : FILTER_MODE_OUT;
 }
@@ -2096,7 +2096,7 @@ void *agent_apply_commands(void *arg)
 	return 0;
 }
 
-static void agent_spawn()
+static void agent_spawn(void)
 {
 	errno = pthread_create(&agent, NULL, &agent_apply_commands, NULL);
 	if (errno != 0)
@@ -2105,7 +2105,7 @@ static void agent_spawn()
 
 /* Check if the agent is up. If so, set its run flag to false, open and close
  * connection . */
-static void agent_kill()
+static void agent_kill(void)
 {
 	int sfd;
 	int status;

--- a/tests/s-diff.c
+++ b/tests/s-diff.c
@@ -1,12 +1,12 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-int bar()
+int bar(void)
 {
 	usleep(100);
 }
 
-int foo()
+int foo(void)
 {
 	usleep(1000);
 	bar();

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -1958,7 +1958,7 @@ TEST_CASE(trigger_setup_args)
 	return TEST_OK;
 }
 
-static struct uftrace_mmap *locfilter_test_load_mmap()
+static struct uftrace_mmap *locfilter_test_load_mmap(void)
 {
 	static struct uftrace_symbol syms[] = {
 		{ 0x1000, 0x1000, ST_GLOBAL_FUNC, "command_dump" },
@@ -2003,7 +2003,7 @@ static struct uftrace_mmap *locfilter_test_load_mmap()
 	return &map;
 }
 
-static struct uftrace_mmap *locfilter_test_load_mmap2()
+static struct uftrace_mmap *locfilter_test_load_mmap2(void)
 {
 	static struct uftrace_symbol syms2[] = {
 		{ 0xa000, 0x1000, ST_GLOBAL_FUNC, "util_fstack" },

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -683,7 +683,7 @@ int fstack_entry(struct uftrace_task_reader *task, struct uftrace_record *rstack
 		}
 	}
 	else {
-		if (fstack_get_loc_mode(&sess->filters) == FILTER_MODE_IN) {
+		if (fstack_get_loc_mode() == FILTER_MODE_IN) {
 			fstack->flags |= FSTACK_FL_NORECORD;
 			return -1;
 		}
@@ -866,8 +866,8 @@ static int fstack_check_skip(struct uftrace_task_reader *task, struct uftrace_re
 		if (tr.fmode == FILTER_MODE_OUT)
 			return -1;
 	}
-	else if ((fstack_get_filter_mode(&sess->filters) == FILTER_MODE_IN ||
-		  fstack_get_loc_mode(&sess->filters) == FILTER_MODE_IN) &&
+	else if ((fstack_get_filter_mode() == FILTER_MODE_IN ||
+		  fstack_get_loc_mode() == FILTER_MODE_IN) &&
 		 task->filter.in_count == 0) {
 		return -1;
 	}
@@ -1004,8 +1004,7 @@ bool fstack_check_filter(struct uftrace_task_reader *task)
 	else if (task->rstack->type == UFTRACE_EVENT) {
 		/* don't change filter state, just check it */
 		if (task->filter.out_count > 0 || task->filter.depth <= 0 ||
-		    (fstack_get_filter_mode(&fstack_triggers) == FILTER_MODE_IN &&
-		     task->filter.in_count == 0))
+		    (fstack_get_filter_mode() == FILTER_MODE_IN && task->filter.in_count == 0))
 			return false;
 
 		if (task->rstack->addr == EVENT_ID_PERF_SCHED_IN ||

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -23,13 +23,13 @@ bool live_disabled = false;
 
 static struct uftrace_triggers_info fstack_triggers;
 
-static inline int fstack_get_filter_mode()
+static inline int fstack_get_filter_mode(void)
 {
 	int filter_count = fstack_triggers.filter_count;
 	return filter_count > 0 ? FILTER_MODE_IN : FILTER_MODE_OUT;
 }
 
-static inline int fstack_get_loc_mode()
+static inline int fstack_get_loc_mode(void)
 {
 	int loc_count = fstack_triggers.loc_count;
 	return loc_count > 0 ? FILTER_MODE_IN : FILTER_MODE_OUT;


### PR DESCRIPTION
This patch remove argument on void non-args function when using
`fstack_get_loc_mode()`, fstack_get_filter_mode()`.

Fixed: #1719
Signed-off-by: Paran Lee <p4ranlee@gmail.com>