### PR TITLE
python: Handle os._exit() properly

### DIFF
--- a/python/uftrace.py
+++ b/python/uftrace.py
@@ -25,6 +25,14 @@ else:
 # UFTRACE_PYMAIN must be set before importing uftrace_python
 import uftrace_python
 
+# Symbol and debug files are finally written at uftrace_trace_python_finish()
+# when program exits, but os._exit() terminates the program immediately so there
+# is no chance to write symbol and debug files at the destructor.
+# The os._exit() is hooked here to prevent this problem.
+def os_exit(n):
+    uftrace_python.exit(n)
+os._exit = os_exit
+
 new_globals = globals()
 new_globals["__file__"] = pathname
 sys.path.insert(0, os.path.dirname(pathname))

--- a/tests/p011_libcall_nested.py
+++ b/tests/p011_libcall_nested.py
@@ -27,3 +27,6 @@ class TestCase(PyTestBase):
 
     def setup(self):
         self.option = '--nest-libcall -N ^importlib -D 6'
+
+    def fixup(self, cflags, result):
+        return result.replace(".JSONEncoder", "")

--- a/tests/p012_os_exit.py
+++ b/tests/p012_os_exit.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+from runtest import PyTestBase
+
+class TestCase(PyTestBase):
+    def __init__(self):
+        PyTestBase.__init__(self, 'abc-exit', """
+# DURATION     TID     FUNCTION
+            [  6461] | __main__.<module>() {
+            [  6461] |   a() {
+            [  6461] |     b() {
+            [  6461] |       c() {
+   1.114 us [  6461] |         posix.getpid();
+   4.746 us [  6461] |       } /* c */
+   7.101 us [  6461] |     } /* b */
+   9.897 us [  6461] |   } /* a */
+
+uftrace stopped tracing with remaining functions
+================================================
+task: 6461
+[0] __main__.<module>
+""", sort='task')

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -318,7 +318,7 @@ class TestBase:
         order = 1
         before_main = True
         for ln in output.split('\n'):
-            if ln.find(' | main()') > 0:
+            if ln.find(' | main()') > 0 or ln.find(' | __main__.<module>') > 0:
                 before_main = False
             if before_main:
                 continue

--- a/tests/s-abc-exit.py
+++ b/tests/s-abc-exit.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import os
+
+def a():
+    b()
+
+def b():
+    c()
+
+def c():
+    return os.getpid()
+
+a()
+os._exit(0)


### PR DESCRIPTION
When os._exit() is invoked in the target python program, uftrace can't write the symbol and dbginfo files because it doesn't invoke the destructor.

This patch fixes the problem by hooking os._exit and invoke the destructor manually then call _exit().

Fixed: #1685