### PR TITLE
doc: Update README.md for user space function tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ the name uftrace stems from the combination of user and ftrace.
 
 It can record data from:
 - User space C/C++/Rust functions (by dynamically patching functions at runtime,
-  or with code compiled with with `-pg`, `-mfentry`, `-finstrument-functions`,
-  or using clang with `-fxray-instrument`)
+  or with code compiled with with `-pg`, `-finstrument-functions` or using
+  `-fpatchable-function-entry=N` for selective NOP patching)
 - C/C++/Rust Library functions (through PLT hooking)
 - Python functions (using Python's trace/profile infrastructure)
 - Kernel functions (using the ftrace framework in Linux kernel)


### PR DESCRIPTION
uftrace provides mulitiple ways for user space function tracing, but it might be confusing to users suggesting all the options in README.md.

We better inform a few options including -pg, -finstrument-functions and -fpatchable-function-entry=N.