### PR TITLE
dynamic: x86_64: refactor patch code

### DIFF
--- a/arch/x86_64/mcount-arch.h
+++ b/arch/x86_64/mcount-arch.h
@@ -59,5 +59,6 @@ struct mcount_disasm_info;
 
 int disasm_check_insns(struct mcount_disasm_engine *disasm, struct mcount_dynamic_info *mdi,
 		       struct mcount_disasm_info *info);
+int check_endbr64(unsigned long addr);
 
 #endif /* MCOUNT_ARCH_H */

--- a/arch/x86_64/mcount-insn.c
+++ b/arch/x86_64/mcount-insn.c
@@ -589,7 +589,6 @@ int disasm_check_insns(struct mcount_disasm_engine *disasm, struct mcount_dynami
 	int status;
 	cs_insn *insn = NULL;
 	uint32_t count, i, size;
-	uint8_t endbr64[] = { 0xf3, 0x0f, 0x1e, 0xfa };
 	void *trampoline_addr;
 	uint8_t *operand;
 	struct dynamic_bad_symbol *badsym;
@@ -612,9 +611,9 @@ int disasm_check_insns(struct mcount_disasm_engine *disasm, struct mcount_dynami
 		return INSTRUMENT_SKIPPED;
 
 	size = info->sym->size;
-	if (!memcmp((void *)info->addr, endbr64, sizeof(endbr64))) {
-		addr += sizeof(endbr64);
-		size -= sizeof(endbr64);
+	if (check_endbr64(info->addr)) {
+		addr += ENDBR_INSN_SIZE;
+		size -= ENDBR_INSN_SIZE;
 
 		if (size <= CALL_INSN_SIZE)
 			return INSTRUMENT_SKIPPED;
@@ -1219,3 +1218,15 @@ int disasm_check_insns(struct mcount_disasm_engine *disasm, struct mcount_dynami
 }
 
 #endif /* HAVE_LIBCAPSTONE */
+
+/**
+ * check_endbr64 - check if instruction at @addr is endbr64
+ * @addr   - address to check for endbr64
+ * @return - 1 if found, 0 if not
+ */
+int check_endbr64(unsigned long addr)
+{
+	uint8_t endbr64[] = { 0xf3, 0x0f, 0x1e, 0xfa };
+
+	return !memcmp((void *)addr, endbr64, sizeof(endbr64));
+}


### PR DESCRIPTION
This is the fifth PR in a series of patches intended to bring runtime dynamic tracing on x86_64 to uftrace.
1. #1702 
2. #1703 
3. #1704
4. #1705
5. #1745 🠈

We refactor code for clarity and prepare `patch_code` to be used at runtime.

Related: #1698