### PR TITLE
dynamic: x86_64: Support runtime dynamic patching

### DIFF
--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <semaphore.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -7,7 +8,6 @@
 #include <linux/membarrier.h>
 #else
 #include <cpuid.h>
-#include <semaphore.h>
 #endif
 
 /* This should be defined before #include "utils.h" */
@@ -38,6 +38,22 @@ static const unsigned char endbr64[] = { 0xf3, 0x0f, 0x1e, 0xfa };
  * (void *int3_location -> void *trampoline)
  */
 static struct Hashmap *int3_hmap;
+
+/* Hashmap of the addresses of instructions that are in patching zones and need
+ * to be executed out of line. The addresses are mapped to their out of line
+ * equivalent.
+ *
+ * (void *critical_insn -> void *out_of_line_insn)
+ */
+static struct Hashmap *patch_region_hmap;
+
+/* Realtime signal number to instruct running threads to move out of patching
+   regions */
+static int sig_clear_patch_region;
+
+/* counter for the threads that are guaranteed to be out of registered patching
+   regions when a signal is issued */
+static sem_t sem_clear_patch_region;
 
 /**
  * register_trap - save trampoline associated to a trap
@@ -233,6 +249,8 @@ static int synchronize_all_cores(void)
 		if (sem_timedwait(&sem_sync_cores, &ts) == -1) {
 			if (errno == EINTR)
 				i--;
+			else
+				pr_dbg3("error syncing with signal handler: %s\n", strerror(errno));
 		}
 		else
 			sync_count++;
@@ -243,6 +261,143 @@ static int synchronize_all_cores(void)
 }
 
 #endif /* HAVE_MEMBARRIER */
+
+/**
+ * register_patch_region - mark a memory region as critical by registering the
+ * addresses that it contains in 'patch_region_hmap'
+ * @start  - address of the patch region
+ * @len    - length of the patch region
+ * @return - -1 on error, 0 on success
+ */
+static int register_patch_region(void *start, int len)
+{
+	void *out_of_line_buffer = mcount_find_code((unsigned long)start + CALL_INSN_SIZE);
+	if (!out_of_line_buffer)
+		return -1;
+
+	for (int i = 0; i < len; i++) {
+		if (!hashmap_put(patch_region_hmap, start + i, out_of_line_buffer + i))
+			return -1;
+	}
+
+	return 0;
+}
+
+/**
+ * unregister_patch_region - unmark a memory region as critical
+ * @start  - address of the patch region
+ * @len    - length of the patch region
+ * @return - -1 on error, 0 on success
+ */
+static int unregister_patch_region(void *start, int len)
+{
+	void *out_of_line_buffer = mcount_find_code((unsigned long)start);
+	if (!out_of_line_buffer)
+		return -1;
+
+	for (int i = 0; i < len; i++) {
+		if (!hashmap_remove(patch_region_hmap, start + i))
+			return -1;
+	}
+
+	return 0;
+}
+
+/**
+ * leave_patch_region - signal handler on which a thread executes out of line if
+ * it happens to be in a registered patching region
+ * @sig      - signal number
+ * @info     - signal info (unused)
+ * @ucontext - user context
+ */
+static void leave_patch_region(int sig, siginfo_t *info, void *ucontext)
+{
+	ucontext_t *uctx = ucontext;
+	mcontext_t *mctx = &uctx->uc_mcontext;
+	void *next_insn;
+	void *out_of_line_insn;
+	(void)sig;
+
+	next_insn = (void *)mctx->gregs[REG_RIP];
+	out_of_line_insn = hashmap_get(patch_region_hmap, next_insn);
+	if (out_of_line_insn)
+		mctx->gregs[REG_RIP] = (uint64_t)out_of_line_insn;
+
+	sem_post(&sem_clear_patch_region);
+}
+
+/**
+ * clear_patch_region - move threads that are in a patching region out of line
+ * @return - 0
+ */
+static int clear_patch_region(void)
+{
+	int signal_count;
+	int move_count = 0;
+	struct timespec ts;
+
+	ASSERT(sig_clear_patch_region >= SIGRTMIN);
+
+	signal_count = thread_broadcast_signal(sig_clear_patch_region);
+
+	if (clock_gettime(CLOCK_REALTIME, &ts) == -1)
+		return -1;
+	ts.tv_sec += 1;
+
+	for (int i = 0; i < signal_count; i++) {
+		if (sem_timedwait(&sem_clear_patch_region, &ts) == -1) {
+			if (errno == EINTR)
+				i--;
+			else
+				pr_dbg3("error syncing with signal handler: %s\n", strerror(errno));
+		}
+		else
+			move_count++;
+	}
+	pr_dbg3("checked ip of %d/%d thread(s)\n", move_count, signal_count);
+
+	return 0;
+}
+
+/**
+ * setup_clear_patch_region - initialize data structures and signals used to
+ * move threads of patching regions
+ *  @return - -1 on error, 0 on success
+ */
+int setup_clear_patch_region(void)
+{
+	struct sigaction act;
+
+	if (!patch_region_hmap) {
+		patch_region_hmap = hashmap_create(4, hashmap_ptr_hash, hashmap_ptr_equals);
+		if (!patch_region_hmap) {
+			pr_dbg("failed to create patch region hashmap\n");
+			return -1;
+		}
+	}
+
+	if (sig_clear_patch_region > 0)
+		return 0;
+
+	sig_clear_patch_region = find_unused_sigrt();
+	if (sig_clear_patch_region == -1)
+		return -1;
+
+	sem_init(&sem_clear_patch_region, 0, 0);
+
+	act.sa_sigaction = leave_patch_region;
+	act.sa_flags = 0;
+
+	if (sigaction(sig_clear_patch_region, &act, NULL) < 0) {
+		pr_dbg("failed to configure clear signal (SIGRT%d) handler\n",
+		       sig_clear_patch_region);
+		return -1;
+	}
+
+	pr_dbg("configured clear signal (SIGRT%d) handler\n", sig_clear_patch_region);
+	return 0;
+}
+
 /**
  * mcount_arch_dynamic_init - initialize arch-specific data structures to
  * perform runtime dynamic instrumentation
@@ -261,6 +416,8 @@ int mcount_arch_dynamic_init(void)
 
 	if (setup_synchronization_mechanism() < 0)
 		return -1;
+
+	setup_clear_patch_region();
 
 	return 0;
 }
@@ -687,6 +844,24 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 	synchronize_all_cores();
 
 	/*
+	 * The second step is to move any thread out of the critical zone if still
+	 * present. Threads in the critical zone resume execution out of line, in
+	 * their dedicated OLX region.
+	 *
+	 * The method used to move the threads is to signal all the threads, so they
+	 * check if their instruction pointer is in the patching region. If so, they
+	 * move their instruction pointer to the corresponding one in the OLX
+	 * region.
+	 */
+
+	if (register_patch_region(origin_code_addr, info->orig_size) == -1)
+		pr_dbg3("failed to register patch region\n");
+	clear_patch_region();
+	unregister_patch_region(origin_code_addr, info->orig_size);
+
+	/* The third step is to write the target address of the call. From the
+	 * processor view the 4-bytes address can be any garbage instructions.
+	 *
 	 * We fill the remaining part of the patching region with nops.
 	 *
 	 *     0x0: int3
@@ -698,8 +873,11 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 	memcpy(&((uint8_t *)origin_code_addr)[1], &trampoline_rel_addr, CALL_INSN_SIZE - 1);
 	memset(origin_code_addr + CALL_INSN_SIZE, 0x90, /* NOP */
 	       info->orig_size - CALL_INSN_SIZE);
+	/* FIXME Need to sync cores? Store membarrier? */
 
 	/*
+	 * The fourth and last step is to replace the trap with the call opcode.
+	 *
 	 *     0x0: call <trampoline>
 	 *     0x5: <nop instructions>
 	 *     0xb: <other instructions>

--- a/arch/x86_64/mcount-insn.c
+++ b/arch/x86_64/mcount-insn.c
@@ -583,13 +583,24 @@ static bool check_unsupported(struct mcount_disasm_engine *disasm, cs_insn *insn
 	return true;
 }
 
+/**
+ * check_endbr64 - check if instruction at @addr is endbr64
+ * @addr   - address to check for endbr64
+ * @return - 1 if found, 0 if not
+ */
+int check_endbr64(unsigned long addr)
+{
+	uint8_t endbr64[] = { 0xf3, 0x0f, 0x1e, 0xfa };
+
+	return !memcmp((void *)addr, endbr64, sizeof(endbr64));
+}
+
 int disasm_check_insns(struct mcount_disasm_engine *disasm, struct mcount_dynamic_info *mdi,
 		       struct mcount_disasm_info *info)
 {
 	int status;
 	cs_insn *insn = NULL;
 	uint32_t count, i, size;
-	uint8_t endbr64[] = { 0xf3, 0x0f, 0x1e, 0xfa };
 	void *trampoline_addr;
 	uint8_t *operand;
 	struct dynamic_bad_symbol *badsym;
@@ -612,9 +623,9 @@ int disasm_check_insns(struct mcount_disasm_engine *disasm, struct mcount_dynami
 		return INSTRUMENT_SKIPPED;
 
 	size = info->sym->size;
-	if (!memcmp((void *)info->addr, endbr64, sizeof(endbr64))) {
-		addr += sizeof(endbr64);
-		size -= sizeof(endbr64);
+	if (check_endbr64(info->addr)) {
+		addr += ENDBR_INSN_SIZE;
+		size -= ENDBR_INSN_SIZE;
 
 		if (size <= CALL_INSN_SIZE)
 			return INSTRUMENT_SKIPPED;

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -52,6 +52,7 @@ struct code_page {
 
 static LIST_HEAD(code_pages);
 
+/* contains out-of-line execution code (return address -> modified instructions ptr) */
 static struct Hashmap *code_hmap;
 
 /* minimum function size for dynamic update */

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -1058,6 +1058,96 @@ int tgkill(pid_t tgid, pid_t tid, int signal)
 }
 #endif
 
+/**
+ * find_unused_sigrt - find a real-time signal with no associated action
+ * @return - unused RT signal, or -1 if none found
+ */
+int find_unused_sigrt()
+{
+	int sig;
+	struct sigaction oldact;
+
+	for (sig = SIGRTMIN; sig <= SIGRTMAX; sig++) {
+		if (sigaction(sig, NULL, &oldact) < 0) {
+			pr_dbg3("failed to check RT signal handler\n");
+			continue;
+		}
+
+		if (!oldact.sa_handler)
+			return sig;
+	}
+
+	pr_dbg2("failed to find unused SIGRT\n");
+	return -1;
+}
+
+/**
+ * thread_broadcast_signal - send a signal to all the other running threads in
+ * the process
+ * @sig - signal to send
+ * @return - number of signals sent, -1 on error
+ */
+int thread_broadcast_signal(int sig)
+{
+	char path[32];
+	DIR *dir;
+	struct dirent *dirent;
+	pid_t pid, tid, task;
+	int signal_count = 0;
+
+	pid = getpid();
+	tid = gettid();
+
+	snprintf(path, 32, "/proc/%u/task", pid);
+	dir = opendir(path);
+	if (!dir) {
+		pr_dbg("failed to open directory '%s'\n", path);
+		goto fail_open_dir;
+	}
+
+	errno = 0;
+	for (dirent = readdir(dir); dirent != NULL; dirent = readdir(dir)) {
+		/* skip "." and ".." directories */
+		if (dirent->d_name[0] == '.')
+			continue;
+
+		task = strtol(dirent->d_name, NULL, 10);
+		if (errno != 0 || task < 0) {
+			pr_dbg("failed to parse TID '%s'\n", dirent->d_name);
+			continue;
+		}
+
+		/* ignore our TID */
+		if (task == tid)
+			continue;
+
+		/*
+		 * By reading /proc/<pid>/task directory, there is the possibility of
+		 * a race condition where a thread exits before we send the signal.
+		 */
+		pr_dbg4("send SIGRT%d to %u\n", sig, task);
+		if (tgkill(pid, task, sig) < 0) {
+			if (errno != ESRCH) {
+				pr_dbg2("cannot signal thread %u: %s\n", task, strerror(errno));
+				errno = 0;
+			}
+		}
+		else
+			signal_count++;
+	}
+
+	if (errno != 0)
+		pr_dbg("failed to read directory entry\n");
+
+	if (closedir(dir) < 0)
+		pr_dbg2("failed to close directory\n");
+
+	return signal_count;
+
+fail_open_dir:
+	return -1;
+}
+
 #ifdef UNIT_TEST
 TEST_CASE(utils_parse_cmdline)
 {

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/uio.h>
+#include <syscall.h>
 #include <unistd.h>
 
 #ifdef HAVE_LIBUNWIND
@@ -1031,6 +1032,31 @@ int copy_file(const char *path_in, const char *path_out)
 	fclose(ofp);
 	return 0;
 }
+
+#ifndef gettid
+/**
+ * gettid - gettid syscall wrapper (glibc < 2.30)
+  * @return - thread id
+ */
+pid_t gettid()
+{
+	return syscall(__NR_gettid);
+}
+#endif
+
+#ifndef tgkill
+/**
+ * tgkill - tgkill syscall wrapper (glibc < 2.30)
+ * @tgid   - thread group id
+ * @tid    - thread id
+ * @signal - signal to send
+ * @return - 0 on success, -1 on error
+ */
+int tgkill(pid_t tgid, pid_t tid, int signal)
+{
+	return syscall(SYS_tgkill, tgid, tid, signal);
+}
+#endif
 
 #ifdef UNIT_TEST
 TEST_CASE(utils_parse_cmdline)

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -434,4 +434,7 @@ int copy_file(const char *path_in, const char *path_out);
 pid_t gettid(void);
 int tgkill(pid_t tgid, pid_t tid, int signal);
 
+int find_unused_sigrt(void);
+int thread_broadcast_signal(int sig);
+
 #endif /* UFTRACE_UTILS_H */

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -431,4 +431,7 @@ void stacktrace(void);
 
 int copy_file(const char *path_in, const char *path_out);
 
+pid_t gettid(void);
+int tgkill(pid_t tgid, pid_t tid, int signal);
+
 #endif /* UFTRACE_UTILS_H */


### PR DESCRIPTION
This is the sixth PR in a series of patches intended to bring runtime dynamic tracing on x86_64 to uftrace.
1. #1702 
2. #1703 
3. #1704
4. #1705
5. #1745
6. #1746 🠈

This PR implements the actual dynamic patching. It has a naive approach, which is optimized in #1747.

The patching strategy is as follows:
1. Trap the entry of the critical region (patching zone) so no thread can enter it
2. Serialize execution so cross-modification is effective in all threads
3. Move threads still in the patching region out of line (if needed)
4. Insert trampoline jump (but leave the trap)
5. Replace the trap with the jump opcode

We make heavy use of signals is this naive approach, to serialize execution and redirect execution flow. Later, we only use 1 or 2 signals per patching batch.

Related: #1698