### PR TITLE
agent: Trigger runtime dynamic instrumentation

### DIFF
--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -327,10 +327,10 @@ static void leave_patch_region(int sig, siginfo_t *info, void *ucontext)
 }
 
 /**
- * clear_patch_region - move threads that are in a patching region out of line
+ * clear_patch_regions - move threads that are in a patching region out of line
  * @return - 0
  */
-static int clear_patch_region(void)
+static int clear_patch_regions(void)
 {
 	int signal_count;
 	int move_count = 0;
@@ -396,6 +396,32 @@ int setup_clear_patch_region(void)
 
 	pr_dbg("configured clear signal (SIGRT%d) handler\n", sig_clear_patch_region);
 	return 0;
+}
+
+/* This list is used to store functions that need to be optimized or cleaned up
+ * later in the code. In both case, a SIGRTMIN+n must be send. By optimizing or
+ * cleaning all of them up at the same time, we only need to send one signal per
+ * thread.
+ */
+LIST_HEAD(normal_funcs_patch);
+
+struct patch_dynamic_info {
+	struct list_head list;
+	struct mcount_dynamic_info *mdi;
+	struct mcount_disasm_info *info;
+};
+
+static void commit_normal_func(struct list_head *list, struct mcount_dynamic_info *mdi,
+			       struct mcount_disasm_info *info)
+{
+	struct patch_dynamic_info *pdi;
+	pdi = xmalloc(sizeof(*pdi));
+
+	pdi->mdi = mdi;
+	pdi->info = info;
+	INIT_LIST_HEAD(&pdi->list);
+
+	list_add(&pdi->list, list);
 }
 
 /**
@@ -790,12 +816,14 @@ static int patch_xray_func(struct mcount_dynamic_info *mdi, struct uftrace_symbo
 }
 
 /**
- * patch_code - inject a call to an instrumentation trampoline
- * @mdi    - dynamic info about the concerned module
- * @info   - disassembly info (instructions address and size)
- * @return - instrumentation status
+ * patch_region_lock - insert a trap at the beginning of a patching region so no
+ * new incoming thread will execute it, and register the region as critical for
+ * next step
+ * @mdi    - mcount dynamic info
+ * @info   - disassembly info for the patched symbol
+ * @return - INSTRUMENT_SUCCESS
  */
-static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info *info)
+static int patch_region_lock(struct mcount_dynamic_info *mdi, struct mcount_disasm_info *info)
 {
 	/*
 	 * Let's assume we have the following instructions.
@@ -814,13 +842,10 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 	 */
 
 	void *origin_code_addr;
-	void *trampoline_rel_addr;
 
 	origin_code_addr = (void *)info->addr;
 	if (info->has_intel_cet)
 		origin_code_addr += ENDBR_INSN_SIZE;
-
-	trampoline_rel_addr = (void *)get_trampoline_offset(mdi, (unsigned long)origin_code_addr);
 
 	/* The first step is to insert a 1-byte trap-based probe point (atomic).
 	 * This will prevent threads to enter the critical zone while we patch it,
@@ -832,19 +857,13 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 	 *     0xb: <other instructions>
 	 *
 	 * The trap will emulate a call to the trampoline while in place.
-	 *
-	 * We ensure that every core sees the trap before patching the critical
-	 * zone, by synchronizing the them.
 	 */
 
 	if (register_trap(origin_code_addr, (void *)mdi->trampoline) == -1)
 		return INSTRUMENT_FAILED;
 	((uint8_t *)origin_code_addr)[0] = 0xcc;
 
-	synchronize_all_cores();
-
-	/*
-	 * The second step is to move any thread out of the critical zone if still
+	/* The second step is to move any thread out of the critical zone if still
 	 * present. Threads in the critical zone resume execution out of line, in
 	 * their dedicated OLX region.
 	 *
@@ -856,8 +875,26 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 
 	if (register_patch_region(origin_code_addr, info->orig_size) == -1)
 		pr_dbg3("failed to register patch region\n");
-	clear_patch_region();
-	unregister_patch_region(origin_code_addr, info->orig_size);
+
+	return INSTRUMENT_SUCCESS;
+}
+
+/**
+ * patch_code - patch a region of the code with the operand of the call
+ * instruction used to probe a function. The call opcode needs to be inserted
+ * later.
+ * @mdi  - mcount dynamic info for the current module
+ * @info - disassembly info for the patched symbol
+ */
+static void patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info *info)
+{
+	void *trampoline_rel_addr;
+	void *origin_code_addr;
+
+	origin_code_addr = (void *)info->addr;
+	if (info->has_intel_cet)
+		origin_code_addr += ENDBR_INSN_SIZE;
+	trampoline_rel_addr = (void *)get_trampoline_offset(mdi, (unsigned long)origin_code_addr);
 
 	/* The third step is to write the target address of the call. From the
 	 * processor view the 4-bytes address can be any garbage instructions.
@@ -873,7 +910,23 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 	memcpy(&((uint8_t *)origin_code_addr)[1], &trampoline_rel_addr, CALL_INSN_SIZE - 1);
 	memset(origin_code_addr + CALL_INSN_SIZE, 0x90, /* NOP */
 	       info->orig_size - CALL_INSN_SIZE);
-	/* FIXME Need to sync cores? Store membarrier? */
+}
+
+/**
+ * patch_region_unlock - unmark a region as critical and remove the trap that
+ * prevents execution.
+ * @info   - disassembly info for the patched symbol
+ */
+static void patch_region_unlock(struct mcount_disasm_info *info)
+{
+	void *origin_code_addr;
+
+	origin_code_addr = (void *)info->addr;
+	if (info->has_intel_cet)
+		origin_code_addr += ENDBR_INSN_SIZE;
+
+	if (unregister_patch_region(origin_code_addr, info->orig_size) == -1)
+		pr_dbg3("failed to unregister patch region\n");
 
 	/*
 	 * The fourth and last step is to replace the trap with the call opcode.
@@ -884,13 +937,19 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 	 */
 
 	((uint8_t *)origin_code_addr)[0] = 0xe8;
-	unregister_trap(origin_code_addr);
-
-	return INSTRUMENT_SUCCESS;
 }
 
-static int patch_normal_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym,
-			     struct mcount_disasm_engine *disasm)
+/**
+ * patch_normal_func_init - perform the initial steps of the patching process,
+ * awaiting for sanitization of the critical region. This step is batched with
+ * subsequent ones.
+ * @mdi    - mcount dynamic info for the current module
+ * @sym    - symbol to patch
+ * @disasm - disassembly engine
+ * @return - instrumentation status
+ */
+static int patch_normal_func_init(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym,
+				  struct mcount_disasm_engine *disasm)
 {
 	uint8_t jmp_insn[15] = {
 		0x3e,
@@ -898,20 +957,22 @@ static int patch_normal_func(struct mcount_dynamic_info *mdi, struct uftrace_sym
 		0x25,
 	};
 	uint64_t jmp_target;
-	struct mcount_disasm_info info = {
-		.sym = sym,
-		.addr = mdi->map->start + sym->addr,
-	};
+	struct mcount_disasm_info *info;
 	unsigned call_offset = CALL_INSN_SIZE;
 	int state;
 
-	state = disasm_check_insns(disasm, mdi, &info);
+	info = xmalloc(sizeof(*info));
+	memset(info, 0, sizeof(*info));
+	info->sym = sym;
+	info->addr = mdi->map->start + sym->addr;
+
+	state = disasm_check_insns(disasm, mdi, info);
 	if (state != INSTRUMENT_SUCCESS) {
 		pr_dbg3("  >> %s: %s\n", state == INSTRUMENT_FAILED ? "FAIL" : "SKIP", sym->name);
 		return state;
 	}
 
-	pr_dbg2("force patch normal func: %s (patch size: %d)\n", sym->name, info.orig_size);
+	pr_dbg2("force patch normal func: %s (patch size: %d)\n", sym->name, info->orig_size);
 
 	/*
 	 *  stored origin instruction block:
@@ -923,20 +984,62 @@ static int patch_normal_func(struct mcount_dynamic_info *mdi, struct uftrace_sym
 	 *  | [Return   address] |
 	 *  ----------------------
 	 */
-	jmp_target = info.addr + info.orig_size;
-	if (info.has_intel_cet) {
+	jmp_target = info->addr + info->orig_size;
+	if (info->has_intel_cet) {
 		jmp_target += ENDBR_INSN_SIZE;
 		call_offset += ENDBR_INSN_SIZE;
 	}
 
 	memcpy(jmp_insn + CET_JMP_INSN_SIZE, &jmp_target, sizeof(jmp_target));
 
-	if (info.has_jump)
-		mcount_save_code(&info, call_offset, jmp_insn, 0);
+	if (info->has_jump)
+		mcount_save_code(info, call_offset, jmp_insn, 0);
 	else
-		mcount_save_code(&info, call_offset, jmp_insn, sizeof(jmp_insn));
+		mcount_save_code(info, call_offset, jmp_insn, sizeof(jmp_insn));
 
-	return patch_code(mdi, &info);
+	state = patch_region_lock(mdi, info);
+	commit_normal_func(&normal_funcs_patch, mdi, info);
+
+	return state;
+}
+
+/**
+ * mcount_patch_normal_func_fini - perform the final step of the patching process and cleanup
+ * @return - 0
+ */
+void mcount_patch_normal_func_fini(void)
+{
+	struct patch_dynamic_info *pdi, *tmp;
+
+	if (list_empty(&normal_funcs_patch))
+		return;
+
+	/* We ensure that every core sees the trap before patching the critical
+	 * zone, by synchronizing the them.
+	 */
+	synchronize_all_cores();
+	clear_patch_regions();
+
+	list_for_each_entry_safe(pdi, tmp, &normal_funcs_patch, list) {
+		patch_code(pdi->mdi, pdi->info);
+		write_memory_barrier();
+		patch_region_unlock(pdi->info);
+	}
+
+	synchronize_all_cores();
+
+	list_for_each_entry_safe(pdi, tmp, &normal_funcs_patch, list) {
+		void *origin_code_addr;
+
+		origin_code_addr = (void *)pdi->info->addr;
+		if (pdi->info->has_intel_cet)
+			origin_code_addr += ENDBR_INSN_SIZE;
+
+		unregister_trap(origin_code_addr);
+		list_del(&pdi->list);
+		free(pdi->info);
+		free(pdi);
+	}
 }
 
 static int unpatch_func(uint8_t *insn, char *name)
@@ -1025,7 +1128,7 @@ int mcount_patch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sy
 		break;
 
 	case DYNAMIC_NONE:
-		result = patch_normal_func(mdi, sym, disasm);
+		result = patch_normal_func_init(mdi, sym, disasm);
 		break;
 
 	default:

--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <semaphore.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -7,7 +8,6 @@
 #include <linux/membarrier.h>
 #else
 #include <cpuid.h>
-#include <semaphore.h>
 #endif
 
 /* This should be defined before #include "utils.h" */
@@ -38,6 +38,22 @@ static const unsigned char endbr64[] = { 0xf3, 0x0f, 0x1e, 0xfa };
  * (void *int3_location -> void *trampoline)
  */
 static struct Hashmap *int3_hmap;
+
+/* Hashmap of the addresses of instructions that are in patching zones and need
+ * to be executed out of line. The addresses are mapped to their out of line
+ * equivalent.
+ *
+ * (void *critical_insn -> void *out_of_line_insn)
+ */
+static struct Hashmap *patch_region_hmap;
+
+/* Realtime signal number to instruct running threads to move out of patching
+   regions */
+static int sig_clear_patch_region;
+
+/* counter for the threads that are guaranteed to be out of registered patching
+   regions when a signal is issued */
+static sem_t sem_clear_patch_region;
 
 /**
  * register_trap - save trampoline associated to a trap
@@ -233,6 +249,8 @@ static int synchronize_all_cores(void)
 		if (sem_timedwait(&sem_sync_cores, &ts) == -1) {
 			if (errno == EINTR)
 				i--;
+			else
+				pr_dbg3("error syncing with signal handler: %s\n", strerror(errno));
 		}
 		else
 			sync_count++;
@@ -243,6 +261,143 @@ static int synchronize_all_cores(void)
 }
 
 #endif /* HAVE_MEMBARRIER */
+
+/**
+ * register_patch_region - mark a memory region as critical by registering the
+ * addresses that it contains in 'patch_region_hmap'
+ * @start  - address of the patch region
+ * @len    - length of the patch region
+ * @return - -1 on error, 0 on success
+ */
+static int register_patch_region(void *start, int len)
+{
+	void *out_of_line_buffer = mcount_find_code((unsigned long)start + CALL_INSN_SIZE);
+	if (!out_of_line_buffer)
+		return -1;
+
+	for (int i = 0; i < len; i++) {
+		if (!hashmap_put(patch_region_hmap, start + i, out_of_line_buffer + i))
+			return -1;
+	}
+
+	return 0;
+}
+
+/**
+ * unregister_patch_region - unmark a memory region as critical
+ * @start  - address of the patch region
+ * @len    - length of the patch region
+ * @return - -1 on error, 0 on success
+ */
+static int unregister_patch_region(void *start, int len)
+{
+	void *out_of_line_buffer = mcount_find_code((unsigned long)start);
+	if (!out_of_line_buffer)
+		return -1;
+
+	for (int i = 0; i < len; i++) {
+		if (!hashmap_remove(patch_region_hmap, start + i))
+			return -1;
+	}
+
+	return 0;
+}
+
+/**
+ * leave_patch_region - signal handler on which a thread executes out of line if
+ * it happens to be in a registered patching region
+ * @sig      - signal number
+ * @info     - signal info (unused)
+ * @ucontext - user context
+ */
+static void leave_patch_region(int sig, siginfo_t *info, void *ucontext)
+{
+	ucontext_t *uctx = ucontext;
+	mcontext_t *mctx = &uctx->uc_mcontext;
+	void *next_insn;
+	void *out_of_line_insn;
+	(void)sig;
+
+	next_insn = (void *)mctx->gregs[REG_RIP];
+	out_of_line_insn = hashmap_get(patch_region_hmap, next_insn);
+	if (out_of_line_insn)
+		mctx->gregs[REG_RIP] = (uint64_t)out_of_line_insn;
+
+	sem_post(&sem_clear_patch_region);
+}
+
+/**
+ * clear_patch_region - move threads that are in a patching region out of line
+ * @return - 0
+ */
+static int clear_patch_region(void)
+{
+	int signal_count;
+	int move_count = 0;
+	struct timespec ts;
+
+	ASSERT(sig_clear_patch_region >= SIGRTMIN);
+
+	signal_count = thread_broadcast_signal(sig_clear_patch_region);
+
+	if (clock_gettime(CLOCK_REALTIME, &ts) == -1)
+		return -1;
+	ts.tv_sec += 1;
+
+	for (int i = 0; i < signal_count; i++) {
+		if (sem_timedwait(&sem_clear_patch_region, &ts) == -1) {
+			if (errno == EINTR)
+				i--;
+			else
+				pr_dbg3("error syncing with signal handler: %s\n", strerror(errno));
+		}
+		else
+			move_count++;
+	}
+	pr_dbg3("checked ip of %d/%d thread(s)\n", move_count, signal_count);
+
+	return 0;
+}
+
+/**
+ * setup_clear_patch_region - initialize data structures and signals used to
+ * move threads of patching regions
+ *  @return - -1 on error, 0 on success
+ */
+int setup_clear_patch_region(void)
+{
+	struct sigaction act;
+
+	if (!patch_region_hmap) {
+		patch_region_hmap = hashmap_create(4, hashmap_ptr_hash, hashmap_ptr_equals);
+		if (!patch_region_hmap) {
+			pr_dbg("failed to create patch region hashmap\n");
+			return -1;
+		}
+	}
+
+	if (sig_clear_patch_region > 0)
+		return 0;
+
+	sig_clear_patch_region = find_unused_sigrt();
+	if (sig_clear_patch_region == -1)
+		return -1;
+
+	sem_init(&sem_clear_patch_region, 0, 0);
+
+	act.sa_sigaction = leave_patch_region;
+	act.sa_flags = 0;
+
+	if (sigaction(sig_clear_patch_region, &act, NULL) < 0) {
+		pr_dbg("failed to configure clear signal (SIGRT%d) handler\n",
+		       sig_clear_patch_region);
+		return -1;
+	}
+
+	pr_dbg("configured clear signal (SIGRT%d) handler\n", sig_clear_patch_region);
+	return 0;
+}
+
 /**
  * mcount_arch_dynamic_init - initialize arch-specific data structures to
  * perform runtime dynamic instrumentation
@@ -261,6 +416,8 @@ int mcount_arch_dynamic_init(void)
 
 	if (setup_synchronization_mechanism() < 0)
 		return -1;
+
+	setup_clear_patch_region();
 
 	return 0;
 }
@@ -687,6 +844,24 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 	synchronize_all_cores();
 
 	/*
+	 * The second step is to move any thread out of the critical zone if still
+	 * present. Threads in the critical zone resume execution out of line, in
+	 * their dedicated OLX region.
+	 *
+	 * The method used to move the threads is to signal all the threads, so they
+	 * check if their instruction pointer is in the patching region. If so, they
+	 * move their instruction pointer to the corresponding one in the OLX
+	 * region.
+	 */
+
+	if (register_patch_region(origin_code_addr, info->orig_size) == -1)
+		pr_dbg3("failed to register patch region\n");
+	clear_patch_region();
+	unregister_patch_region(origin_code_addr, info->orig_size);
+
+	/* The third step is to write the target address of the call. From the
+	 * processor view the 4-bytes address can be any garbage instructions.
+	 *
 	 * We fill the remaining part of the patching region with nops.
 	 *
 	 *     0x0: int3
@@ -698,8 +873,11 @@ static int patch_code(struct mcount_dynamic_info *mdi, struct mcount_disasm_info
 	memcpy(&((uint8_t *)origin_code_addr)[1], &trampoline_rel_addr, CALL_INSN_SIZE - 1);
 	memset(origin_code_addr + CALL_INSN_SIZE, 0x90, /* NOP */
 	       info->orig_size - CALL_INSN_SIZE);
+	/* FIXME Need to sync cores? Store membarrier? */
 
 	/*
+	 * The fourth and last step is to replace the trap with the call opcode.
+	 *
 	 *     0x0: call <trampoline>
 	 *     0x5: <nop instructions>
 	 *     0xb: <other instructions>

--- a/arch/x86_64/mcount-insn.c
+++ b/arch/x86_64/mcount-insn.c
@@ -583,13 +583,24 @@ static bool check_unsupported(struct mcount_disasm_engine *disasm, cs_insn *insn
 	return true;
 }
 
+/**
+ * check_endbr64 - check if instruction at @addr is endbr64
+ * @addr   - address to check for endbr64
+ * @return - 1 if found, 0 if not
+ */
+int check_endbr64(unsigned long addr)
+{
+	uint8_t endbr64[] = { 0xf3, 0x0f, 0x1e, 0xfa };
+
+	return !memcmp((void *)addr, endbr64, sizeof(endbr64));
+}
+
 int disasm_check_insns(struct mcount_disasm_engine *disasm, struct mcount_dynamic_info *mdi,
 		       struct mcount_disasm_info *info)
 {
 	int status;
 	cs_insn *insn = NULL;
 	uint32_t count, i, size;
-	uint8_t endbr64[] = { 0xf3, 0x0f, 0x1e, 0xfa };
 	void *trampoline_addr;
 	uint8_t *operand;
 	struct dynamic_bad_symbol *badsym;
@@ -612,9 +623,9 @@ int disasm_check_insns(struct mcount_disasm_engine *disasm, struct mcount_dynami
 		return INSTRUMENT_SKIPPED;
 
 	size = info->sym->size;
-	if (!memcmp((void *)info->addr, endbr64, sizeof(endbr64))) {
-		addr += sizeof(endbr64);
-		size -= sizeof(endbr64);
+	if (check_endbr64(info->addr)) {
+		addr += ENDBR_INSN_SIZE;
+		size -= ENDBR_INSN_SIZE;
 
 		if (size <= CALL_INSN_SIZE)
 			return INSTRUMENT_SKIPPED;

--- a/cmds/live.c
+++ b/cmds/live.c
@@ -361,7 +361,7 @@ static int forward_options(struct uftrace_opts *opts)
 	}
 
 	/* provide a pattern type for options that need it */
-	if (opts->filter || opts->caller || opts->trigger) {
+	if (opts->filter || opts->caller || opts->trigger || opts->patch) {
 		status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_PATTERN,
 					&opts->patt_type, sizeof(opts->patt_type));
 		if (status < 0)
@@ -385,6 +385,13 @@ static int forward_options(struct uftrace_opts *opts)
 	if (opts->trigger) {
 		status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_TRIGGER, opts->trigger,
 					strlen(opts->trigger) + 1);
+		if (status < 0)
+			goto close;
+	}
+
+	if (opts->patch) {
+		status = forward_option(sfd, capabilities, UFTRACE_AGENT_OPT_PATCH, opts->patch,
+					strlen(opts->patch) + 1);
 		if (status < 0)
 			goto close;
 	}

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -384,10 +384,17 @@ static bool match_pattern_module(char *pathname)
 	return ret;
 }
 
-static bool match_pattern_list(struct uftrace_mmap *map, char *soname, char *sym_name)
+/**
+ * match_pattern_list - match a symbol name against a pattern list
+ * @map - memory map of the symbol
+ * @soname - name of the module
+ * @sym_name - name of the symbol
+ * @return - -1 if match negative, 1 if match positive, 0 if no match
+ */
+static int match_pattern_list(struct uftrace_mmap *map, char *soname, char *sym_name)
 {
 	struct patt_list *pl;
-	bool ret = false;
+	int ret = 0;
 	char *libname = basename(map->libname);
 
 	list_for_each_entry(pl, &patterns, list) {
@@ -398,7 +405,7 @@ static bool match_pattern_list(struct uftrace_mmap *map, char *soname, char *sym
 			continue;
 
 		if (match_filter_pattern(&pl->patt, sym_name))
-			ret = pl->positive;
+			ret = pl->positive ? 1 : -1;
 	}
 
 	return ret;
@@ -470,9 +477,6 @@ static bool skip_sym(struct uftrace_symbol *sym, struct mcount_dynamic_info *mdi
 	if (sym->type != ST_LOCAL_FUNC && sym->type != ST_GLOBAL_FUNC && sym->type != ST_WEAK_FUNC)
 		return true;
 
-	if (!match_pattern_list(map, soname, sym->name))
-		return true;
-
 	return false;
 }
 
@@ -539,6 +543,7 @@ static void patch_normal_func_matched(struct mcount_dynamic_info *mdi, struct uf
 	unsigned i;
 	struct uftrace_symbol *sym;
 	bool found = false;
+	int match;
 	char *soname = get_soname(map->libname);
 
 	symtab = &map->mod->symtab;
@@ -548,9 +553,15 @@ static void patch_normal_func_matched(struct mcount_dynamic_info *mdi, struct uf
 
 		if (skip_sym(sym, mdi, map, soname))
 			continue;
-
 		found = true;
-		mcount_patch_func_with_stats(mdi, sym);
+
+		match = match_pattern_list(map, soname, sym->name);
+		if (!match)
+			continue;
+		else if (match == 1)
+			mcount_patch_func_with_stats(mdi, sym);
+		else
+			mcount_unpatch_func(mdi, sym, NULL);
 	}
 
 	if (!found)
@@ -826,27 +837,27 @@ TEST_CASE(dynamic_pattern_list)
 	pr_dbg("check simple match with default module\n");
 	parse_pattern_list("abc;!def", "main", PATT_SIMPLE);
 
-	TEST_EQ(match_pattern_list(main_map, NULL, "abc"), true);
-	TEST_EQ(match_pattern_list(main_map, NULL, "def"), false);
-	TEST_EQ(match_pattern_list(other_map, NULL, "xyz"), false);
+	TEST_EQ(match_pattern_list(main_map, NULL, "abc"), 1);
+	TEST_EQ(match_pattern_list(main_map, NULL, "def"), -1);
+	TEST_EQ(match_pattern_list(other_map, NULL, "xyz"), 0);
 
 	release_pattern_list();
 
 	pr_dbg("check negative regex match with default module\n");
 	parse_pattern_list("!^a", "main", PATT_REGEX);
 
-	TEST_EQ(match_pattern_list(main_map, NULL, "abc"), false);
-	TEST_EQ(match_pattern_list(main_map, NULL, "def"), true);
-	TEST_EQ(match_pattern_list(other_map, NULL, "xyz"), false);
+	TEST_EQ(match_pattern_list(main_map, NULL, "abc"), -1);
+	TEST_EQ(match_pattern_list(main_map, NULL, "def"), 0);
+	TEST_EQ(match_pattern_list(other_map, NULL, "xyz"), 0);
 
 	release_pattern_list();
 
 	pr_dbg("check wildcard match with other module\n");
 	parse_pattern_list("*@other", "main", PATT_GLOB);
 
-	TEST_EQ(match_pattern_list(main_map, NULL, "abc"), false);
-	TEST_EQ(match_pattern_list(main_map, NULL, "def"), false);
-	TEST_EQ(match_pattern_list(other_map, NULL, "xyz"), true);
+	TEST_EQ(match_pattern_list(main_map, NULL, "abc"), 0);
+	TEST_EQ(match_pattern_list(main_map, NULL, "def"), 0);
+	TEST_EQ(match_pattern_list(other_map, NULL, "xyz"), 1);
 
 	release_pattern_list();
 

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -229,6 +229,10 @@ __weak void mcount_patch_normal_func_fini(void)
 {
 }
 
+__weak void mcount_unpatch_normal_func_fini(void)
+{
+}
+
 __weak int mcount_unpatch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym)
 {
 	return -1;
@@ -572,6 +576,7 @@ static void patch_normal_func_matched(struct mcount_dynamic_info *mdi, struct uf
 		stats.nomatch++;
 
 	mcount_patch_normal_func_fini();
+	mcount_unpatch_normal_func_fini();
 
 	free(soname);
 }

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -410,7 +410,6 @@ static void parse_pattern_list(char *patch_funcs, char *def_mod, enum uftrace_pa
 	char *name;
 	int j;
 	struct patt_list *pl;
-	bool all_negative = true;
 
 	strv_split(&funcs, patch_funcs, ";");
 
@@ -421,10 +420,8 @@ static void parse_pattern_list(char *patch_funcs, char *def_mod, enum uftrace_pa
 
 		if (name[0] == '!')
 			name++;
-		else {
+		else
 			pl->positive = true;
-			all_negative = false;
-		}
 
 		delim = strchr(name, '@');
 		if (delim == NULL) {
@@ -437,20 +434,6 @@ static void parse_pattern_list(char *patch_funcs, char *def_mod, enum uftrace_pa
 
 		init_filter_pattern(ptype, &pl->patt, name);
 		list_add_tail(&pl->list, &patterns);
-	}
-
-	/* prepend match-all pattern, if all patterns are negative */
-	if (all_negative) {
-		pl = xzalloc(sizeof(*pl));
-		pl->positive = true;
-		pl->module = xstrdup(def_mod);
-
-		if (ptype == PATT_REGEX)
-			init_filter_pattern(ptype, &pl->patt, ".");
-		else
-			init_filter_pattern(PATT_GLOB, &pl->patt, "*");
-
-		list_add(&pl->list, &patterns);
 	}
 
 	strv_free(&funcs);

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -52,6 +52,7 @@ struct code_page {
 
 static LIST_HEAD(code_pages);
 
+/* contains out-of-line execution code (return address -> modified instructions ptr) */
 static struct Hashmap *code_hmap;
 
 /* minimum function size for dynamic update */

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -229,8 +229,7 @@ __weak void mcount_patch_normal_func_fini(void)
 {
 }
 
-__weak int mcount_unpatch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym,
-			       struct mcount_disasm_engine *disasm)
+__weak int mcount_unpatch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym)
 {
 	return -1;
 }
@@ -566,7 +565,7 @@ static void patch_normal_func_matched(struct mcount_dynamic_info *mdi, struct uf
 		else if (match == 1)
 			mcount_patch_func_with_stats(mdi, sym);
 		else
-			mcount_unpatch_func(mdi, sym, NULL);
+			mcount_unpatch_func(mdi, sym);
 	}
 
 	if (!found)

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -225,6 +225,10 @@ __weak int mcount_patch_func(struct mcount_dynamic_info *mdi, struct uftrace_sym
 	return -1;
 }
 
+__weak void mcount_patch_normal_func_fini(void)
+{
+}
+
 __weak int mcount_unpatch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym,
 			       struct mcount_disasm_engine *disasm)
 {
@@ -567,6 +571,8 @@ static void patch_normal_func_matched(struct mcount_dynamic_info *mdi, struct uf
 
 	if (!found)
 		stats.nomatch++;
+
+	mcount_patch_normal_func_fini();
 
 	free(soname);
 }

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -470,11 +470,8 @@ static bool skip_sym(struct uftrace_symbol *sym, struct mcount_dynamic_info *mdi
 	if (sym->type != ST_LOCAL_FUNC && sym->type != ST_GLOBAL_FUNC && sym->type != ST_WEAK_FUNC)
 		return true;
 
-	if (!match_pattern_list(map, soname, sym->name)) {
-		if (mcount_unpatch_func(mdi, sym, &disasm) == 0)
-			stats.unpatch++;
+	if (!match_pattern_list(map, soname, sym->name))
 		return true;
-	}
 
 	return false;
 }

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -107,7 +107,7 @@ static volatile bool agent_run = false;
 #define MCOUNT_AGENT_CAPABILITIES                                                                  \
 	(UFTRACE_AGENT_OPT_TRACE | UFTRACE_AGENT_OPT_DEPTH | UFTRACE_AGENT_OPT_THRESHOLD |         \
 	 UFTRACE_AGENT_OPT_PATTERN | UFTRACE_AGENT_OPT_FILTER | UFTRACE_AGENT_OPT_CALLER |         \
-	 UFTRACE_AGENT_OPT_TRIGGER)
+	 UFTRACE_AGENT_OPT_TRIGGER | UFTRACE_AGENT_OPT_PATCH)
 
 __weak void dynamic_return(void)
 {
@@ -1986,6 +1986,11 @@ static int agent_apply_option(int opt, void *value, size_t size,
 	case UFTRACE_AGENT_OPT_TRIGGER:
 		pr_dbg3("apply trigger '%s' (size=%d)\n", value, size);
 		agent_setup_trigger(value, triggers);
+		break;
+
+	case UFTRACE_AGENT_OPT_PATCH:
+		pr_dbg3("apply patch '%s' (size=%d)\n", value, size);
+		mcount_dynamic_update(&mcount_sym_info, value, mcount_filter_setting.ptype);
 		break;
 
 	default:

--- a/uftrace.h
+++ b/uftrace.h
@@ -466,6 +466,7 @@ enum uftrace_agent_opt {
 	UFTRACE_AGENT_OPT_FILTER = (1U << 4), /* tracing filters */
 	UFTRACE_AGENT_OPT_CALLER = (1U << 5), /* tracing caller filters */
 	UFTRACE_AGENT_OPT_TRIGGER = (1U << 6), /* tracing trigger actions */
+	UFTRACE_AGENT_OPT_PATCH = (1U << 7), /* patch string */
 };
 
 extern struct uftrace_session *first_session;

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -1058,6 +1058,96 @@ int tgkill(pid_t tgid, pid_t tid, int signal)
 }
 #endif
 
+/**
+ * find_unused_sigrt - find a real-time signal with no associated action
+ * @return - unused RT signal, or -1 if none found
+ */
+int find_unused_sigrt()
+{
+	int sig;
+	struct sigaction oldact;
+
+	for (sig = SIGRTMIN; sig <= SIGRTMAX; sig++) {
+		if (sigaction(sig, NULL, &oldact) < 0) {
+			pr_dbg3("failed to check RT signal handler\n");
+			continue;
+		}
+
+		if (!oldact.sa_handler)
+			return sig;
+	}
+
+	pr_dbg2("failed to find unused SIGRT\n");
+	return -1;
+}
+
+/**
+ * thread_broadcast_signal - send a signal to all the other running threads in
+ * the process
+ * @sig - signal to send
+ * @return - number of signals sent, -1 on error
+ */
+int thread_broadcast_signal(int sig)
+{
+	char path[32];
+	DIR *dir;
+	struct dirent *dirent;
+	pid_t pid, tid, task;
+	int signal_count = 0;
+
+	pid = getpid();
+	tid = gettid();
+
+	snprintf(path, 32, "/proc/%u/task", pid);
+	dir = opendir(path);
+	if (!dir) {
+		pr_dbg("failed to open directory '%s'\n", path);
+		goto fail_open_dir;
+	}
+
+	errno = 0;
+	for (dirent = readdir(dir); dirent != NULL; dirent = readdir(dir)) {
+		/* skip "." and ".." directories */
+		if (dirent->d_name[0] == '.')
+			continue;
+
+		task = strtol(dirent->d_name, NULL, 10);
+		if (errno != 0 || task < 0) {
+			pr_dbg("failed to parse TID '%s'\n", dirent->d_name);
+			continue;
+		}
+
+		/* ignore our TID */
+		if (task == tid)
+			continue;
+
+		/*
+		 * By reading /proc/<pid>/task directory, there is the possibility of
+		 * a race condition where a thread exits before we send the signal.
+		 */
+		pr_dbg4("send SIGRT%d to %u\n", sig, task);
+		if (tgkill(pid, task, sig) < 0) {
+			if (errno != ESRCH) {
+				pr_dbg2("cannot signal thread %u: %s\n", task, strerror(errno));
+				errno = 0;
+			}
+		}
+		else
+			signal_count++;
+	}
+
+	if (errno != 0)
+		pr_dbg("failed to read directory entry\n");
+
+	if (closedir(dir) < 0)
+		pr_dbg2("failed to close directory\n");
+
+	return signal_count;
+
+fail_open_dir:
+	return -1;
+}
+
 #ifdef UNIT_TEST
 TEST_CASE(utils_parse_cmdline)
 {

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/uio.h>
+#include <syscall.h>
 #include <unistd.h>
 
 #ifdef HAVE_LIBUNWIND
@@ -1031,6 +1032,31 @@ int copy_file(const char *path_in, const char *path_out)
 	fclose(ofp);
 	return 0;
 }
+
+#ifndef gettid
+/**
+ * gettid - gettid syscall wrapper (glibc < 2.30)
+  * @return - thread id
+ */
+pid_t gettid()
+{
+	return syscall(__NR_gettid);
+}
+#endif
+
+#ifndef tgkill
+/**
+ * tgkill - tgkill syscall wrapper (glibc < 2.30)
+ * @tgid   - thread group id
+ * @tid    - thread id
+ * @signal - signal to send
+ * @return - 0 on success, -1 on error
+ */
+int tgkill(pid_t tgid, pid_t tid, int signal)
+{
+	return syscall(SYS_tgkill, tgid, tid, signal);
+}
+#endif
 
 #ifdef UNIT_TEST
 TEST_CASE(utils_parse_cmdline)

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -434,4 +434,7 @@ int copy_file(const char *path_in, const char *path_out);
 pid_t gettid(void);
 int tgkill(pid_t tgid, pid_t tid, int signal);
 
+int find_unused_sigrt(void);
+int thread_broadcast_signal(int sig);
+
 #endif /* UFTRACE_UTILS_H */

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -431,4 +431,7 @@ void stacktrace(void);
 
 int copy_file(const char *path_in, const char *path_out);
 
+pid_t gettid(void);
+int tgkill(pid_t tgid, pid_t tid, int signal);
+
 #endif /* UFTRACE_UTILS_H */


### PR DESCRIPTION
This is the ninth PR in a series of patches intended to bring runtime dynamic tracing on x86_64 to uftrace.
1. #1702 
2. #1703 
3. #1704
4. #1705
5. #1745
6. #1746
7. #1747
8. #1748
9. #1749 🠈
10. #1750

We support triggering runtime dynamic patching and unpatching from the agent.

Related: #1698