### PR TITLE
uftrace: Fix dead store warnings found by infer

### DIFF
--- a/utils/debug.c
+++ b/utils/debug.c
@@ -383,8 +383,8 @@ void print_time_unit(uint64_t delta_nsec)
 
 void print_diff_percent(uint64_t base_nsec, uint64_t pair_nsec)
 {
-	double percent = 999.99;
-	const char *sc = get_color(COLOR_CODE_NORMAL);
+	double percent;
+	const char *sc;
 	const char *ec = get_color(COLOR_CODE_RESET);
 
 	if (base_nsec == 0) {

--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -43,7 +43,6 @@ struct kfilter {
 static int set_filter_file(const char *filter_file, struct list_head *filters)
 {
 	struct kfilter *pos, *tmp;
-	int ret = -1;
 	int fd;
 
 	fd = open_tracing_file(filter_file, true);
@@ -64,10 +63,9 @@ static int set_filter_file(const char *filter_file, struct list_head *filters)
 		if (write(fd, " ", 1) != 1)
 			pr_dbg2("writing filter file failed, but ignoring...\n");
 	}
-	ret = 0;
 
 	close(fd);
-	return ret;
+	return 0;
 }
 
 static int set_tracing_filter(struct uftrace_kernel_writer *kernel)

--- a/utils/perf.c
+++ b/utils/perf.c
@@ -227,7 +227,6 @@ void record_perf_data(struct uftrace_perf_writer *perf, int cpu, int sock)
 
 	buf = &data[start & mask];
 	size = end - start;
-	start += size;
 
 	if (sock > 0)
 		send_trace_perf_data(sock, cpu, buf, size);


### PR DESCRIPTION
uftrace: Fix dead store warnings found by infer

This patch fixes some dead store warnings found by a static analysis
tool, called infer[1].

The warning messages are as follows.
```
  $ cd /path/to/uftrace
  $ infer run --force-integration make
          ...
  utils/debug.c:386: error: Dead Store
    The value written to `&percent` (type `double`) is never used.
    384. void print_diff_percent(uint64_t base_nsec, uint64_t pair_nsec)
    385. {
    386. 	double percent = 999.99;
          ^

  utils/debug.c:387: error: Dead Store
    The value written to `&sc` is never used.
    385. {
    386.  double percent = 999.99;
    387.  const char *sc = get_color(COLOR_CODE_NORMAL);
          ^
    388.  const char *ec = get_color(COLOR_CODE_RESET);
    389.

  utils/kernel.c:57: error: Dead Store
    The value written to `&ret` is never used.
    55. {
    56.   struct kfilter *pos, *tmp;
    57.   int ret = -1;
         ^
    58.   int fd;
    59.

  utils/perf.c:230: error: Dead Store
    The value written to `&start` is never used.
    228.  buf = &data[start & mask];
    229.  size = end - start;
    230.  start += size;
          ^
```

[1] https://github.com/facebook/infer

Fixed: #1553
Signed-off-by: Paran Lee <p4ranlee@gmail.com>