### PR TITLE
Refactor the kernel depth option and documentation

### DIFF
--- a/cmds/record.c
+++ b/cmds/record.c
@@ -1782,7 +1782,7 @@ static void setup_writers(struct writer_data *wd, struct uftrace_opts *opts)
 
 		kernel->pid = wd->pid;
 		kernel->output_dir = opts->dirname;
-		kernel->depth = opts->kernel_depth ?: 1;
+		kernel->depth = opts->kernel_depth;
 		kernel->bufsize = opts->kernel_bufsize;
 		kernel->clock = opts->clock;
 

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -62,9 +62,9 @@ RECORD OPTIONS
     library call from the main executable.  Implies `--force`.
 
 -k, \--kernel
-:   Trace kernel functions as well as user functions.  Only kernel entry/exit
-    functions will be traced by default.  Use the `--kernel-depth` option to
-    override this.
+:   Trace kernel functions as well as user functions.  By default, the tracing
+    depth is 1 (Only kernel entry/exit functions will be traced).
+    Use the `-K`/`--kernel-depth` option to override this.
 
 -K *DEPTH*, \--kernel-depth=*DEPTH*
 :   Set kernel max function depth separately.  Implies `--kernel`.

--- a/uftrace.c
+++ b/uftrace.c
@@ -655,14 +655,15 @@ static int parse_option(struct uftrace_opts *opts, int key, char *arg)
 
 	case 'k':
 		opts->kernel = true;
+		opts->kernel_depth = 1;
 		break;
 
 	case 'K':
 		opts->kernel = true;
 		opts->kernel_depth = strtol(arg, NULL, 0);
 		if (opts->kernel_depth < 1 || opts->kernel_depth > 50) {
-			pr_use("invalid kernel depth: %s (ignoring...)\n", arg);
-			opts->kernel_depth = 0;
+			pr_use("invalid kernel depth: %s. Set depth to 1.\n", arg);
+			opts->kernel_depth = 1;
 		}
 		break;
 


### PR DESCRIPTION
To process the `-k` option, the `kernel_depth` in opt field is not set and is set to 1 when used (`setup_writers`).
This PR initializes the `opts->kernel_depth` to 1 at the case  `-k` and `-K` if the input value is invalid.

This refactoring clarifies the code semantic when the user only uses the `-k`, and invalid `-K`.