### PR TITLE
build: Fix compile warning message

### DIFF
--- a/python/trace-python.c
+++ b/python/trace-python.c
@@ -5,6 +5,9 @@
  *
  * Released under the GPL v2.
  */
+
+#undef _XOPEN_SOURCE
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include <fcntl.h>

--- a/utils/script-python.h
+++ b/utils/script-python.h
@@ -14,6 +14,7 @@ struct script_info;
 
 #if defined(HAVE_LIBPYTHON2) || defined(HAVE_LIBPYTHON3)
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #define SCRIPT_PYTHON_ENABLED 1


### PR DESCRIPTION
Python.h should not be on the first line.
Python.h needs to be rearranged.

issue: #1648

Signed-off-by: Jin Jang <keepgoingxxx@gmail.com>