### PR TITLE
tests: fix `gen_port()` to select unbind ports

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -5,6 +5,7 @@ import multiprocessing
 import os
 import random
 import re
+import socket
 import subprocess as sp
 import sys
 import tempfile
@@ -136,8 +137,16 @@ class TestBase:
     def set_keep(self, keep):
         self.keep = keep
 
-    def gen_port(self):
-        self.port = random.randint(40000, 50000)
+    def gen_port(self, start = 40000, end = 50000):
+        for port in random.sample(list(range(start, end + 1)), end - start + 1):
+            try:
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                    s.bind(("localhost", port))
+                self.port = port
+                return
+            except OSError as e:
+                pass
+        raise Exception("No available port found")
 
     def test_feature(self):
         try:


### PR DESCRIPTION
Using `socket` module and scan ports linearly, and select unused(unbinded) port.

Also, still sometimes when I run test recv test cases parallelly (such as `t142_recv_multi.py`), still got `connection refused` error. Perhaps these are caused by race condition.

```
ubuntu@ubuntu:~/uftrace/tests$ for i in `seq 25`; do (python3 runtest.py -d 142); done 
Start 1 tests without worker pool

Compiler                  gcc                                         
Runtime test case         pg             finstrument-fu fpatchable-fun
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os
142 recv_multi          : OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK

Start 1 tests without worker pool

Compiler                  gcc                                         
Runtime test case         pg             finstrument-fu fpatchable-fun
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os
142 recv_multi          : OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK

Start 1 tests without worker pool

Compiler                  gcc                                         
Runtime test case         pg             finstrument-fu fpatchable-fun
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os
uftrace: /home/ubuntu/uftrace/cmds/recv.c:124:setup_client_socket
 ERROR: socket connect failed (host: localhost, port: 49922): Connection refused
142 recv_multi          : OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK

Start 1 tests without worker pool

Compiler                  gcc                                         
Runtime test case         pg             finstrument-fu fpatchable-fun
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os
142 recv_multi          : OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK

Start 1 tests without worker pool

Compiler                  gcc                                         
Runtime test case         pg             finstrument-fu fpatchable-fun
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os
uftrace: /home/ubuntu/uftrace/cmds/recv.c:124:setup_client_socket
 ERROR: socket connect failed (host: localhost, port: 49829): Connection refused
142 recv_multi          : OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK

Start 1 tests without worker pool
...
```

Resolves #1767