### PR TITLE
tests: Changing test case statistics conditions.

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -1135,5 +1135,5 @@ if __name__ == "__main__":
     sys.stdout.write("\n")
     sys.stdout.flush()
 
-    if shared.total >= 30:
+    if shared.progress >= 10 or shared.total >= 300:
         print_test_report(color, shared)


### PR DESCRIPTION
tests: Change test result statistics condition

As it comes with more combinations of compiler and flags,
it's better to update the condition to print the test stats.
Specifically we want to print it when there are more than
300 test runs or more than 10 kind of tests were run.

Fixed: #1770 

Signed-off-by: Jungmin Kim <jungmin82@gmail.com>
