### PR TITLE
record: skip whitespaces after shebang for scripts

### DIFF
--- a/cmds/record.c
+++ b/cmds/record.c
@@ -1625,7 +1625,7 @@ again:
 		if (!opts->force && !opts->patch)
 			pr_err_ns(SCRIPT_MSG, opts->exename);
 
-		script = str_ltrim(script);
+		script = str_trim(script);
 
 		/* ignore options */
 		p = strchr(script, ' ');

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -595,33 +595,33 @@ char *strjoin(char *left, char *right, const char *delim)
 }
 
 /**
- * str_ltrim - to trim left spaces
- * @str: input string
- *
- * This function make @str to left trimmed @str
- */
-char *str_ltrim(char *str)
-{
-	if (!str)
-		return NULL;
-	while (isspace((unsigned char)*str)) {
-		str++;
-	}
-	return str;
-}
-
-/**
- * str_rtrim - to trim right spaces
+ * str_trim - to trim all spaces
  * @str: input string
  *
  * This function make @str to right trimmed @str
  */
-char *str_rtrim(char *str)
+char *str_trim(char *str) 
 {
-	char *p = strchr(str, '\0');
-	while (--p >= str && isspace(*p))
-		;
-	*(p + 1) = '\0';
+	int i = 0;
+	int j = 0;
+	bool spaceFound = false;
+
+    if (!str)
+        return NULL;
+
+    while (str[j]) {
+        if (str[j] != ' ' || !spaceFound) {
+            str[i] = str[j];
+            i++;
+            spaceFound = (str[j] == ' ');
+        }
+        j++;
+    }
+
+    if (i > 0 && str[i-1] == ' ')
+        i--;
+
+    str[i] = '\0';
 	return str;
 }
 


### PR DESCRIPTION
Python tracing won't work when the shebang line has a space like below:

" #! /usr/bin/env   python3    "

This patch makes uftrace to understand the above shebang as well.

Fixed: #1690
Signed-off-by: 0xGabriel <0xgabriel.kim@gmail.com>