### PR TITLE
utils: fix demangle_full to only demangle mangled C++ symbols

### DIFF
--- a/utils/demangle.c
+++ b/utils/demangle.c
@@ -1750,6 +1750,10 @@ static char *demangle_full(char *str)
 	size_t len = 64; /* minimum length */
 	int status;
 
+	/* str is not mangled C++ symbol */
+	if (str[0] != '_' || str[1] != 'Z')
+		return xstrdup(str);
+
 	__cxa_demangle(str, NULL, &len, &status);
 	if (status < 0)
 		return xstrdup(str);


### PR DESCRIPTION
Currently, uftrace demangles all symbols, regardless of whether they are mangled C++ symbols or unmangled C symbols.

But when setting --demangle=full, uftrace calls __cxa_demangle(), which translates unmangled symbols confusingly; e.g., "f" is translated to "float".

To address this, now we only call __cxa_demangle() if a symbol is mangled (starts with "_Z").

Fixed #1778