### PR TITLE
misc: modify manual to build dockerfile

### DIFF
--- a/doc/uftrace.md
+++ b/doc/uftrace.md
@@ -356,7 +356,7 @@ record and `replay` internally. Thus, it describes most regular option in detail
 :   Hide small functions run less than the *TIME*
 
 \--task
-:   [info]: Print task relationship in a tree form instead of the tracing info.
+:   Print task relationship in a tree form instead of the tracing info.
 
 \--task-newline
 :   Interleave a newline when task is changed


### PR DESCRIPTION
Currently make install on some Ubuntu versions failed like below:
```
    GEN      uftrace.1
  pandoc: blocks is null
  CallStack (from HasCallStack):
    error, called at src/Text/Pandoc/Writers/Man.hs:287:47 in pandoc-1.19.2.4-HbfKWUyODESBIy0vGktOwX:Text.Pandoc.Writers.Man
  Makefile:18: recipe for target 'uftrace.1' failed
```
It's because the description of --task option has incompatible format in
the pandoc syntax.  We don't need that part so let's get rid of it.

Fixed: #1766
