### PR TITLE
docker: Add make install in Dockerfile when test=yes

### DIFF
--- a/misc/docker/centos/7/Dockerfile
+++ b/misc/docker/centos/7/Dockerfile
@@ -14,7 +14,7 @@ RUN git clone https://github.com/namhyung/uftrace /usr/src/uftrace
 RUN if [ "$test" = "yes" ] ; then \
         cd /usr/src/uftrace \
         && ./misc/install-deps.sh -y \
-        && ./configure && make ASAN=1 && make ASAN=1 unittest; \
+        && ./configure && make ASAN=1 && make install && make ASAN=1 unittest; \
     else \
         cd /usr/src/uftrace && ./misc/install-deps.sh -y && ./configure && make && make install; \
     fi

--- a/misc/docker/fedora/33/Dockerfile
+++ b/misc/docker/fedora/33/Dockerfile
@@ -6,7 +6,7 @@ RUN git clone https://github.com/namhyung/uftrace /usr/src/uftrace
 RUN if [ "$test" = "yes" ] ; then \
         cd /usr/src/uftrace \
         && ./misc/install-deps.sh -y \
-        && ./configure && make ASAN=1 && make ASAN=1 unittest; \
+        && ./configure && make ASAN=1 && make install && make ASAN=1 unittest; \
     else \
         cd /usr/src/uftrace && ./misc/install-deps.sh -y && ./configure && make && make install; \
     fi

--- a/misc/docker/fedora/34/Dockerfile
+++ b/misc/docker/fedora/34/Dockerfile
@@ -6,7 +6,7 @@ RUN git clone https://github.com/namhyung/uftrace /usr/src/uftrace
 RUN if [ "$test" = "yes" ] ; then \
         cd /usr/src/uftrace \
         && ./misc/install-deps.sh -y \
-        && ./configure && make ASAN=1 && make ASAN=1 unittest; \
+        && ./configure && make ASAN=1 && make install && make ASAN=1 unittest; \
     else \
         cd /usr/src/uftrace && ./misc/install-deps.sh -y && ./configure && make && make install; \
     fi

--- a/misc/docker/ubuntu/16.04/Dockerfile
+++ b/misc/docker/ubuntu/16.04/Dockerfile
@@ -7,7 +7,7 @@ RUN git clone https://github.com/namhyung/uftrace /usr/src/uftrace
 RUN if [ "$test" = "yes" ] ; then \
         cd /usr/src/uftrace \
         && ./misc/install-deps.sh -y \
-        && ./configure && make ASAN=1 && make ASAN=1 unittest; \
+        && ./configure && make ASAN=1 && make install && make ASAN=1 unittest; \
     else \
         cd /usr/src/uftrace && ./misc/install-deps.sh -y && ./configure && make && make install; \
     fi

--- a/misc/docker/ubuntu/18.04/Dockerfile
+++ b/misc/docker/ubuntu/18.04/Dockerfile
@@ -7,7 +7,7 @@ RUN git clone https://github.com/namhyung/uftrace /usr/src/uftrace
 RUN if [ "$test" = "yes" ] ; then \
         cd /usr/src/uftrace \
         && ./misc/install-deps.sh -y \
-        && ./configure && make ASAN=1 && make ASAN=1 unittest; \
+        && ./configure && make ASAN=1 && make install && make ASAN=1 unittest; \
     else \
         cd /usr/src/uftrace && ./misc/install-deps.sh -y && ./configure && make && make install; \
     fi


### PR DESCRIPTION
Added code because docker file is missing 'make install' in case test=yes

Alpine and Arch could not be added due to the following error
I'm going to give a try to fix these problems.

Alpine(only if test =yes)
[Makefile:49: test_unit] Segmentation fault (core dumped)

Arch(for both condition)
no matching manifest for linux/arm64/v8 in the manifest list entries