### PR TITLE
dump: Fix Mermaid to work properly by specifying the version of Mermaid

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -1354,7 +1354,7 @@ static void dump_mermaid_footer(struct uftrace_dump_ops *ops, struct uftrace_dat
 	pr_out("flowchart TB\n");
 	print_graph_node_mermaid(&mermaid_graph, &mermaid_graph.root);
 	pr_out("</div>\n");
-	pr_out("<script src=\"https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js\"></script>\n");
+	pr_out("<script src=\"https://cdn.jsdelivr.net/npm/mermaid@9/dist/mermaid.min.js\"></script>\n");
 	pr_out("<script>\n");
 	pr_out("var config = {\n");
 	pr_out("	startOnLoad: true,\n");


### PR DESCRIPTION
After Mermaid v10, the function `mermaid.render` does not support callback, but only supports async operation.

This commit fixed the Mermaid to work by temporarily specifying the version of Mermaid as v9.

Ps. The PR has temporarily specified a version of the mermaid. Please do not close issue as we are planning to rewrite `mermaid.js` for ESM in the future.

Ref: #1793