### PR TITLE
mcount-dynamic: Use MAP_FIXED_NOREPLACE for trampoline

### DIFF
--- a/arch/i386/mcount-dynamic.c
+++ b/arch/i386/mcount-dynamic.c
@@ -30,10 +30,12 @@ int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
 		pr_dbg2("adding a page for fentry trampoline at %#lx\n", mdi->trampoline);
 
 		trampoline_check = mmap((void *)mdi->trampoline, PAGE_SIZE, PROT_READ | PROT_WRITE,
-					MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+					MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
-		if (trampoline_check == MAP_FAILED)
-			pr_err("failed to mmap trampoline for setup");
+		if (trampoline_check != (void *)mdi->trampoline) {
+			pr_err("could not map trampoline at desired location %#lx, got %#lx: %m\n",
+			       mdi->trampoline, (uintptr_t)trampoline_check);
+		}
 	}
 
 	if (mprotect((void *)mdi->text_addr, mdi->text_size, PROT_READ | PROT_WRITE)) {

--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -43,10 +43,12 @@ int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
 
 		trampoline_check = mmap((void *)mdi->trampoline, PAGE_SIZE,
 					PROT_READ | PROT_WRITE | PROT_EXEC,
-					MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+					MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
-		if (trampoline_check == MAP_FAILED)
-			pr_err("failed to mmap trampoline for setup");
+		if (trampoline_check != (void *)mdi->trampoline) {
+			pr_err("could not map trampoline at desired location %#lx, got %#lx: %m\n",
+			       mdi->trampoline, (uintptr_t)trampoline_check);
+		}
 	}
 
 	if (mprotect(PAGE_ADDR(mdi->text_addr), PAGE_LEN(mdi->text_addr, mdi->text_size),


### PR DESCRIPTION
By trying to allocate the extra page for a trampoline with MAP_FIXED, Uftrace could end up overlapping already mapped pages, which are discarded.  Typically, if data was there with rw- protection, now the data is undefined and has rwx protection.

Since Linux 4.17, the flag MAP_FIXED_NOREPLACE can be used to ensure that the fixed location is mapped atomically, preventing any clobbering.

For earlier kernel, the call to mmap(2) will fall back to a random address, by not honoring the MAP_FIXED request at all.  So callers should ensure that the returned address matches the requested one.