### PR TITLE
dynamic: Fix -U for -fpatchable-function-entry

### DIFF
--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -623,6 +623,7 @@ int mcount_unpatch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *
 
 	switch (mdi->type) {
 	case DYNAMIC_FENTRY:
+	case DYNAMIC_PATCHABLE:
 		result = unpatch_fentry_func(mdi, sym);
 		break;
 

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -508,6 +508,8 @@ static void patch_patchable_func_matched(struct mcount_dynamic_info *mdi, struct
 		.size = UINT_MAX,
 		.name = namebuf,
 	};
+	bool found = false;
+	int match;
 	char *soname = get_soname(map->libname);
 
 	symtab = &map->mod->symtab;
@@ -531,8 +533,18 @@ static void patch_patchable_func_matched(struct mcount_dynamic_info *mdi, struct
 				continue;
 		}
 
-		mcount_patch_func_with_stats(mdi, sym);
+		found = true;
+		match = match_pattern_list(map, soname, sym->name);
+		if (!match)
+			continue;
+		else if (match == 1)
+			mcount_patch_func_with_stats(mdi, sym);
+		else
+			mcount_unpatch_func(mdi, sym, NULL);
 	}
+
+	if (!found)
+		stats.nomatch++;
 
 	free(soname);
 }


### PR DESCRIPTION
We have missed handling -U option to functions compiled with -fpatchable-function-entry.

This patch fixes the problem as follows.

Before:
```
  $ ./runtest.py "265|266"
  Start 2 tests with 2 worker

  Compiler                  gcc                                           clang
  Runtime test case         pg             finstrument-fu fpatchable-fun  pg             finstrument-fu fpatchable-fun
  ------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os  O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os
  265 patchable_dynamic3  : NG NG NG NG NG NG NG NG NG NG NG NG NG NG NG  NG NG NG NG NG NG NG NG NG NG NG NG NG NG NG
  266 patchable_dynamic4  : NG NG NG NG NG NG NG NG NG NG NG NG NG NG NG  NG NG NG NG NG NG NG NG NG NG NG NG NG NG NG
```
After:
```
  $ ./runtest.py "265|266"
  Start 2 tests with 2 worker

  Compiler                  gcc                                           clang
  Runtime test case         pg             finstrument-fu fpatchable-fun  pg             finstrument-fu fpatchable-fun
  ------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os  O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os
  265 patchable_dynamic3  : OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK  OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK
  266 patchable_dynamic4  : OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK  OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK
```
This is verified in both x86_64 and aarch64.

Fixes: 151fb611 ("dynamic: Refactor 'match_pattern_list'")