### PR TITLE
record: suggestion for fallback with named pipe creation

### DIFF
--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -2259,6 +2259,12 @@ static __used void mcount_startup(void)
 		char *channel = NULL;
 
 		xasprintf(&channel, "%s/%s", dirname, ".channel");
+		/* try fallback fifo under tmpfs */
+		if (access(channel, F_OK) != 0) {
+			free(channel);
+			xasprintf(&channel, "/tmp/%s%s", dirname, ".channel");
+		}
+
 		pfd = open(channel, O_WRONLY);
 		free(channel);
 	}

--- a/libtraceevent/.gitignore
+++ b/libtraceevent/.gitignore
@@ -3,3 +3,4 @@ libtraceevent.a
 *.so
 .*.cmd
 .*.d
+.*.d.*


### PR DESCRIPTION
Specifically, some file systems like `vboxsf` and `FAT` do not support
`mkfifo()`. As a result, the 'uftrace record' fails when creating the 
`.channel` file for communication.

```bash
# uftrace record -vvv -P . ./spintest
uftrace: running uftrace v0.14-21-gafed ( x86_64 dwarf python3 luajit tui perf sched dynamic )
uftrace: checking binary ./spintest
uftrace: removing uftrace.data.old directory
uftrace: /home/vagrant/uftrace/cmds/record.c:2273:command_record
 ERROR: cannot create a communication channel: Operation not permitted
```

To address this issue, one proposed solution is **creating a fallback 
channel** through `tmpfs`, which does support mkfifo(). In this 
suggestion, the .channel file will be named as the following.
`/tmp/<dirname>.channel`

Close #1804 