### PR TITLE
filter: Remove obsolete function add_trigger

### DIFF
--- a/utils/filter.h
+++ b/utils/filter.h
@@ -172,7 +172,6 @@ const char *get_filter_pattern(enum uftrace_pattern_type ptype);
 
 char *uftrace_clear_kernel(char *filter_str);
 
-void add_trigger(struct uftrace_filter *filter, struct uftrace_trigger *tr, bool exact_match);
 int setup_trigger_action(char *str, struct uftrace_trigger *tr, char **module,
 			 unsigned long orig_flags, struct uftrace_filter_setting *setting);
 


### PR DESCRIPTION
The function add_trigger has been replaced with update_trigger,
rendering it unnecessary. This commit removes the now-unused
add_trigger function.

related: https://github.com/namhyung/uftrace/commit/eeb5d745de91cf6316d27d3270b4b5aa739df55b

Signed-off-by: Soyeon Park <sypark9646@gmail.com>