### PR TITLE
misc: Add wget-pr.sh script

### DIFF
--- a/misc/wget-pr.sh
+++ b/misc/wget-pr.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ $# -ne "1" ]; then
+	echo "usage: $0 <PR number>"
+	exit 1
+fi
+
+pr=$1
+wget https://github.com/namhyung/uftrace/pull/$pr.patch


### PR DESCRIPTION
GitHub provides an easy way to download the patches of PR by adding .patch postfix to the URL of PR.

This patch adds a simple script that can download the patch of the given pull request.

The usage is simple as follows.
```
  $ ./misc/wget-pr.sh
  usage: ./misc/wget-pr.sh <PR number>
```
If you want to download the patch of the PR number 1526, then it can be used as follows.
```
  $ ./misc/wget-pr.sh 1526
  --2023-08-27 07:04:48--  https://github.com/namhyung/uftrace/pull/1526.patch
      ...
  Saving to: ‘1526.patch’

  1526.patch              [ <=>                ]   5.47K  --.-KB/s    in 0s

  2023-08-27 07:04:48 (22.2 MB/s) - ‘1526.patch’ saved [5601]
```
Then simply apply the 1526.patch file by running 'git am'.
```
  $ git am 1526.patch
  Applying: record: Do not initialize when libmcount.so is explictly linked
```