### PR TITLE
libmcount: support no-plt binary

### DIFF
--- a/arch/x86_64/mcount-noplt.c
+++ b/arch/x86_64/mcount-noplt.c
@@ -51,7 +51,8 @@ struct plthook_data *mcount_arch_hook_no_plt(struct uftrace_elf_data *elf, const
 	pd->module_id = (unsigned long)pd;
 	pd->base_addr = offset;
 
-	if (load_elf_dynsymtab(&pd->dsymtab, elf, offset, 0) < 0 || pd->dsymtab.nr_sym == 0) {
+	if (arch_load_dynsymtab_noplt(&pd->dsymtab, elf, offset, 0) < 0 ||
+	    pd->dsymtab.nr_sym == 0) {
 		free(pd);
 		return NULL;
 	}

--- a/arch/x86_64/symbol.c
+++ b/arch/x86_64/symbol.c
@@ -29,12 +29,11 @@ int arch_load_dynsymtab_noplt(struct uftrace_symtab *dsymtab, struct uftrace_elf
 
 	memset(dsymtab, 0, sizeof(*dsymtab));
 
-	/* assumes there's only one RELA section (rela.dyn) for no-plt binary */
 	elf_for_each_shdr(elf, &sec_iter) {
-		if (sec_iter.shdr.sh_type == SHT_RELA) {
+		if (strcmp(elf_get_name(elf, &sec_iter, sec_iter.shdr.sh_name), ".rela.dyn") == 0) {
 			memcpy(&rel_iter, &sec_iter, sizeof(sec_iter));
-			pr_dbg2("found RELA section: %s\n",
-				elf_get_name(elf, &sec_iter, sec_iter.shdr.sh_name));
+			pr_dbg2("found rela.dyn section with %ld entry.\n",
+				sec_iter.shdr.sh_entsize);
 
 			reloc_start = rel_iter.shdr.sh_addr + offset;
 			reloc_entsize = rel_iter.shdr.sh_entsize;
@@ -93,6 +92,7 @@ int arch_load_dynsymtab_noplt(struct uftrace_symtab *dsymtab, struct uftrace_elf
 		pr_dbg3("[%zd] %c %lx + %-5u %s\n", dsymtab->nr_sym, sym->type, sym->addr,
 			sym->size, sym->name);
 	}
+	sort_dynsymtab(dsymtab);
 
 	return dsymtab->nr_sym;
 }

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -368,6 +368,8 @@ extern unsigned long mcount_arch_plthook_addr(struct plthook_data *pd, int idx);
 extern unsigned long plthook_resolver_addr;
 extern const struct plthook_skip_symbol plt_skip_syms[];
 extern size_t plt_skip_nr;
+extern const char *const noplt_skip_syms[];
+extern size_t noplt_skip_nr;
 
 struct uftrace_trigger;
 struct uftrace_arg_spec;

--- a/utils/symbol.h
+++ b/utils/symbol.h
@@ -162,6 +162,7 @@ struct uftrace_module *load_module_symtab(struct uftrace_sym_info *sinfo, const 
 					  char *build_id);
 void save_module_symtabs(const char *dirname);
 void unload_module_symtabs(void);
+void sort_dynsymtab(struct uftrace_symtab *dsymtab);
 
 enum uftrace_trace_type {
 	TRACE_ERROR = -1,


### PR DESCRIPTION
Issue #1777 reported that no-plt binary is handled as plt-enable binary because some functions are still left in plt section. The patch fixes this bug by comparing the name of self with a list of known functions.