### PR TITLE
replay: Revise the logic of setting NEEDS_PAREN to correctly add parentheses

### DIFF
--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -739,7 +739,10 @@ static int print_graph_rstack(struct uftrace_data *handle, struct uftrace_task_r
 		goto out;
 
 	if (rstack->type == UFTRACE_ENTRY) {
-		if (symname[strlen(symname) - 1] != ')' || rstack->more)
+		int len = strlen(symname);
+
+		if (symname[len - 1] != ')' || rstack->more ||
+		    (len > 10 && !strcmp(symname + len - 10, "operator()")))
 			str_mode |= NEEDS_PAREN;
 	}
 


### PR DESCRIPTION
The full demangler __cxa_demangle() may or may not add parentheses at the end of symbol names, so NEEDS_PAREN was introduced.

Previously, NEEDS_PAREN was set when the last character of the symbol name was not ')'. Now, it is also set when the last few characters are "operator()", to handle functors and lambdas in C++.

Related to #1827