### PR TITLE
build: Fix build errors due to low kernel version

### DIFF
--- a/arch/aarch64/mcount-dynamic.c
+++ b/arch/aarch64/mcount-dynamic.c
@@ -14,6 +14,10 @@
 #include "utils/symbol.h"
 #include "utils/utils.h"
 
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE MAP_FIXED
+#endif
+
 #define CODE_SIZE 8
 
 static const unsigned int patchable_nop_patt[] = { 0xd503201f, 0xd503201f };

--- a/arch/i386/mcount-dynamic.c
+++ b/arch/i386/mcount-dynamic.c
@@ -11,6 +11,10 @@
 #include "utils/symbol.h"
 #include "utils/utils.h"
 
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE MAP_FIXED
+#endif
+
 static const unsigned char fentry_nop_patt[] = { 0x0f, 0x1f, 0x44, 0x00, 0x00 };
 
 int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)

--- a/arch/x86_64/mcount-dynamic.c
+++ b/arch/x86_64/mcount-dynamic.c
@@ -12,6 +12,10 @@
 #include "utils/symbol.h"
 #include "utils/utils.h"
 
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE MAP_FIXED
+#endif
+
 static const unsigned char fentry_nop_patt1[] = { 0x67, 0x0f, 0x1f, 0x04, 0x00 };
 static const unsigned char fentry_nop_patt2[] = { 0x0f, 0x1f, 0x44, 0x00, 0x00 };
 static const unsigned char patchable_gcc_nop[] = { 0x90, 0x90, 0x90, 0x90, 0x90 };

--- a/cmds/record.c
+++ b/cmds/record.c
@@ -29,6 +29,10 @@
 #include "utils/symbol.h"
 #include "utils/utils.h"
 
+#ifndef EM_RISCV
+#define EM_RISCV 243
+#endif
+
 #ifndef EFD_SEMAPHORE
 #define EFD_SEMAPHORE (1 << 0)
 #endif

--- a/utils/tracefs.c
+++ b/utils/tracefs.c
@@ -8,6 +8,10 @@
 #include "utils/tracefs.h"
 #include "utils/utils.h"
 
+#ifndef TRACEFS_MAGIC
+#define TRACEFS_MAGIC 0x74726163
+#endif
+
 #define PROC_MOUNTS_DIR_PATH "/proc/mounts"
 #define TRACEFS_DIR_PATH "/sys/kernel/tracing"
 #define OLD_TRACEFS_DIR_PATH "/sys/kernel/debug/tracing"


### PR DESCRIPTION
EM_RISCV, TRACEFS_MAGIC, MAP_FIXED_NOREPLACE macros are added to fix build errors
since they are not declared in the low kernel version.

The error messages are below:
```sh
uftrace/cmds/record.c:1592:75: error: ‘EM_RISCV’ undeclared (first use in this function)
  uint16_t supported_machines[] = { EM_X86_64, EM_ARM, EM_AARCH64, EM_386, EM_RISCV };
                                                                           ^
uftrace/utils/tracefs.c:26:53: error: ‘TRACEFS_MAGIC’ undeclared (first use in this function)
  if (!statfs(TRACEFS_DIR_PATH, &fs) && fs.f_type == TRACEFS_MAGIC) {
                                                     ^
uftrace/arch/x86_64/mcount-dynamic.c:46:6: error: ‘MAP_FIXED_NOREPLACE’ undeclared (first use in this function)
      MAP_FIXED_NOREPLACE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
      ^
```

Fixed: https://github.com/namhyung/uftrace/issues/1834

Signed-off-by: Michelle Jin <shjy180909@gmail.com>