### PR TITLE
mcount: Restore/reset rstack only when the return address is hijacked

### DIFF
--- a/libmcount/wrap.c
+++ b/libmcount/wrap.c
@@ -105,6 +105,9 @@ void mcount_rstack_reset_exception(struct mcount_thread_data *mtdp, unsigned lon
 	int idx;
 	struct mcount_ret_stack *rstack;
 
+	if (unlikely(mcount_estimate_return))
+		return;
+
 	/* it needs to find how much stack frame unwinds */
 	for (idx = mtdp->idx - 1; idx >= 0; idx--) {
 		rstack = &mtdp->rstack[idx];
@@ -393,7 +396,7 @@ __visible_default void *__cxa_begin_catch(void *exception)
 	obj = real_cxa_begin_catch(exception);
 
 	mtdp = get_thread_data();
-	if (!mcount_estimate_return && !check_thread_data(mtdp) && unlikely(mtdp->in_exception)) {
+	if (!check_thread_data(mtdp) && unlikely(mtdp->in_exception)) {
 		unsigned long *frame_ptr;
 		unsigned long frame_addr;
 


### PR DESCRIPTION
When specifying estimate_return, the return address is not hijacked. This patch ensures that mcount_rstack_reset_exception() is not called in this case, to avoid recording incorrect end times.

Before:
I got an inverted time bug in estimate_return mode (it only occurs when using dynamic tracing). 
I found that `mcount_rstack_reset_exception()` was called unexpectedly, which sets the end time using `mcount_gettime()`, but the end time should be estimated by `mcount_rstack_inject_return()`. 
This PR should fix this small problem.

```shell
$ clang++ tests/s-exception3.cpp -o test/exp
$ uftrace -P. -e test/exp
# DURATION     TID     FUNCTION
            [117574] | main() {
            [117574] |   A::A() {
            [117574] |     foo1() {
            [117574] |       foo2() {
            [117574] |         foo4() {
   5.050 us [117574] |           C::C();
            [117574] |           foo5() {
 129.894 us [117574] |             __cxa_allocate_exception();
  81.546 us [117574] |           } /* foo5 */
  36.698 us [117574] |           C::~C();
 515.376 us [117574] |         } /* foo4 */
 547.074 us [117574] |       } /* foo2 */
                     |          /* inverted time: broken data? */
 289.136 us [117574] |     } /* foo1 */
  13.199 us [117574] |     B::B();
  17.199 us [117574] |     B::~B();
                     |        /* inverted time: broken data? */
 335.734 us [117574] |   } /* A::A */
   5.700 us [117574] |   A::~A();
            [117574] |   catch_exc() {
            [117574] |     bar() {
   3.450 us [117574] |       B::B();
            [117574] |       bar1() {
            [117574] |         bar2() {
   3.549 us [117574] |           C::C();
   7.199 us [117574] |           __cxa_allocate_exception();
  10.399 us [117574] |           C::~C();
  64.897 us [117574] |         } /* bar2 */
                     |            /* inverted time: broken data? */
  42.348 us [117574] |       } /* bar1 */
   3.749 us [117574] |       B::~B();
            [117574] |       catch_exc() {
  73.298 us [117574] |         baz();
  86.498 us [117574] |       } /* catch_exc */
 235.792 us [117574] |     } /* bar */
 261.492 us [117574] |   } /* catch_exc */
 988.659 us [117574] | } /* main */
```





