### PR TITLE
misc: Enhance and rename wget-pr script

### DIFF
--- a/misc/get-pr.sh
+++ b/misc/get-pr.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if [ $# -ne "1" ]; then
+	echo "usage: $0 <PR number>"
+	exit 1
+fi
+
+pr=$1
+
+if command -v wget &> /dev/null; then
+    wget https://github.com/namhyung/uftrace/pull/$pr.patch
+elif command -v curl &> /dev/null; then
+    curl -L https://github.com/namhyung/uftrace/pull/$pr.patch > $pr.patch
+else
+    echo "You need wget or curl to run this script."
+fi

--- a/misc/wget-pr.sh
+++ b/misc/wget-pr.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-if [ $# -ne "1" ]; then
-	echo "usage: $0 <PR number>"
-	exit 1
-fi
-
-pr=$1
-wget https://github.com/namhyung/uftrace/pull/$pr.patch


### PR DESCRIPTION
I improved the recently added wget-pr.sh script.
It's really useful to get the patch file by pull request number. However, some systems (e.g. CentOS 7 or 8, fedora 33 or 34) do not provide wget unless install manually.

This commit improves the script to get the patch with curl if wget is not available. This also renames the file to a more appropriate name.