### PR TITLE
misc: Enhance and rename wget-pr script

### DIFF
--- a/misc/wget-pr.sh
+++ b/misc/wget-pr.sh
@@ -6,4 +6,14 @@ if [ $# -ne "1" ]; then
 fi
 
 pr=$1
-wget https://github.com/namhyung/uftrace/pull/$pr.patch
+
+if [ -x "$(command -v wget)" ]; then
+    wget https://github.com/namhyung/uftrace/pull/$pr.patch
+    exit 0
+elif [ -x "$(command -v curl)" ]; then
+    curl -L https://github.com/namhyung/uftrace/pull/$pr.patch > $pr.patch
+    exit 0
+else
+    echo "You need wget or curl to run this script."
+    exit 1
+fi


### PR DESCRIPTION
I improved the recently added wget-pr.sh script.
It's really useful to get the patch file by pull request number. However, some systems (e.g. CentOS 7 or 8, fedora 33 or 34) do not provide wget unless install manually.

This commit improves the script to get the patch with curl if wget is not available. This also renames the file to a more appropriate name.