### PR TITLE
info: Add --system option to show system info

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -554,7 +554,7 @@ static void dump_raw_header(struct uftrace_dump_ops *ops, struct uftrace_data *h
 	const char *info_str[] = { "EXE_NAME",	   "EXE_BUILD_ID", "EXIT_STATUS", "CMDLINE",
 				   "CPUINFO",	   "MEMINFO",	   "OSINFO",	  "TASKINFO",
 				   "USAGEINFO",	   "LOADINFO",	   "ARG_SPEC",	  "RECORD_DATE",
-				   "PATTERN_TYPE", "VERSION",	   "UTC_OFFSET" };
+				   "PATTERN_TYPE", "VERSION",	   "UTC_OFFSET",  "SYSCTL" };
 
 	pr_out("uftrace file header: magic         = ");
 	for (i = 0; i < UFTRACE_MAGIC_LEN; i++)

--- a/cmds/info.c
+++ b/cmds/info.c
@@ -8,6 +8,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <sys/resource.h>
@@ -894,6 +895,53 @@ static int read_utc_offset(void *arg)
 	return 0;
 }
 
+static int fill_sysctl(void *arg)
+{
+	struct fill_handler_arg *fha = arg;
+	int paranoid = INT_MIN;
+	int kptr = -1;
+	FILE *fp;
+
+	fp = fopen("/proc/sys/kernel/perf_event_paranoid", "r");
+	if (fp != NULL) {
+		if (fscanf(fp, "%d", &paranoid) != 1)
+			paranoid = INT_MIN;
+		fclose(fp);
+	}
+	fp = fopen("/proc/sys/kernel/kptr_restrict", "r");
+	if (fp != NULL) {
+		if (fscanf(fp, "%d", &kptr) != 1)
+			kptr = -1;
+		fclose(fp);
+	}
+
+	if (paranoid == INT_MIN && kptr < 0)
+		return -1;
+
+	dprintf(fha->fd, "sysctl:perf_event_paranoid=%d kptr_restrict=%d\n", paranoid, kptr);
+	return 0;
+}
+
+static int read_sysctl(void *arg)
+{
+	struct read_handler_arg *rha = arg;
+	struct uftrace_data *handle = rha->handle;
+	struct uftrace_info *info = &handle->info;
+	char *buf = rha->buf;
+
+	info->perf_event_paranoid = INT_MIN;
+	info->kptr_restrict = -1;
+
+	if (fgets(buf, sizeof(rha->buf), handle->fp) == NULL)
+		return -1;
+	if (strncmp(buf, "sysctl:", 7))
+		return -1;
+
+	sscanf(&buf[7], "perf_event_paranoid=%d kptr_restrict=%d", &info->perf_event_paranoid,
+	       &info->kptr_restrict);
+	return 0;
+}
+
 struct uftrace_info_handler {
 	enum uftrace_info_bits bit;
 	int (*handler)(void *arg);
@@ -927,6 +975,7 @@ void fill_uftrace_info(uint64_t *info_mask, int fd, struct uftrace_opts *opts, i
 		{ PATTERN_TYPE, fill_pattern_type },
 		{ VERSION, fill_uftrace_version },
 		{ UTC_OFFSET, fill_utc_offset },
+		{ SYSCTL, fill_sysctl },
 	};
 
 	for (i = 0; i < ARRAY_SIZE(fill_handlers); i++) {
@@ -971,6 +1020,7 @@ int read_uftrace_info(uint64_t info_mask, struct uftrace_data *handle)
 		{ PATTERN_TYPE, read_pattern_type },
 		{ VERSION, read_uftrace_version },
 		{ UTC_OFFSET, read_utc_offset },
+		{ SYSCTL, read_sysctl },
 	};
 
 	memset(&handle->info, 0, sizeof(handle->info));
@@ -1065,6 +1115,14 @@ void process_uftrace_info(struct uftrace_data *handle, struct uftrace_opts *opts
 		process(data, fmt, "kernel version", info->kernel);
 		process(data, fmt, "hostname", info->hostname);
 		process(data, fmt, "distro", info->distro);
+	}
+
+	if (info_mask & SYSCTL) {
+		if (info->perf_event_paranoid != INT_MIN)
+			process(data, "# %-20s: %d\n", "perf_event_paranoid",
+				info->perf_event_paranoid);
+		if (info->kptr_restrict >= 0)
+			process(data, "# %-20s: %d\n", "kptr_restrict", info->kptr_restrict);
 	}
 
 	process(data, "#\n");
@@ -1255,10 +1313,56 @@ static void print_task_info(struct uftrace_data *handle)
 	}
 }
 
+static void print_system_info(void)
+{
+	const char *fmt = "%-20s: %s\n";
+	struct uftrace_data handle = {};
+	struct fill_handler_arg fha = {};
+	struct read_handler_arg rha = { .handle = &handle };
+	struct uftrace_info *info = &handle.info;
+	int pfd[2];
+
+	if (pipe(pfd) < 0)
+		return;
+
+	fha.fd = pfd[1];
+	fill_cpuinfo(&fha);
+	fill_meminfo(&fha);
+	fill_osinfo(&fha);
+	fill_sysctl(&fha);
+	close(pfd[1]);
+
+	handle.fp = fdopen(pfd[0], "r");
+	read_cpuinfo(&rha);
+	read_meminfo(&rha);
+	read_osinfo(&rha);
+	read_sysctl(&rha);
+	fclose(handle.fp);
+
+	pr_out(fmt, "cpu info", info->cpudesc);
+	pr_out("%-20s: %d / %d (online / possible)\n", "number of cpus", info->nr_cpus_online,
+	       info->nr_cpus_possible);
+	pr_out(fmt, "memory info", info->meminfo);
+	pr_out(fmt, "kernel version", info->kernel);
+	pr_out(fmt, "hostname", info->hostname);
+	pr_out(fmt, "distro", info->distro);
+	if (info->perf_event_paranoid != INT_MIN)
+		pr_out("%-20s: %d\n", "perf_event_paranoid", info->perf_event_paranoid);
+	if (info->kptr_restrict >= 0)
+		pr_out("%-20s: %d\n", "kptr_restrict", info->kptr_restrict);
+
+	clear_uftrace_info(info);
+}
+
 int command_info(int argc, char *argv[], struct uftrace_opts *opts)
 {
 	int ret;
 	struct uftrace_data handle;
+
+	if (opts->show_system) {
+		print_system_info();
+		return 0;
+	}
 
 	ret = open_info_file(opts, &handle);
 	if (ret < 0) {

--- a/doc/ko/uftrace-info.md
+++ b/doc/ko/uftrace-info.md
@@ -26,6 +26,9 @@ uftrace info [*options*] [*COMMAND*]
 \--task
 :   데이터 정보 대신 태스크의 관계를 트리 형태로 출력한다.
 
+\--system
+:   현재 시스템 정보(`perf_event_paranoid`, `kptr_restrict` 포함)를 출력한다.
+
 
 예시
 =======
@@ -46,6 +49,8 @@ uftrace info [*options*] [*COMMAND*]
     # kernel version      : Linux 4.5.4-1-ARCH
     # hostname            : sejong
     # distro              : "Arch Linux"
+    # perf_event_paranoid : 2
+    # kptr_restrict       : 1
     #
     # process information
     # ===================
@@ -91,6 +96,20 @@ uftrace info [*options*] [*COMMAND*]
     $ uftrace info --task
     [166399] parent
           [166401] child
+
+`--system` 옵션은 현재 시스템에서 읽은 시스템 정보를 출력한다. 기록된 데이터가
+필요하지 않으며, 기록 전에 uftrace 동작에 영향을 주는 커널 설정값을 확인하는
+데 사용할 수 있다.
+
+    $ uftrace info --system
+    cpu info            : Intel(R) Core(TM) i7-3930K CPU @ 3.20GHz
+    number of cpus      : 12 / 12 (online / possible)
+    memory info         : 19.8 / 23.5 GB (free / total)
+    kernel version      : Linux 4.5.4-1-ARCH
+    hostname            : sejong
+    distro              : "Arch Linux"
+    perf_event_paranoid : 2
+    kptr_restrict       : 1
 
 
 함께 보기

--- a/doc/uftrace-info.md
+++ b/doc/uftrace-info.md
@@ -35,6 +35,10 @@ OPTIONS
 \--task
 :   Print a task relationship tree instead of the trace metadata.
 
+\--system
+:   Print current system information (including `perf_event_paranoid` and
+    `kptr_restrict`).
+
 
 EXAMPLES
 ========
@@ -55,6 +59,8 @@ This command shows information like below:
     # kernel version      : Linux 4.5.4-1-ARCH
     # hostname            : sejong
     # distro              : "Arch Linux"
+    # perf_event_paranoid : 2
+    # kptr_restrict       : 1
     #
     # process information
     # ===================
@@ -100,6 +106,20 @@ The `--task` option shows task family hierarchy.
     $ uftrace info --task
     [166399] parent
           [166401] child
+
+The `--system` option prints system information read from the running system.
+It does not need a recorded trace and can be used to check kernel knobs that
+affect uftrace before recording.
+
+    $ uftrace info --system
+    cpu info            : Intel(R) Core(TM) i7-3930K CPU @ 3.20GHz
+    number of cpus      : 12 / 12 (online / possible)
+    memory info         : 19.8 / 23.5 GB (free / total)
+    kernel version      : Linux 4.5.4-1-ARCH
+    hostname            : sejong
+    distro              : "Arch Linux"
+    perf_event_paranoid : 2
+    kptr_restrict       : 1
 
 
 SEE ALSO

--- a/tests/t303_info_system.py
+++ b/tests/t303_info_system.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'hello', """
+cpu info            : Intel(R) Core(TM) i7-3930K CPU @ 3.20GHz
+number of cpus      : 12 / 12 (online / possible)
+memory info         : 19.8 / 23.5 GB (free / total)
+kernel version      : Linux 4.5.4-1-ARCH
+hostname            : sejong
+distro              : "Arch Linux"
+perf_event_paranoid : 2
+kptr_restrict       : 1
+""")
+
+    def setup(self):
+        self.subcmd = 'info'
+        self.option = '--system'
+        self.exearg = ''
+
+    def sort(self, output):
+        result = []
+        for ln in output.split('\n'):
+            if ln.strip() == '' or ln.startswith('#'):
+                continue
+            if ':' not in ln:
+                continue
+            label = ln.split(':', 1)[0].rstrip()
+            result.append(label)
+        return '\n'.join(result)

--- a/uftrace.c
+++ b/uftrace.c
@@ -48,6 +48,7 @@ enum uftrace_short_options {
 	OPT_logfile,
 	OPT_force,
 	OPT_task,
+	OPT_system,
 	OPT_no_merge,
 	OPT_nop,
 	OPT_time,
@@ -276,6 +277,7 @@ static const struct option uftrace_options[] = {
 	REQ_ARG(buffer, 'b'),
 	REQ_ARG(logfile, OPT_logfile),
 	NO_ARG(task, OPT_task),
+	NO_ARG(system, OPT_system),
 	REQ_ARG(tid, OPT_tid_filter),
 	NO_ARG(no-merge, OPT_no_merge),
 	NO_ARG(nop, OPT_nop),
@@ -807,6 +809,10 @@ static int parse_option(struct uftrace_opts *opts, int key, char *arg)
 
 	case OPT_task:
 		opts->show_task = true;
+		break;
+
+	case OPT_system:
+		opts->show_system = true;
 		break;
 
 	case OPT_tid_filter:

--- a/uftrace.h
+++ b/uftrace.h
@@ -99,6 +99,7 @@ enum uftrace_info_bits {
 	PATTERN_TYPE_BIT,
 	VERSION_BIT,
 	UTC_OFFSET_BIT,
+	SYSCTL_BIT,
 
 	INFO_BIT_MAX,
 
@@ -118,6 +119,7 @@ enum uftrace_info_bits {
 	PATTERN_TYPE = (1U << PATTERN_TYPE_BIT),
 	VERSION = (1U << VERSION_BIT),
 	UTC_OFFSET = (1U << UTC_OFFSET_BIT),
+	SYSCTL = (1U << SYSCTL_BIT),
 };
 
 struct uftrace_info {
@@ -157,6 +159,8 @@ struct uftrace_info {
 	float load15;
 	enum uftrace_pattern_type patt_type;
 	char *uftrace_version;
+	int perf_event_paranoid;
+	int kptr_restrict;
 };
 
 enum {
@@ -276,6 +280,7 @@ struct uftrace_opts {
 	bool print_symtab;
 	bool force;
 	bool show_task;
+	bool show_system;
 	bool no_merge;
 	bool nop;
 	bool time;


### PR DESCRIPTION
In order to get kernel information with uftrace without any problem, I think /proc/sys/kernel/perf_event_paranoid should be 2 or less. But many distros nowadays set this value to more than 3 as default.

I wanted to inform users about this in the docs, but it's so general that it's unclear which docs to leave this information in.

So this commit suggests checking this information
when configuring uftrace.

Closes: #1424