### PR TITLE
Clementguidi dynamic runtime init

### DIFF
--- a/arch/aarch64/mcount-insn.c
+++ b/arch/aarch64/mcount-insn.c
@@ -8,10 +8,19 @@
 #include <capstone/capstone.h>
 #include <capstone/platform.h>
 
+/**
+ * mcount_disasm_init - initialize the capstone engine once
+ * @disasm - mcount disassembly engine
+ */
 void mcount_disasm_init(struct mcount_disasm_engine *disasm)
 {
+	if (disasm->engine)
+		return;
+
+	pr_dbg2("initialize disassembly engine\n");
+
 	if (cs_open(CS_ARCH_ARM64, CS_MODE_ARM, &disasm->engine) != CS_ERR_OK) {
-		pr_dbg("failed to init Capstone disasm engine\n");
+		pr_dbg("failed to init capstone disasm engine\n");
 		return;
 	}
 

--- a/arch/x86_64/mcount-insn.c
+++ b/arch/x86_64/mcount-insn.c
@@ -19,8 +19,17 @@ struct disasm_check_data {
 	uint32_t size;
 };
 
+/**
+ * mcount_disasm_init - initialize the capstone engine once
+ * @disasm - mcount disassembly engine
+ */
 void mcount_disasm_init(struct mcount_disasm_engine *disasm)
 {
+	if (disasm->engine)
+		return;
+
+	pr_dbg2("initialize disassembly engine\n");
+
 	if (cs_open(CS_ARCH_X86, CS_MODE_64, &disasm->engine) != CS_ERR_OK) {
 		pr_dbg("failed to init capstone disasm engine\n");
 		return;
@@ -674,7 +683,7 @@ TEST_CASE(dynamic_x86_handle_lea)
 		.addr = 0x3000,
 		.size = 32,
 	};
-	struct mcount_disasm_engine disasm;
+	struct mcount_disasm_engine disasm = { 0 };
 	struct mcount_disasm_info info = {
 		.sym = &sym,
 		.addr = ORIGINAL_BASE + sym.addr,
@@ -745,7 +754,7 @@ TEST_CASE(dynamic_x86_handle_call)
 		.addr = 0x4000,
 		.size = 32,
 	};
-	struct mcount_disasm_engine disasm;
+	struct mcount_disasm_engine disasm = { 0 };
 	struct mcount_disasm_info info = {
 		.sym = &sym1,
 		.addr = ORIGINAL_BASE + sym1.addr,
@@ -823,7 +832,7 @@ TEST_CASE(dynamic_x86_handle_jmp)
 		.addr = 0x3000,
 		.size = 32,
 	};
-	struct mcount_disasm_engine disasm;
+	struct mcount_disasm_engine disasm = { 0 };
 	struct mcount_disasm_info info = {
 		.sym = &sym,
 		.addr = ORIGINAL_BASE + sym.addr,
@@ -927,7 +936,7 @@ TEST_CASE(dynamic_x86_handle_jcc)
 		.addr = 0x3000,
 		.size = 32,
 	};
-	struct mcount_disasm_engine disasm;
+	struct mcount_disasm_engine disasm = { 0 };
 	struct mcount_disasm_info info = {
 		.sym = &sym,
 		.addr = ORIGINAL_BASE + sym.addr,
@@ -1036,7 +1045,7 @@ TEST_CASE(dynamic_x86_handle_mov_load)
 		.addr = 0x3000,
 		.size = 32,
 	};
-	struct mcount_disasm_engine disasm;
+	struct mcount_disasm_engine disasm = { 0 };
 	struct mcount_disasm_info info = {
 		.sym = &sym,
 		.addr = ORIGINAL_BASE + sym.addr,

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -717,6 +717,14 @@ static int calc_percent(int n, int total, int *rem)
 	return quot;
 }
 
+/**
+ * mcount_dynamic_update - prepare and perform dynamic patching or unpatching,
+ * then display statistics
+ * @sinfo       - dynamic symbol info
+ * @patch_funcs - spec of symbols to patch or unpatch
+ * @ptype       - matching pattern type
+ * @return      - 0 (unused)
+ */
 int mcount_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 			  enum uftrace_pattern_type ptype)
 {
@@ -724,9 +732,7 @@ int mcount_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 	bool needs_modules = !!strchr(patch_funcs, '@');
 
 	mcount_disasm_init(&disasm);
-
 	prepare_dynamic_update(sinfo, needs_modules);
-
 	setup_size_filter();
 
 	ret = do_dynamic_update(sinfo, patch_funcs, ptype);

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -105,6 +105,9 @@ void mcount_save_code(struct mcount_disasm_info *info, unsigned call_size, void 
 	struct mcount_orig_insn *orig;
 	int patch_size;
 
+	if (hashmap_get(code_hmap, (void *)info->addr + call_size))
+		return;
+
 	if (unlikely(info->modified)) {
 		/* it needs to save original instructions as well */
 		int orig_size = ALIGN(info->orig_size, 16);

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -296,14 +296,14 @@ static struct mcount_dynamic_info *create_mdi(struct dl_phdr_info *info)
 }
 
 /**
- * find_dynamic_module - callback for dl_iterate_phdr(), iterated over all
- * loaded shared objects
- * @info   - info about shared object
- * @sz     - _unused_
- * @data   - mcount module data
- * @return - 0 to continue iteration, non-zero to stop
+ * prepare_dynamic_module - store dynamic module info and install trampoline;
+ * callback for dl_iterate_phdr()
+ * @info   - module info
+ * @sz     - data size (unused)
+ * @data   - callback data: symbol info and module parsing flag
+ * @return - stop iteration on non-zero value
  */
-static int find_dynamic_module(struct dl_phdr_info *info, size_t sz, void *data)
+static int prepare_dynamic_module(struct dl_phdr_info *info, size_t sz, void *data)
 {
 	struct mcount_dynamic_info *mdi;
 	struct find_module_data *fmd = data;
@@ -327,6 +327,9 @@ static int find_dynamic_module(struct dl_phdr_info *info, size_t sz, void *data)
 		mdi->map = map;
 		mcount_arch_find_module(mdi, &map->mod->symtab);
 
+		if (mcount_setup_trampoline(mdi) < 0)
+			mdi->trampoline = 0;
+
 		mdi->next = mdinfo;
 		mdinfo = mdi;
 		if (is_executable)
@@ -348,6 +351,7 @@ static int find_dynamic_module(struct dl_phdr_info *info, size_t sz, void *data)
  */
 static void prepare_dynamic_update(struct uftrace_sym_info *sinfo, bool needs_modules)
 {
+	int rc = 0;
 	struct find_module_data fmd = {
 		.sinfo = sinfo,
 		.needs_modules = needs_modules,
@@ -365,7 +369,7 @@ static void prepare_dynamic_update(struct uftrace_sym_info *sinfo, bool needs_mo
 		code_hmap = hashmap_create(hash_size, hashmap_ptr_hash, hashmap_ptr_equals);
 	}
 
-	int rc = dl_iterate_phdr(find_dynamic_module, &fmd);
+	rc = dl_iterate_phdr(prepare_dynamic_module, &fmd);
 
 	if (needs_modules && rc == 0)
 		modules_loaded = true;
@@ -657,10 +661,18 @@ static void patch_func_matched(struct mcount_dynamic_info *mdi, struct uftrace_m
 		patch_normal_func_matched(mdi, map);
 }
 
+/**
+ * do_dynamic_update - apply (un)patching across loaded modules' maps
+ * @sinfo       - dynamic symbol info
+ * @patch_funcs - spec of symbols to (un)patch
+ * @ptype       - matching pattern type
+ * @return      - 0 (unused)
+ */
 static int do_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 			     enum uftrace_pattern_type ptype)
 {
 	struct uftrace_mmap *map;
+	struct mcount_dynamic_info *mdi;
 	char *def_mod;
 
 	if (patch_funcs == NULL)
@@ -669,15 +681,11 @@ static int do_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 	def_mod = basename(sinfo->exec_map->libname);
 	parse_pattern_list(patch_funcs, def_mod, ptype);
 
-	for_each_map(sinfo, map) {
-		struct mcount_dynamic_info *mdi;
-
-		/* TODO: filter out unsuppported libs */
-		mdi = setup_trampoline(map);
-		if (mdi == NULL)
-			continue;
-
-		patch_func_matched(mdi, map);
+	/* TODO: filter out unsupported libs */
+	for (mdi = mdinfo; mdi != NULL; mdi = mdi->next) {
+		map = mdi->map;
+		if (mdi->trampoline)
+			patch_func_matched(mdi, map);
 	}
 
 	release_pattern_list();
@@ -688,24 +696,6 @@ static int do_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 	}
 
 	return 0;
-}
-
-static void freeze_dynamic_update(void)
-{
-	struct mcount_dynamic_info *mdi, *tmp;
-
-	mdi = mdinfo;
-	while (mdi) {
-		tmp = mdi->next;
-
-		mcount_arch_dynamic_recover(mdi, &disasm);
-		mcount_cleanup_trampoline(mdi);
-		free(mdi);
-
-		mdi = tmp;
-	}
-
-	mcount_freeze_code();
 }
 
 /* do not use floating-point in libmcount */
@@ -752,7 +742,7 @@ int mcount_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 		pr_dbg("no match: %8d\n", stats.nomatch);
 	}
 
-	freeze_dynamic_update();
+	mcount_freeze_code();
 	return ret;
 }
 
@@ -798,9 +788,29 @@ void mcount_dynamic_dlopen(struct uftrace_sym_info *sinfo, struct dl_phdr_info *
 	mcount_freeze_code();
 }
 
+/**
+ * mcount_free_mdinfo - free all dynamic info structures
+ */
+static void mcount_free_mdinfo(void)
+{
+	struct mcount_dynamic_info *mdi, *tmp;
+
+	mdi = mdinfo;
+	while (mdi) {
+		tmp = mdi->next;
+
+		mcount_arch_dynamic_recover(mdi, &disasm);
+		mcount_cleanup_trampoline(mdi);
+		free(mdi);
+
+		mdi = tmp;
+	}
+}
+
 void mcount_dynamic_finish(void)
 {
 	release_pattern_list();
+	mcount_free_mdinfo();
 	mcount_disasm_finish(&disasm);
 }
 

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -371,6 +371,21 @@ static void prepare_dynamic_update(struct uftrace_sym_info *sinfo, bool needs_mo
 		modules_loaded = true;
 }
 
+/**
+ * setup_size_filter - initialize size filter if not set
+ */
+void setup_size_filter(void)
+{
+	char *size_filter;
+
+	if (min_size)
+		return;
+
+	size_filter = getenv("UFTRACE_MIN_SIZE");
+	if (size_filter)
+		min_size = strtoul(size_filter, NULL, 0);
+}
+
 struct mcount_dynamic_info *setup_trampoline(struct uftrace_mmap *map)
 {
 	struct mcount_dynamic_info *mdi;
@@ -704,16 +719,13 @@ int mcount_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 			  enum uftrace_pattern_type ptype)
 {
 	int ret = 0;
-	char *size_filter;
 	bool needs_modules = !!strchr(patch_funcs, '@');
 
 	mcount_disasm_init(&disasm);
 
 	prepare_dynamic_update(sinfo, needs_modules);
 
-	size_filter = getenv("UFTRACE_MIN_SIZE");
-	if (size_filter != NULL)
-		min_size = strtoul(size_filter, NULL, 0);
+	setup_size_filter();
 
 	ret = do_dynamic_update(sinfo, patch_funcs, ptype);
 

--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -680,6 +680,8 @@ static int do_dynamic_update(struct uftrace_sym_info *sinfo, char *patch_funcs,
 		patch_func_matched(mdi, map);
 	}
 
+	release_pattern_list();
+
 	if (stats.failed + stats.skipped + stats.nomatch == 0) {
 		pr_dbg("patched all (%d) functions in '%s'\n", stats.total,
 		       basename(sinfo->filename));


### PR DESCRIPTION
This is #1702 (first PR of @clementguidi's series) below rebased to the current master as asked by 

The description for this first PR in the series is:

> First, we refactor the life cycle of dynamic structures so a dynamic update can be triggered at anytime during execution, any amount of times. This will allow the agent to call mcount_dynamic_update() multiple times at runtime.

I only did:
```py
gh pr checkout 1702
git switch -c this-branch
git rebase master
git push
```

Hopefully, this fixes the remaining test failures from #1702:
---
Copied from the description of #1702:

This is the first PR in a series of patches intended to bring runtime dynamic tracing on x86_64 to uftrace.

https://github.com/namhyung/uftrace/pull/1702 🠈
https://github.com/namhyung/uftrace/pull/1703
https://github.com/namhyung/uftrace/pull/1704
https://github.com/namhyung/uftrace/pull/1705
https://github.com/namhyung/uftrace/pull/1745
https://github.com/namhyung/uftrace/pull/1746
https://github.com/namhyung/uftrace/pull/1747
https://github.com/namhyung/uftrace/pull/1748
https://github.com/namhyung/uftrace/pull/1749
https://github.com/namhyung/uftrace/pull/1750
https://github.com/namhyung/uftrace/pull/1751

First, we refactor the life cycle of dynamic structures so a dynamic update can be triggered at anytime during execution, any amount of times. This will allow the agent to call mcount_dynamic_update() multiple times at runtime.

Related: https://github.com/namhyung/uftrace/pull/1698