### PR TITLE
utils: Add DTRAP macro and use it in pr_err

### DIFF
--- a/utils/debug.c
+++ b/utils/debug.c
@@ -214,6 +214,7 @@ void __pr_err(const char *fmt, ...)
 
 	color(TERM_COLOR_RESET, logfp);
 
+	DTRAP();
 	exit(1);
 }
 
@@ -233,6 +234,7 @@ void __pr_err_s(const char *fmt, ...)
 
 	color(TERM_COLOR_RESET, logfp);
 
+	DTRAP();
 	exit(1);
 }
 

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -417,6 +417,11 @@ void stacktrace(void);
 #define TRAP() raise(SIGTRAP)
 #endif
 
+#define DTRAP()                                                                                    \
+	if (DEBUG_MODE) {                                                                          \
+		TRAP();                                                                            \
+	}
+
 #define ASSERT(cond)                                                                               \
 	if (unlikely(!(cond))) {                                                                   \
 		pr_red("%s:%d: %s: ASSERT `%s' failed.\n", __FILE__, __LINE__, __func__, #cond);   \


### PR DESCRIPTION
We don't have much information when uftrace hits pr_err, but it just shows the given error message.

Instead, it'd be useful if we can attach gdb inside pr_err so that we can see its backtrace and so on.

This patch adds DTRAP, which enables TRAP only when debug mode is on.

We can add DTRAP just before pr_err goes to exit().