### PR TITLE
utils: Fix warnings implicit declaration of function 'close'

### DIFF
--- a/utils/kernel-parser.c
+++ b/utils/kernel-parser.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 /* This should be defined before #include "utils.h" */
 #define PR_FMT "kernel"


### PR DESCRIPTION
This patch fix warning on compile time with including unistd.h header file.
```
  utils/kernel-parser.c:151:9:
  warning: implicit declaration of function 'close';
  did you mean 'pclose'?
  [-Wimplicit-function-declaration]
    151 |         close(kp->fds[cpu]);
        |         ^~~~~
        |         pclose
```
Fixed: #1859