### PR TITLE
New release v0.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.14
+VERSION := 0.15
 
 # Makefiles suck: This macro sets a default value of $(2) for the
 # variable named by $(1), unless the variable has been set by

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,32 @@
+uftrace v0.15
+=============
+* New architecture support
+  Basic support for RISC-V (RV64G ABI) (#1815)
+  Arguments and return value recording (#1824)
+  PLT hooking for library call tracing (#1853)
+
+* Bug fixes
+  Support library call tracing with `-fno-plt` (#1777)
+  Reduce failures on `uftrace recv` test (#1767)
+  Fix tracefs check on qemu (#1753)
+  Skip offline CPUs for kernel tracing (#1849)
+  Ignore unpaired __cyg_profile_func_exit() to avoid crashes
+
+* other changes
+  Get rid of old copy of libtraceevent (#1728)
+  Use MAP_FIXED_NOREPLACE for dynamic tracing (#1798)
+  Many documentation updates (#1669, #1744, #1759, #1760, #1783, #1785, #1786, #1788, #1790, #1806)
+  Add misc/wget-pr.sh script to get patch files from github (#1808)
+  Add more unit test cases
+
+And many other fixes and improvements.  Thanks all contributors:
+  Bernhard Kaindl, ChoKyuWon, Chongyun Lee, Clément Guidi, Gichoel Choi,
+  Honggyu Kim, Jeonghwan In, Jin Jang, JungminKim, Kang Minchul,
+  Michelle Jin, Olivier Dion, Paran Lee, Robert Berger, SangGyuLee,
+  SeokMin Kwon, Seong Jin Kim, Soyeon Park, Stefan Hoffmeister,
+  Yoojung Nam, Yufeng Jin, kang-hyuck
+
+
 uftrace v0.14
 =============
 * new options


### PR DESCRIPTION
I think it's time for a new release. :)  We have a good set of new features and bug fixes including:

 * basic RISC-V (RV64G) architecture support
 * fixes for a couple of kernel tracing bugs
 * better support for binaries built with -fno-plt
 * ignoring unpaired __cyg_profile_func_exit() (probably due to compiler bugs)
 * various documentation and test updates

Maybe I can wait for a few more days for last minute changes and fixes.  Please test the code and let me know if it works well for you.  Thanks!