### PR TITLE
utils: Fix incorrect header includes

### DIFF
--- a/utils/shmem.h
+++ b/utils/shmem.h
@@ -1,6 +1,8 @@
 #ifndef UFTRACE_SHMEM_H
 #define UFTRACE_SHMEM_H
 
+#include <sys/stat.h>
+
 int uftrace_shmem_open(const char *name, int oflag, mode_t mode);
 int uftrace_shmem_unlink(const char *name);
 const char *uftrace_shmem_root(void);

--- a/utils/socket.h
+++ b/utils/socket.h
@@ -5,6 +5,8 @@
 
 #define MCOUNT_AGENT_SOCKET_DIR "/tmp/uftrace"
 
+struct uftrace_msg;
+
 void socket_unlink(struct sockaddr_un *addr);
 int agent_socket_create(struct sockaddr_un *addr, pid_t pid);
 int agent_listen(int fd, struct sockaddr_un *addr);


### PR DESCRIPTION
Each header has to be buildable independently, but some headers fail as follows.

Before:
```
  $ find -name "*\.h" | grep -v prototypes.h | xargs gcc -I. -I./arch/$(uname -m)
  ./utils/socket.h:8:27: warning: ‘struct sockaddr_un’ declared inside parameter
    list will not be visible outside of this definition or declaration
      8 | void socket_unlink(struct sockaddr_un *addr);
        |                           ^~~~~~~~~~~
          ...
  ./utils/socket.h:15:48: warning: ‘struct uftrace_msg’ declared inside parameter
    list will not be visible outside of this definition or declaration
     15 | int agent_message_read_response(int fd, struct uftrace_msg *response);
        |                                                ^~~~~~~~~~~
  ./utils/shmem.h:4:53: error: unknown type name ‘mode_t’
      4 | int uftrace_shmem_open(const char *name, int oflag, mode_t mode);
        |                                                     ^~~~~~
  ./libmcount/dynamic.h:84:67: warning: ‘struct dl_phdr_info’ declared inside
    parameter list will not be visible outside of this definition or declaration
     84 | void mcount_dynamic_dlopen(struct uftrace_sym_info *sinfo, struct dl_phdr_info *info, char *path);
        |                                                                   ^~~~~~~~~~~~
```
This patch is to fix these problems only except the following warning. This is because we add defining _GNU_SOURCE in Makefile instead of header file itself so we better ignore it as of now.

After:
```
  $ find -name "*\.h" | grep -v prototypes.h | xargs gcc -I. -I./arch/$(uname -m)
  ./libmcount/dynamic.h:84:67: warning: ‘struct dl_phdr_info’ declared inside
    parameter list will not be visible outside of this definition or declaration
     84 | void mcount_dynamic_dlopen(struct uftrace_sym_info *sinfo, struct dl_phdr_info *info, char *path);
        |                                                                   ^~~~~~~~~~~~
```