### PR TITLE
build: Fix build failure on RHEL 7

### DIFF
--- a/check-deps/Makefile
+++ b/check-deps/Makefile
@@ -37,7 +37,7 @@ endif
 CFLAGS_cc_has_mfentry = -mfentry
 LDFLAGS_cxa_demangle = -lstdc++
 LDFLAGS_have_libelf = -lelf
-CFLAGS_cc_has_mno_sse2 = -mno-sse -mno-sse2
+CFLAGS_cc_has_mno_sse2 = -O2 -mno-sse -mno-sse2
 LDFLAGS_have_libpython2.7 = -lpython2.7
 CFLAGS_have_libpython3 = $(shell pkg-config python3$(EMBED) --cflags 2> /dev/null)
 LDFLAGS_have_libpython3 = $(shell pkg-config python3$(EMBED) --libs 2> /dev/null)

--- a/check-deps/__cc_has_mno_sse2.c
+++ b/check-deps/__cc_has_mno_sse2.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 int main(void)
 {
 	return 0;


### PR DESCRIPTION
Fix issue of uftrace build fail on rhel 7.9

System information

```
NAME="Red Hat Enterprise Linux Server"
VERSION="7.9 (Maipo)"
ID="rhel"
ID_LIKE="fedora"
VARIANT="Server"
VARIANT_ID="server"
VERSION_ID="7.9"
PRETTY_NAME="Red Hat Enterprise Linux Server 7.9 (Maipo)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:7.9:GA:server"
HOME_URL="https://www.redhat.com/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
REDHAT_BUGZILLA_PRODUCT_VERSION=7.9
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="7.9"
```

Build error:

```sh
[uftrace]$ ./configure
uftrace detected system features:
...         prefix: /usr/local
...         libelf: [ on  ] - more flexible ELF data handling
...          libdw: [ on  ] - DWARF debug info support
...      libpython: [ OFF ] - python tracing & scripting support
...      libluajit: [ on  ] - luajit scripting support
...    libncursesw: [ on  ] - TUI support
...   cxa_demangle: [ on  ] - full demangler support with libstdc++
...     perf_event: [ on  ] - perf (PMU) event support
...       schedule: [ on  ] - scheduler event support
...       capstone: [ on  ] - full dynamic tracing support
...  libtraceevent: [ OFF ] - kernel tracing support
...      libunwind: [ OFF ] - stacktrace support (optional for debugging)
[uftrace]$ make
  CC       uftrace.o
  CC       cmds/recv.o
  CC       cmds/script.o
  CC       cmds/report.o
  CC       cmds/info.o
  CC       cmds/replay.o
#include <stdlib.h>
  CC       cmds/tui.o
  CC       cmds/dump.o
  CC       cmds/live.o
  CC       cmds/graph.o
  CC       cmds/record.o
  CC       utils/symbol-rawelf.o
  CC       utils/session.o
  CC       utils/rbtree.o
  CC       utils/extern.o
  CC       utils/hashmap.o
  CC       utils/tracefs.o
  CC       utils/auto-args.o
  CC       utils/report.o
  CC       utils/data-file.o
  CC       utils/pager.o
  CC       utils/regs.o
  CC       utils/dwarf.o
  CC       utils/symbol-libelf.o
  CC       utils/script-luajit.o
  CC       utils/shmem.o
  CC       utils/perf.o
  CC       utils/graph.o
  CC       utils/event.o
  CC       utils/filter.o
  CC       utils/demangle.o
  CC       utils/argspec.o
  CC       utils/debug.o
  CC       utils/script.o
  CC       utils/fstack.o
  CC       utils/script-python.o
  CC       utils/kernel-parser.o
  CC       utils/socket.o
  CC       utils/kernel.o
  CC       utils/symbol.o
  CC       utils/utils.o
  CC       utils/field.o
  CC       arch/x86_64/cpuinfo.o
  CC       arch/x86_64/symbol.o
  LINK     arch/x86_64/uftrace.o
  LINK     uftrace
  CC FPIC  libmcount/mcount.op
In file included from /usr/include/stdlib.h:951:0,
                 from /home/rshen/works/uftrace/libmcount/mcount.c:14:
/usr/include/bits/stdlib-float.h: 在函数‘atof’中:
/usr/include/bits/stdlib-float.h:27:1: 错误：已禁用 SSE 却在 SSE 寄存器中返回
 {
 ^
make: *** [/home/rshen/works/uftrace/libmcount/mcount.op] 错误 1
```