### PR TITLE
mcount: Fix a compiler warning on PAGE_SIZE

### DIFF
--- a/libmcount/dynamic.c
+++ b/libmcount/dynamic.c
@@ -40,7 +40,6 @@ static struct mcount_dynamic_stats {
 	int unpatch;
 } stats;
 
-#define PAGE_SIZE 4096
 #define CODE_CHUNK (PAGE_SIZE * 8)
 
 struct code_page {


### PR DESCRIPTION
The musl libc defines PAGE_SIZE macro and shows warning like this:

/usr/src/uftrace/libmcount/dynamic.c:43: warning: "PAGE_SIZE" redefined
   43 | #define PAGE_SIZE 4096
      |
In file included from /usr/include/fortify/stdlib.h:30,
                 from /usr/src/uftrace/libmcount/dynamic.h:5,
                 from /usr/src/uftrace/libmcount/dynamic.c:24:
/usr/include/limits.h:97: note: this is the location of the previous definition
   97 | #define PAGE_SIZE PAGESIZE