### PR TITLE
fix: #1858 by changing the wrong logic in update_dbg_info

### DIFF
--- a/python/trace-python.c
+++ b/python/trace-python.c
@@ -382,7 +382,7 @@ static void update_dbg_info(const char *name, uint64_t addr, const char *file, i
 		old_hdr.val = tmp_hdr.val;
 	}
 
-	if (new_hdr.offset >= uftrace_symtab_size) {
+	if (new_hdr.offset >= uftrace_dbginfo_size) {
 		unsigned new_dbginfo_size = uftrace_dbginfo_size + UFTRACE_PYTHON_SYMTAB_SIZE;
 
 		pr_dbg("try to increase the shared memory for %s (new size=%uMB)\n",


### PR DESCRIPTION
by changing the wrong logic in update_dbg_info

backtrace(need set follow-fork-mode child)
```
__memmove_avx_unaligned_erms () at ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:457
457	../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S: No such file or directory.
#0  __memmove_avx_unaligned_erms () at ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:457
#1  0x00007ffff7c8de6c in __GI__IO_default_xsputn (n=<optimized out>, data=<optimized out>, f=<optimized out>) at ./libio/genops.c:386
#2  __GI__IO_default_xsputn (f=0x7fffffff7a10, data=<optimized out>, n=174) at ./libio/genops.c:370
#3  0x00007ffff7c74918 in outstring_func (done=0, length=174, 
    string=0x55555c1634d0 "F: 723bd tensorflow._api.v2.experimental.numpy.random.<module>\nL: 1 /home/yihong/.local/lib/python3.10/site-packages/tensorflow/_api/v2/experimental/numpy/random/__init__.py\n", s=0x7fffffff7440) at ../libio/libioP.h:947
#4  printf_positional (s=s@entry=0x7fffffff7a10, format=format@entry=0x7ffff62d1911 "%s", readonly_format=<optimized out>, readonly_format@entry=0, ap=ap@entry=0x7fffffff7b90, 
    ap_savep=ap_savep@entry=0x7fffffff75a8, done=<optimized out>, done@entry=0, nspecs_done=<optimized out>, lead_str_end=<optimized out>, work_buffer=<optimized out>, 
    save_errno=<optimized out>, grouping=<optimized out>, thousands_sep=<optimized out>, mode_flags=<optimized out>) at ./stdio-common/vfprintf-internal.c:1927
#5  0x00007ffff7c75336 in __vfprintf_internal (s=s@entry=0x7fffffff7a10, format=format@entry=0x7ffff62d1911 "%s", ap=ap@entry=0x7fffffff7b90, mode_flags=mode_flags@entry=0)
    at ./stdio-common/vfprintf-internal.c:1602
#6  0x00007ffff7c8849a in __vsnprintf_internal (string=0x7ffff4ffffeb "", maxlen=<optimized out>, format=0x7ffff62d1911 "%s", args=args@entry=0x7fffffff7b90, mode_flags=mode_flags@entry=0)
    at ./libio/vsnprintf.c:114
#7  0x00007ffff7c60856 in __GI___snprintf (s=s@entry=0x7ffff4ffffeb "", maxlen=maxlen@entry=175, format=format@entry=0x7ffff62d1911 "%s") at ./stdio-common/snprintf.c:31
#8  0x00007ffff62cc1be in snprintf (__fmt=0x7ffff62d1911 "%s", __n=175, __s=0x7ffff4ffffeb "") at /usr/include/x86_64-linux-gnu/bits/stdio2.h:71
#9  update_dbg_info (line=<optimized out>, file=<optimized out>, addr=<optimized out>, name=<optimized out>) at /home/yihong/repos/uftrace/python/trace-python.c:403
#10 convert_function_addr (is_pyfunc=<optimized out>, args=<optimized out>, frame=<optimized out>) at /home/yihong/repos/uftrace/python/trace-python.c:943
#11 uftrace_trace_python (self=<optimized out>, args=<optimized out>) at /home/yihong/repos/uftrace/python/trace-python.c:976
```
