### PR TITLE
ci: Fix ci warning on GitHub Acitons

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "install dependencies"
         run: sudo ./misc/install-deps.sh -y

--- a/.github/workflows/on-demand-test.yml
+++ b/.github/workflows/on-demand-test.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "install dependencies"
         run: sudo ./misc/install-deps.sh -y
@@ -24,10 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "check out uftrace source"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "install dependencies"
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
 
       - name: "run pre-commit"
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "install dependencies"
         run: sudo ./misc/install-deps.sh -y
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "check out uftrace source"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "install dependencies"
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
 
       - name: "run pre-commit"
         uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
by changing actions/checkout from v3 to v4
actions/setup-python from v4 to v5
warning on GitHub Acitions

before:
![image](https://github.com/namhyung/uftrace/assets/15976103/5c1f9b77-b8f9-4a1c-b158-b1f5a08b422a)

after:
![image](https://github.com/namhyung/uftrace/assets/15976103/c9257d4c-85e3-46a3-be95-e073b88bdbab)
