### PR TITLE
build: Fix compiler warnings

### DIFF
--- a/utils/script-python.h
+++ b/utils/script-python.h
@@ -14,6 +14,8 @@ struct script_info;
 
 #if defined(HAVE_LIBPYTHON2) || defined(HAVE_LIBPYTHON3)
 
+#undef _XOPEN_SOURCE
+#undef _POSIX_C_SOURCE
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 


### PR DESCRIPTION
Fix compiler warnings when using python2.7

```sh
/usr/include/python2.7/pyconfig-64.h:1191:0: error: "_POSIX_C_SOURCE" redefined [-Werror]
 #define _POSIX_C_SOURCE 200112L
 ^
In file included from /usr/include/inttypes.h:25:0,
                 from /home/uftrace/libmcount/mcount.h:12,
                 from /home/uftrace/utils/script.h:11,
                 from /home/uftrace/utils/script.c:13:
/usr/include/features.h:168:0: note: this is the location of the previous definition
 # define _POSIX_C_SOURCE 200809L
 ^
In file included from /usr/include/python2.7/pyconfig.h:6:0,
                 from /usr/include/python2.7/Python.h:8,
                 from /home/uftrace/utils/script-python.h:18,
                 from /home/uftrace/utils/script.h:13,
                 from /home/uftrace/utils/script.c:13:
/usr/include/python2.7/pyconfig-64.h:1213:0: error: "_XOPEN_SOURCE" redefined [-Werror]
 #define _XOPEN_SOURCE 600
 ^
In file included from /usr/include/inttypes.h:25:0,
                 from /home/uftrace/libmcount/mcount.h:12,
                 from /home/uftrace/utils/script.h:11,
                 from /home/uftrace/utils/script.c:13:
/usr/include/features.h:170:0: note: this is the location of the previous definition
 # define _XOPEN_SOURCE 700
 ^
```

Fixed: https://github.com/namhyung/uftrace/issues/1276

Signed-off-by: Michelle Jin <shjy180909@gmail.com>