### PR TITLE
Fix Python SyntaxWarning on invalid escape sequence in the tests scripts

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -325,7 +325,7 @@ class TestBase:
             # ignore result of remaining functions which follows a blank line
             if ln.strip() == '':
                 break
-            pid_patt = re.compile('[^[]+\[ *(\d+)\] |')
+            pid_patt = re.compile(r'[^[]+\[ *(\d+)\] |')
             m = pid_patt.match(ln)
             try:
                 pid = int(m.group(1))
@@ -493,7 +493,7 @@ class TestBase:
                 break
 
             m = re.match( r'\s+(?P<start_depth>\d+)_(?P<start_id>\d+)\[\"(?P<start_name>\S+)\"\]\s+'
-                + '-->\|(?P<call_num>\d+)\|\s+(?P<end_depth>\d+)_(?P<end_id>\d+)\[\"(?P<end_name>\S+)\"\];', ln)
+                + r'-->\|(?P<call_num>\d+)\|\s+(?P<end_depth>\d+)_(?P<end_id>\d+)\[\"(?P<end_name>\S+)\"\];', ln)
             if m:
                 result.append("%s_%s_%s %s> %s_%s_%s" % (m.group('start_depth'), m.group('start_id'), m.group('start_name'),
                 m.group('call_num'), m.group('end_depth'), m.group('end_id'), m.group('end_name')))

--- a/tests/t230_graph_task.py
+++ b/tests/t230_graph_task.py
@@ -36,7 +36,7 @@ class TestCase(TestBase):
 
             if " : " in ln:
                 line = ln.split(':')[1]  # remove time part
-                line = re.sub('\[\d+\]', 'TID', line)
+                line = re.sub(r'\[\d+\]', 'TID', line)
                 result.append(line)
             else:
                 result.append(ln)


### PR DESCRIPTION
Fixes the following `SyntaxWarning:` from the Python Interpreter:

```sh
uftrace/tests/./runtest.py:328: SyntaxWarning: invalid escape sequence '\['
  pid_patt = re.compile('[^[]+\[ *(\d+)\] |')

uftrace/tests/./runtest.py:496: SyntaxWarning: invalid escape sequence '\|'
  + '-->\|(?P<call_num>\d+)\|\s+(?P<end_depth>\d+)_(?P<end_id>\d+)\[\"(?P<end_name>\S+)\"\];', ln)

uftrace/tests/t230_graph_task.py:39: SyntaxWarning: invalid escape sequence '\['
  line = re.sub('\[\d+\]', 'TID', line)
```