### PR TITLE
include libgen.h for basename

### DIFF
--- a/utils/utils.h
+++ b/utils/utils.h
@@ -11,6 +11,9 @@
 
 #include <ctype.h>
 #include <endian.h>
+#ifndef __GLIBC__
+#include <libgen.h>
+#endif
 #include <limits.h>
 #include <signal.h>
 #include <stdbool.h>
@@ -21,6 +24,7 @@
 #include <time.h>
 
 #include "compiler.h"
+
 
 #ifndef container_of
 #define container_of(ptr, type, member)                                                            \


### PR DESCRIPTION
basename prototype has been removed from string.h from latest musl [1] compilers e.g. clang-18 flags the absense of prototype as error. therefore include libgen.h for providing it.

[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7