### PR TITLE
utils: Lower the debug level after dwfl_module_getdwarf

### DIFF
--- a/utils/symbol-libelf.c
+++ b/utils/symbol-libelf.c
@@ -95,7 +95,7 @@ int elf_retry(const char *filename, struct uftrace_elf_data *elf)
 
 	dw = dwfl_module_getdwarf(mod, &bias);
 	if (dw == NULL) {
-		pr_dbg("cannot find debug file: %s\n", dwfl_errmsg(dwfl_errno()));
+		pr_dbg2("cannot find debug file: %s\n", dwfl_errmsg(dwfl_errno()));
 		goto out;
 	}
 


### PR DESCRIPTION
The current return value check after dwfl_module_getdwarf shows too many repeated debug messages as follows.
```
  $ sudo apt install vulkan-tools

  $ uftrace record -P. -la -v vkcube
  uftrace: running uftrace v0.15.2-32-g1919a ( x86_64 dwarf python3 luajit tui perf sched dynamic kernel )
  uftrace: checking binary /usr/bin/vkcube
  uftrace: removing uftrace.data.old directory
  uftrace: using /home/honggyu/usr/lib/uftrace/libmcount.so library for tracing
  uftrace: creating 2 thread(s) for recording
  mcount: initializing mcount library
  symbol: cannot find debug file: No DWARF information found
  symbol: cannot find debug file: No DWARF information found
      (... repeated about 40 times ...)
  symbol: cannot find debug file: No DWARF information found
  symbol: cannot find debug file: No DWARF information found
  dwarf: prepare debug info
  dynamic: dynamic patch type: vkcube: 0 (none)
  plthook: setup nested PLT hooking "/usr/bin/vkcube"
  mcount: mcount setup done
```
so it'd be better to lower the debug level to pr_dbg2.

Fixed: #1905