### PR TITLE
wrap: Do not print "dlopen is called for '(null)'"

### DIFF
--- a/libmcount/wrap.c
+++ b/libmcount/wrap.c
@@ -482,11 +482,11 @@ __visible_default void *dlopen(const char *filename, int flags)
 	if (unlikely(real_dlopen == NULL))
 		mcount_hook_functions();
 
-	pr_dbg("%s is called for '%s'\n", __func__, filename);
 	ret = real_dlopen(filename, flags);
 
 	if (filename == NULL)
 		return ret;
+	pr_dbg("%s is called for '%s'\n", __func__, filename);
 
 	mtdp = get_thread_data();
 	if (unlikely(check_thread_data(mtdp))) {


### PR DESCRIPTION
If dlopen is called with (null) for the filename, it does nothing so it's not useful to print a debug message for such case.

But the current implementation shows too many message as follows.
```
  $ sudo apt install vulkan-tools

  $ uftrace record -P. -la -v vkcube
      ...
  wrap: dlopen is called for 'libVkLayer_MESA_device_select.so'
  wrap: dlopen is called for '(null)'
  wrap: dlopen is called for '(null)'
      (... repeated 18 more times ...)
  mcount: shmem_finish: tid: 10312 seqnum = 2 curr = 0, nr_buf = 2 max_buf = 2
```
This patch is to avoid printing these unhelpful messages.