### PR TITLE
build: Add "check-syntax" make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,10 @@ help:
 	@echo "  make O=dir [targets]        - Set directory as objdir (default: $(srcdir))"
 	@echo ""
 
+check-syntax:
+	@$(CC) -I $(srcdir) -I $(srcdir)/arch/$(ARCH) -o /dev/null -S ${CHK_SOURCES} || true
+
 $(C_STR_OBJS): $(objdir)/%.$(C_STR_EXTENSION): $(srcdir)/%
 	$(QUIET_GEN)sed -e 's#\\#\\\\#g;s#\"#\\"#g;s#$$#\\n\"#;s#^#\"#' $< > $@
 
-.PHONY: all config clean test dist doc ctags help PHONY
+.PHONY: all config clean test dist doc ctags help check-syntax PHONY


### PR DESCRIPTION
Hi,

Do you have any interest in supporting syntax checkers such as Emacs' Flymake?

It would require a `check-syntax` target to be added to the Makefile.

See https://www.gnu.org/software/emacs/manual/html_node/flymake/Example_002d_002d_002dConfiguring-a-tool-called-via-make.html (bottom of the page).