### PR TITLE
info: Add utc_offset info for external usage

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -540,7 +540,7 @@ static void dump_raw_header(struct uftrace_dump_ops *ops, struct uftrace_data *h
 	const char *info_str[] = { "EXE_NAME",	   "EXE_BUILD_ID", "EXIT_STATUS", "CMDLINE",
 				   "CPUINFO",	   "MEMINFO",	   "OSINFO",	  "TASKINFO",
 				   "USAGEINFO",	   "LOADINFO",	   "ARG_SPEC",	  "RECORD_DATE",
-				   "PATTERN_TYPE", "VERSION" };
+				   "PATTERN_TYPE", "VERSION",	   "UTC_OFFSET" };
 
 	pr_out("uftrace file header: magic         = ");
 	for (i = 0; i < UFTRACE_MAGIC_LEN; i++)

--- a/uftrace.h
+++ b/uftrace.h
@@ -98,6 +98,7 @@ enum uftrace_info_bits {
 	RECORD_DATE_BIT,
 	PATTERN_TYPE_BIT,
 	VERSION_BIT,
+	UTC_OFFSET_BIT,
 
 	INFO_BIT_MAX,
 
@@ -116,6 +117,7 @@ enum uftrace_info_bits {
 	RECORD_DATE = (1U << RECORD_DATE_BIT),
 	PATTERN_TYPE = (1U << PATTERN_TYPE_BIT),
 	VERSION = (1U << VERSION_BIT),
+	UTC_OFFSET = (1U << UTC_OFFSET_BIT),
 };
 
 struct uftrace_info {
@@ -142,6 +144,7 @@ struct uftrace_info {
 	double utime;
 	char *record_date;
 	char *elapsed_time;
+	char *utc_offset;
 	long vctxsw;
 	long ictxsw;
 	long maxrss;


### PR DESCRIPTION
In some cases, there is a requirement to get the time offset between UTC time and our timestamp from the given clock source, CLOCK_MONOTONIC by default.

This patch provides an additional info to provide UTC time offset in the output of uftrace info.

This number can be used to make time adjustment easier for external tools such as tracecompass[1].

Closes: #1916

[1] https://eclipse.dev/tracecompass
Requested-by: Matthew Khouzam <matthew.khouzam@gmail.com>
Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>