### PR TITLE
build: Remove -Wdeclaration-after-statement flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ export ARCH CC AR LD RM srcdir objdir LDFLAGS
 COMMON_CFLAGS := -std=gnu11 -D_GNU_SOURCE $(CFLAGS) $(CPPFLAGS)
 COMMON_CFLAGS += -iquote $(srcdir) -iquote $(objdir) -iquote $(srcdir)/arch/$(ARCH)
 COMMON_CFLAGS += -W -Wall -Wno-unused-parameter -Wno-missing-field-initializers
-COMMON_CFLAGS += -Wdeclaration-after-statement -Wstrict-prototypes
+COMMON_CFLAGS += -Wstrict-prototypes
 
 COMMON_LDFLAGS := -ldl -pthread -Wl,-z,noexecstack $(LDFLAGS)
 ifeq ($(ANDROID),)


### PR DESCRIPTION
Remove ISO C90 forbids mixed declarations and code in C warning flag. #1934

Signed-off-by: Yunseong Kim <yskelg@gmail.com>