### PR TITLE
uftrace: Align exact argument on calloc

### DIFF
--- a/cmds/info.c
+++ b/cmds/info.c
@@ -539,7 +539,7 @@ static int read_taskinfo(void *arg)
 		else if (!strncmp(&buf[9], "tids=", 5)) {
 			char *tids_str = &buf[14];
 			char *endp = tids_str;
-			int *tids = xcalloc(sizeof(*tids), info->nr_tid);
+			int *tids = xcalloc(info->nr_tid, sizeof(*tids));
 			int nr_tid = 0;
 
 			while (*endp != '\n') {

--- a/libmcount/record.c
+++ b/libmcount/record.c
@@ -73,7 +73,7 @@ void prepare_shmem_buffer(struct mcount_thread_data *mtdp)
 
 	shmem->nr_buf = 2;
 	shmem->max_buf = 2;
-	shmem->buffer = xcalloc(sizeof(*shmem->buffer), 2);
+	shmem->buffer = xcalloc(2, sizeof(*shmem->buffer));
 
 	for (idx = 0; idx < shmem->nr_buf; idx++) {
 		shmem->buffer[idx] = allocate_shmem_buffer(buf, sizeof(buf), tid, idx);

--- a/libmcount/wrap.c
+++ b/libmcount/wrap.c
@@ -197,7 +197,7 @@ static char **collect_uftrace_envp(void)
 			n++;
 	}
 
-	envp = xcalloc(sizeof(*envp), n + 2);
+	envp = xcalloc(n + 2, sizeof(*envp));
 
 	for (i = k = 0; i < ARRAY_SIZE(uftrace_env); i++) {
 		char *env_str;
@@ -232,7 +232,7 @@ static char **merge_envp(char *const *env1, char **env2)
 	n += count_envp(env1);
 	n += count_envp(env2);
 
-	envp = xcalloc(sizeof(*envp), n + 1);
+	envp = xcalloc(n + 1, sizeof(*envp));
 
 	n = 0;
 	for (i = 0; env1 && env1[i]; i++)

--- a/utils/kernel.c
+++ b/utils/kernel.c
@@ -1778,7 +1778,7 @@ static int kernel_test_setup_handle(struct uftrace_kernel_reader *kernel,
 	int i;
 
 	handle->nr_tasks = NUM_TASK;
-	handle->tasks = xcalloc(sizeof(*handle->tasks), NUM_TASK);
+	handle->tasks = xcalloc(NUM_TASK, sizeof(*handle->tasks));
 
 	handle->time_range.start = handle->time_range.stop = 0;
 	handle->time_filter = 0;

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -190,16 +190,16 @@ extern void setup_signal(void);
 
 #define xzalloc(sz)                                                                                \
 	({                                                                                         \
-		void *__ptr = calloc(sz, 1);                                                       \
+		void *__ptr = calloc(1, sz);                                                       \
 		if (__ptr == NULL) {                                                               \
 			pr_err("xzalloc");                                                         \
 		}                                                                                  \
 		__ptr;                                                                             \
 	})
 
-#define xcalloc(sz, n)                                                                             \
+#define xcalloc(n, sz)                                                                             \
 	({                                                                                         \
-		void *__ptr = calloc(sz, n);                                                       \
+		void *__ptr = calloc(n, sz);                                                       \
 		if (__ptr == NULL) {                                                               \
 			pr_err("xcalloc");                                                         \
 		}                                                                                  \


### PR DESCRIPTION
Align argument for calloc() call in some code and macro in utils.h file.

This patch remove warning on #1933 
```
/home/paran/uftrace/cmds/graph.c:213:53: error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
  213 |         struct session_graph *graph = xzalloc(sizeof(*graph));
      |                                                     ^
/home/paran/uftrace/utils/utils.h:193:38: note: in definition of macro ‘xzalloc’
  193 |                 void *__ptr = calloc(sz, 1);                                                       \
      |                                      ^~
/home/paran/uftrace/cmds/graph.c:213:53: note: earlier argument should specify number of elements, later size of each element
  213 |         struct session_graph *graph = xzalloc(sizeof(*graph));
      |                                                     ^
/home/paran/uftrace/utils/utils.h:193:38: note: in definition of macro ‘xzalloc’
  193 |                 void *__ptr = calloc(sz, 1);                                                       \
      |                                      ^~
```

Signed-off-by: Yunseong Kim <yskelg@gmail.com>