### PR TITLE
uftrace: Add sub-command specific help

### DIFF
--- a/uftrace.c
+++ b/uftrace.c
@@ -1383,6 +1383,19 @@ __used static void apply_default_opts(int *argc, char ***argv, struct uftrace_op
 	}
 }
 
+__used static void show_man_page(char *cmd)
+{
+	char *cmdstr = NULL;
+
+	if (cmd)
+		xasprintf(&cmdstr, "uftrace-%s", cmd);
+	else
+		cmdstr = xstrdup("uftrace");
+	execlp("man", "man", cmdstr, (char *)NULL);
+	/* fall through if man command itself is not found */
+	free(cmdstr);
+}
+
 #ifndef UNIT_TEST
 int main(int argc, char *argv[])
 {
@@ -1428,6 +1441,8 @@ int main(int argc, char *argv[])
 		ret = 0;
 		goto cleanup;
 	case -3:
+		if (opts.mode)
+			show_man_page(argv[1]);
 		if (opts.use_pager)
 			start_pager(setup_pager());
 		pr_out(uftrace_usage);


### PR DESCRIPTION
uftrace: Add sub-command specific help

i redirect subcommand help to man pages just like git and perf do.
```c
	case -3:
+		if (opts.mode) {
+			execlp("man", "man", "uftrace", argv[1], (char *)NULL);
+			abort();
+		}
		if (opts.use_pager)
			start_pager(setup_pager());
		pr_out(uftrace_usage);
		pr_out(uftrace_help);
		wait_for_pager();
		ret = 0;
		goto cleanup;
	}
```

Fixed: #1316

Signed-off-by: ParkSeungHyeok <tmdgur1324@naver.com>