### PR TITLE
test: Fix testcase 84

### DIFF
--- a/tests/s-exp-mixed.c
+++ b/tests/s-exp-mixed.c
@@ -7,6 +7,9 @@ double mixed_add(int a, float b)
 	return a + b;
 }
 
+#if __clang__
+__attribute__((optnone))
+#endif
 long mixed_sub(void *a, unsigned long b)
 {
 	return (long)a - b;


### PR DESCRIPTION
Fix testcase 84 arg_mixed in ubuntu24.04

In 84 arg_mixed test, the mixed_sub is renamed to mixed_sub.specialized.1
in clang optimized builds so the test fails.
Fix not to optimize in mixed_sub function.


Start 1 tests without worker pool

Compiler                  gcc                                           clang                                       
Runtime test case         pg             finstrument-fu fpatchable-fun  pg             finstrument-fu fpatchable-fun
------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os  O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os
084 arg_mixed           : OK OK OK OK OK SK SK SK SK SK OK OK OK OK OK  OK OK OK OK OK SK SK SK SK SK OK OK OK OK OK