### PR TITLE
risc64: Add description for arch registers

### DIFF
--- a/arch/riscv64/mcount.S
+++ b/arch/riscv64/mcount.S
@@ -1,5 +1,21 @@
 #include "utils/asm.h"
 
+/*
+ * RISC-V Integer Register Convention
+ *
+ * | Name      | ABI Mnemonic | Meaning                | Preserved across calls?
+ * | x0        | zero         | Zero                   | -- (Immutable)
+ * | x1        | ra           | Return address         | No
+ * | x2        | sp           | Stack pointer          | Yes
+ * | x3        | gp           | Global pointer         | -- (Unallocatable)
+ * | x4        | tp           | Thread pointer         | -- (Unallocatable)
+ * | x5 - x7   | t0 - t2      | Temporary registers    | No
+ * | x8 - x9   | s0 - s1      | Callee-saved registers | Yes
+ * | x10 - x17 | a0 - a7      | Argument registers     | No
+ * | x18 - x27 | s2 - s11     | Callee-saved registers | Yes
+ * | x28 - x31 | t3 - t6      | Temporary registers    | No
+ */
+
 .text
 
 GLOBAL(_mcount)


### PR DESCRIPTION
It'd be a lot easier to understand the assembly code by having description table for architecture registers.

This patch adds the register table to mcount.S for RISC-V[1].

References:
[1] https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/v1.0/riscv-cc.adoc#integer-register-convention