### PR TITLE
doc/ko: Add missing options in uftrace-live.md

### DIFF
--- a/doc/ko/uftrace-live.md
+++ b/doc/ko/uftrace-live.md
@@ -77,6 +77,10 @@ uftrace [live] [*options*] COMMAND [*command-options*]
 :   uftrace 를 시작할때 데이터를 기록하지 않고 시작한다.
     이것은 `trace_on` 트리거와 함께 사용되었을 때만 의미를 가진다.
 
+\--trace=*STATE*
+:   utfrace 트레이싱 상태를 정의한다. 가능한 상태로는 `on`과 `off`가 있다. 
+    기본 옵션은 `on`이다. 이 옵션은 `trace_on` 트리거나 agent와 함께 이용할 때만 의미있다.
+
 \--with-syms=*DIR*
 :   DIR 디렉토리의 .sym 파일에서 심볼(symbol) 데이터를 읽는다.
     이는 심볼(symbol) 데이터가 제거된 바이너리 파일을 다루는데 유용하다.
@@ -93,6 +97,9 @@ LIVE 옵션
 \--record
 :   기록된 데이터를 향후 분석을 위해 저장한다.
 
+-p *PID*, \--pid=*PID*
+:   클라이언트 모드로 변경한다. 주어진 PID를 가진 실행중인 타겟의 지원되는 트레이싱 옵션을 전달한다.
+    자세한 내용은 *AGENT* 을 참고한다. 
 
 RECORD 옵션
 ==============
@@ -113,10 +120,6 @@ RECORD 옵션
 :   주어진 FUNC 함수에 대해 동적 패치를 적용하지 않는다.
     이 옵션은 한번 이상 쓰일 수 있다.
     관련 설명은 *DYNAMIC TRACING* 을 참고한다.
-
--Z *SIZE*, \--size-filter=*SIZE*
-:   SIZE 바이트보다 큰 함수들을 동적으로 패치한다.
-    동적추적에 대해서는 *DYNAMIC TRACING* 을 참고한다.
 
 -E *EVENT*, \--event=*EVENT*
 :   이벤트 추적을 활성화한다.  시스템 내에서 사용 가능한 이벤트여야 한다.
@@ -233,6 +236,9 @@ RECORD 설정 옵션
 :   ASLR(Address Space Layout Randomization)을 비활성화 한다.
     이는 프로세스의 라이브러리 로딩 주소가 매번 변경되지 않도록 막아준다.
 
+-g, \--agent
+:   타겟에 있는 agent 쓰레드를 생성한다. 실행되는 동안 agent는 바깥의 명령어를 수용하고
+    지원된 트레이싱 옵션을 변경할 수 있다. 자세한 내용은 *AGENT*를 참고한다. 
 
 REPLAY 옵션
 ==============
@@ -263,6 +269,9 @@ REPLAY 옵션
 
 \--libname
 :   함수 이름과 함께 라이브러리 이름을 출력한다.
+
+\--no-args
+:   함수의 인자와 반환 값을 보이지 않도록 한다.
 
 
 공통 분석 옵션

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -196,7 +196,7 @@ extern uint64_t mcount_threshold; /* nsec */
 extern unsigned mcount_minsize;
 extern pthread_key_t mtd_key;
 extern int shmem_bufsize;
-extern int mcount_pfd;
+extern int pfd;
 extern int mcount_depth;
 extern char *mcount_exename;
 extern int page_size_in_kb;
@@ -317,11 +317,11 @@ extern void uftrace_send_message(int type, void *data, size_t len);
 extern void build_debug_domain(char *dbg_domain_str);
 
 extern void mcount_rstack_restore(struct mcount_thread_data *mtdp);
-extern void mcount_rstack_rehook(struct mcount_thread_data *mtdp);
-extern void mcount_rstack_rehook_exception(struct mcount_thread_data *mtdp,
-					   unsigned long frame_addr);
+extern void mcount_rstack_reset(struct mcount_thread_data *mtdp);
+extern void mcount_rstack_reset_exception(struct mcount_thread_data *mtdp,
+					  unsigned long frame_addr);
 extern void mcount_auto_restore(struct mcount_thread_data *mtdp);
-extern void mcount_auto_rehook(struct mcount_thread_data *mtdp);
+extern void mcount_auto_reset(struct mcount_thread_data *mtdp);
 extern bool mcount_rstack_has_plthook(struct mcount_thread_data *mtdp);
 
 extern void prepare_shmem_buffer(struct mcount_thread_data *mtdp);

--- a/libmcount/misc.c
+++ b/libmcount/misc.c
@@ -76,13 +76,13 @@ void uftrace_send_message(int type, void *data, size_t len)
 		},
 	};
 
-	if (mcount_pfd < 0)
+	if (pfd < 0)
 		return;
 
 	len += sizeof(msg);
-	if (writev(mcount_pfd, iov, 2) != (ssize_t)len) {
+	if (writev(pfd, iov, 2) != (ssize_t)len) {
 		if (!mcount_should_stop())
-			pr_err("send msg (type %d) failed", type);
+			pr_err("writing shmem name to pipe");
 	}
 }
 
@@ -190,7 +190,7 @@ last_rstack:
 }
 
 /* hook return address again (used after mcount_rstack_restore) */
-void mcount_rstack_rehook(struct mcount_thread_data *mtdp)
+void mcount_rstack_reset(struct mcount_thread_data *mtdp)
 {
 	int idx;
 	struct mcount_ret_stack *rstack;
@@ -244,7 +244,7 @@ void mcount_auto_restore(struct mcount_thread_data *mtdp)
 	}
 }
 
-void mcount_auto_rehook(struct mcount_thread_data *mtdp)
+void mcount_auto_reset(struct mcount_thread_data *mtdp)
 {
 	struct mcount_ret_stack *curr_rstack;
 	struct mcount_ret_stack *prev_rstack;

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -948,7 +948,7 @@ static unsigned long __plthook_entry(unsigned long *ret_addr, unsigned long chil
 			    strcmp(pd->mod_name, mcount_exename)) {
 				*ret_addr = rstack->parent_ip;
 				if (mcount_auto_recover)
-					mcount_auto_rehook(mtdp);
+					mcount_auto_reset(mtdp);
 
 				/*
 				 * as its return address was recovered,
@@ -1078,7 +1078,7 @@ again:
 
 	/* re-hijack return address of parent */
 	if (mcount_auto_recover)
-		mcount_auto_rehook(mtdp);
+		mcount_auto_reset(mtdp);
 
 	__mcount_unguard_recursion(mtdp);
 

--- a/libmcount/wrap.c
+++ b/libmcount/wrap.c
@@ -56,14 +56,14 @@ static void send_dlopen_msg(struct mcount_thread_data *mtdp, const char *sess_id
 	};
 	int len = sizeof(msg) + msg.len;
 
-	if (mcount_pfd < 0)
+	if (pfd < 0)
 		return;
 
 	mcount_memcpy4(dlop.sid, sess_id, sizeof(dlop.sid));
 
-	if (writev(mcount_pfd, iov, 3) != len) {
+	if (writev(pfd, iov, 3) != len) {
 		if (!mcount_should_stop())
-			pr_err("send dlopen msg failed");
+			pr_err("write tid info failed");
 	}
 }
 
@@ -93,7 +93,7 @@ static int dlopen_base_callback(struct dl_phdr_info *info, size_t size, void *ar
 	return 0;
 }
 
-void mcount_rstack_rehook_exception(struct mcount_thread_data *mtdp, unsigned long frame_addr)
+void mcount_rstack_reset_exception(struct mcount_thread_data *mtdp, unsigned long frame_addr)
 {
 	int idx;
 	struct mcount_ret_stack *rstack;
@@ -148,7 +148,7 @@ void mcount_rstack_rehook_exception(struct mcount_thread_data *mtdp, unsigned lo
 	mtdp->idx = idx + 1;
 	pr_dbg3("%s: exception returned to [%d]\n", __func__, mtdp->idx);
 
-	mcount_rstack_rehook(mtdp);
+	mcount_rstack_reset(mtdp);
 }
 
 static char **collect_uftrace_envp(void)
@@ -305,7 +305,7 @@ __visible_default int backtrace(void **buffer, int sz)
 	ret = real_backtrace(buffer, sz);
 
 	if (!check_thread_data(mtdp))
-		mcount_rstack_rehook(mtdp);
+		mcount_rstack_reset(mtdp);
 
 	return ret;
 }
@@ -326,7 +326,7 @@ __visible_default void __cxa_throw(void *exception, void *type, void *dest)
 		/*
 		 * restore return addresses so that it can unwind stack
 		 * frames safely during the exception handling.
-		 * It pairs to mcount_rstack_rehook_exception().
+		 * It pairs to mcount_rstack_reset_exception().
 		 */
 		mcount_rstack_restore(mtdp);
 	}
@@ -350,7 +350,7 @@ __visible_default void __cxa_rethrow(void)
 		/*
 		 * restore return addresses so that it can unwind stack
 		 * frames safely during the exception handling.
-		 * It pairs to mcount_rstack_rehook_exception()
+		 * It pairs to mcount_rstack_reset_exception()
 		 */
 		mcount_rstack_restore(mtdp);
 	}
@@ -374,7 +374,7 @@ __visible_default void _Unwind_Resume(void *exception)
 		/*
 		 * restore return addresses so that it can unwind stack
 		 * frames safely during the exception handling.
-		 * It pairs to mcount_rstack_rehook_exception().
+		 * It pairs to mcount_rstack_reset_exception().
 		 */
 		mcount_rstack_restore(mtdp);
 	}
@@ -404,7 +404,7 @@ __visible_default void *__cxa_begin_catch(void *exception)
 		if (frame_addr < (unsigned long)frame_ptr)
 			frame_addr = (unsigned long)frame_ptr;
 
-		mcount_rstack_rehook_exception(mtdp, frame_addr);
+		mcount_rstack_reset_exception(mtdp, frame_addr);
 		mtdp->in_exception = false;
 		pr_dbg2("%s: exception caught begin on [%d]\n", __func__, mtdp->idx);
 	}
@@ -443,7 +443,7 @@ __visible_default void __cxa_guard_abort(void *guard_obj)
 		if (frame_addr < (unsigned long)frame_ptr)
 			frame_addr = (unsigned long)frame_ptr;
 
-		mcount_rstack_rehook_exception(mtdp, frame_addr);
+		mcount_rstack_reset_exception(mtdp, frame_addr);
 		mtdp->in_exception = false;
 
 		/*
@@ -615,7 +615,7 @@ __visible_default int close(int fd)
 	if (unlikely(real_close == NULL))
 		mcount_hook_functions();
 
-	if (unlikely(fd == mcount_pfd)) {
+	if (unlikely(fd == pfd)) {
 		return 0;
 	}
 


### PR DESCRIPTION
These four missing options are translated and added to 'uftrace-live.md'

1. public options, --trace = `STATE`
2. LIVE options, -p *PID*, \--pid=*PID*
3. RECORD config options, -g, \--agent
4. REPLAY options, --no-args