### PR TITLE
doc/ko: Add missing option in uftrace-record.md

### DIFF
--- a/doc/ko/uftrace-record.md
+++ b/doc/ko/uftrace-record.md
@@ -231,6 +231,11 @@ RECORD 설정 옵션
 :   ASLR(Address Space Layout Randomization)을 비활성화 한다.
     이는 프로세스의 라이브러리 로딩 주소가 매번 변경되지 않도록 막아준다.
 
+-g, \--agent
+:   대상에서 agent thread을 시작한다.
+    런타임에 agent는 외부 커멘드를 받아 지원되는 tracing 옵션을 바꿀 수 있다.
+    관련 설명은 `utfrace-live`(1)에서 *AGENT* 부분을 참고한다.
+
 \--srcline
 :   디버그 정보에 레코드한 소스 줄번호를 표시한다.
 

--- a/doc/ko/uftrace-record.md
+++ b/doc/ko/uftrace-record.md
@@ -175,6 +175,10 @@ RECORD 옵션
 :   추적을 사용하지 않은 채로 uftrace를 시작한다. 이것은 `trace_on` 트리거와 함께
     사용되었을 때만 의미를 가진다.
 
+\--trace=*STATE*
+:   uftrace tracing을 STATE로 지정한다. 가능한 상태는 `on`과 `off`이다. 기본은 `on`이다.
+    이것은 `trace_on` 트리거와 함께 사용되거나 agent와 사용되었을 때만 의미를 가진다.
+
 \--with-syms=*DIR*
 :   DIR 디렉토리의 .sym 파일에서 심볼(symbol) 데이터를 읽는다.
     이는 심볼(symbol) 데이터가 제거된 바이너리 파일을 다루는데 유용하다.


### PR DESCRIPTION
The missing option '-g, \--agent' is translated and added to uftrace-record.md in Korean