### PR TITLE
Improve/Amend bash completion feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ libdir = $(prefix)/lib/uftrace
 etcdir = $(prefix)/etc
 mandir = $(prefix)/share/man
 docdir = $(srcdir)/doc
-completiondir = $(etcdir)/bash_completion.d
+completiondir = $(compldir)
 
 ifeq ($(DOCLANG), ko)
   docdir = $(srcdir)/doc/ko

--- a/configure
+++ b/configure
@@ -146,6 +146,17 @@ libdir=${libdir:-${prefix}/lib/uftrace}
 etcdir=${etcdir:-${prefix}/etc}
 mandir=${mandir:-${prefix}/share/man}
 
+if [ -z "$compldir" ]; then
+    if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists bash-completion; then
+        compldir=$(pkg-config --variable=completionsdir bash-completion)
+        if [[ "$compldir" == /usr/share/* ]] && [ "$prefix" != "/usr" ]; then
+            compldir="${prefix}/share/bash-completion/completions"
+        fi
+    else
+        compldir=${prefix}/share/bash-completion/completions
+    fi
+fi
+
 if [ "$etcdir" = /usr/etc ]; then
     etcdir=/etc
 fi
@@ -280,6 +291,7 @@ override bindir := $bindir
 override libdir := $libdir
 override mandir := $mandir
 override etcdir := $etcdir
+override compldir := $compldir
 EOF
 
 if [ ! -z $with_elfutils ]; then


### PR DESCRIPTION
This PR improves and modifies previously non-operational bash completion capabilities.

Apply the patch from @mug896 to improve the bash completion script and reset the path based on pkg-config to ensure it works correctly.



<a href="https://asciinema.org/a/khbCurz95CaFPxyImIR7CmE1Q" target="_blank"><img src="https://asciinema.org/a/khbCurz95CaFPxyImIR7CmE1Q.svg" /></a>




The bash completion works correctly even when installed with the prefix as follows.

```
$ configure --prefix=<prefix_dir>
$ make
$ make install
```

For your information, the bash completion feature does not apply immediately after the installation, 
but apply immediately after `source` or after terminal is refreshed.

```
source /usr/share/bash-completion/completions/uftrace
```