### PR TITLE
dump: Handle cycles in graphviz

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -1258,8 +1258,9 @@ static void print_graph_to_graphviz(struct uftrace_graph_node *node, struct uftr
 {
 	struct uftrace_graph_node *child;
 	unsigned long n_calls = node->nr_calls;
+	bool skip = node->skip;
 
-	if (n_calls) {
+	if (n_calls && !skip) {
 		struct uftrace_graph_node *parent = node->parent;
 
 		pr_out("    ");

--- a/utils/graph.h
+++ b/utils/graph.h
@@ -17,6 +17,7 @@ struct uftrace_graph_node {
 	uint64_t time;
 	uint64_t child_time;
 	uint32_t id;
+	bool skip;
 	struct list_head head;
 	struct list_head list;
 	struct uftrace_graph_node *parent;


### PR DESCRIPTION
These commits include skipping the recursive calls during the dump of graphviz, and correctly adding number of calls of the skipped entries to the initial recursive call.

Fixed: #1500 