### PR TITLE
dump: Handle cycles in graphviz

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -1258,8 +1258,9 @@ static void print_graph_to_graphviz(struct uftrace_graph_node *node, struct uftr
 {
 	struct uftrace_graph_node *child;
 	unsigned long n_calls = node->nr_calls;
+	bool skip = node->skip;
 
-	if (n_calls) {
+	if (n_calls && !skip) {
 		struct uftrace_graph_node *parent = node->parent;
 
 		pr_out("    ");

--- a/utils/graph.c
+++ b/utils/graph.c
@@ -145,7 +145,7 @@ static int add_graph_entry(struct uftrace_task_graph *tg, char *name, size_t nod
 
 out:
 	node->nr_calls++;
-	if (skip) {
+	if (skip && recursive_src) {
 		list_for_each_entry(add_calls_tgt, &recursive_src->head, list) {
 			if (name && !strcmp(name, add_calls_tgt->name))
 				break;

--- a/utils/graph.c
+++ b/utils/graph.c
@@ -82,7 +82,7 @@ static int add_graph_entry(struct uftrace_task_graph *tg, char *name, size_t nod
 		return -1;
 
 	if (name) {
-		if (curr && curr->parent) {
+		if (curr && curr->name && curr->parent && curr->parent->name) {
 			skip = !strcmp(name, curr->name) && !strcmp(name, curr->parent->name);
 		}
 

--- a/utils/graph.c
+++ b/utils/graph.c
@@ -61,6 +61,7 @@ static int add_graph_entry(struct uftrace_task_graph *tg, char *name, size_t nod
 {
 	struct uftrace_graph_node *node = NULL;
 	struct uftrace_graph_node *curr = tg->node;
+	struct uftrace_graph_node *search_curr = NULL;
 	struct uftrace_graph_node *recursive_src = NULL;
 	struct uftrace_graph_node *add_calls_tgt = NULL;
 	struct uftrace_fstack *fstack;
@@ -85,13 +86,13 @@ static int add_graph_entry(struct uftrace_task_graph *tg, char *name, size_t nod
 			skip = !strcmp(name, curr->name) && !strcmp(name, curr->parent->name);
 		}
 
-		while (curr && !strcmp(name, curr->name)) {
-			recursive_src = curr;
-			curr = curr->parent;
+		search_curr = curr;
+		while (search_curr && search_curr->name && !strcmp(name, search_curr->name)) {
+			recursive_src = search_curr;
+			search_curr = search_curr->parent;
 		}
 	}
 
-	curr = tg->node;
 	list_for_each_entry(node, &curr->head, list) {
 		if (name && !strcmp(name, node->name))
 			break;

--- a/utils/graph.h
+++ b/utils/graph.h
@@ -17,6 +17,7 @@ struct uftrace_graph_node {
 	uint64_t time;
 	uint64_t child_time;
 	uint32_t id;
+	bool skip;
 	struct list_head head;
 	struct list_head list;
 	struct uftrace_graph_node *parent;


### PR DESCRIPTION
These commits include skipping the recursive calls during the dump of graphviz, and correctly adding number of calls of the skipped entries to the initial recursive call.

Fixed: #1500 