### PR TITLE
Release v0.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.16
+VERSION := 0.17
 
 # Makefiles suck: This macro sets a default value of $(2) for the
 # variable named by $(1), unless the variable has been set by

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,20 @@
+uftrace v0.17
+=============
+* New features
+  Support watchpoint for global variables (#661)
+  Show man pages for the given command (#1316)
+  Add utc_offset in the header info (#1916)
+
+* Bug fixes
+  Show arguments in libraries from dlopen (#842, #1981)
+  Save debug info for libraries from dlopen (#1312)
+  Protect FD of communication channel from being closed
+
+And many other fixes and improvements.  Thanks all contributors:
+  Daehyun Kim, Honggyu Kim, Kang Minchul, Michelle Jin, Rongsong Shen,
+  Seunghyeok Park, Sin Sohi, Yunseong Kim, zyxeeker
+
+
 uftrace v0.16
 =============
 * New features


### PR DESCRIPTION
I'd like to release a new version (v0.17).  Please check out the current version and run the test on your environment.

This is a small release including the following changes.

* global variable watchpoint support
* argument/return value and srcline support for dlopen libraries
* show man page of current command when -h option is used