### PR TITLE
symbol: Fix uninitialized 'sec_iter' in the 'arch_load_dynsymtab_noplt'

### DIFF
--- a/arch/x86_64/symbol.c
+++ b/arch/x86_64/symbol.c
@@ -20,7 +20,7 @@
 int arch_load_dynsymtab_noplt(struct uftrace_symtab *dsymtab, struct uftrace_elf_data *elf,
 			      unsigned long offset, unsigned long flags)
 {
-	struct uftrace_elf_iter sec_iter;
+	struct uftrace_elf_iter sec_iter = {};
 	struct uftrace_elf_iter rel_iter;
 	struct uftrace_elf_iter sym_iter;
 	unsigned grow = SYMTAB_GROW;


### PR DESCRIPTION
The `struct uftrace_elf_iter sec_iter` is being used without initialization, and only specific values are being copied. This can lead to unexpected behavior in the copied other iters.
```
SUMMARY: MemorySanitizer: use-of-uninitialized-value
 arch/x86_64/symbol.c:33:14 in arch_load_dynsymtab_noplt
Exiting
==2474640==WARNING: MemorySanitizer: use-of-uninitialized-value ==2474525==WARNING: MemorySanitizer: use-of-uninitialized-value ==2474780==WARNING: MemorySanitizer: use-of-uninitialized-value
 0 0x55985b0a1f46 in arch_load_dynsymtab_noplt arch/x86_64/symbol.c:33
 1 0x55985b0792f7 in load_dynsymtab utils/symbol.c:726:2
 2 0x55985b05bb30 in load_module_symbol utils/symbol.c:1111:2
 3 0x55985b05a3fe in load_module_symtab utils/symbol.c:1144:2
 4 0x55985b05db5f in load_module_symtabs utils/symbol.c:1220:14
 5 0x55985adb5b34 in load_session_symbols cmds/record.c:1482:3
 6 0x55985ada6e0e in write_symbol_files cmds/record.c:2036:2
 7 0x55985ad923d1 in do_main_loop cmds/record.c:2142:2
 8 0x55985ad8ce9a in command_record cmds/record.c:2311:9
 9 0x55985acf190a in main uftrace.c:1534:9
 ```