### PR TITLE
record: Add shmem directory to exec permission

### DIFF
--- a/cmds/record.c
+++ b/cmds/record.c
@@ -833,7 +833,7 @@ static void record_mmap_file(const char *dirname, char *sess_id, int bufsize)
 	struct mcount_shmem_buffer *shmem_buf;
 
 	/* write (append) it to disk */
-	fd = uftrace_shmem_open(sess_id, O_RDWR, 0600);
+	fd = uftrace_shmem_open(sess_id, O_RDWR, UFTRACE_SHMEM_PERMISSION_MODE);
 	if (fd < 0) {
 		pr_dbg("open shmem buffer failed: %s: %m\n", sess_id);
 		return;

--- a/libmcount/record.c
+++ b/libmcount/record.c
@@ -34,7 +34,7 @@ static struct mcount_shmem_buffer *allocate_shmem_buffer(char *sess_id, size_t s
 
 	snprintf(sess_id, size, SHMEM_SESSION_FMT, mcount_session_name(), tid, idx);
 
-	fd = uftrace_shmem_open(sess_id, O_RDWR | O_CREAT | O_TRUNC, 0600);
+	fd = uftrace_shmem_open(sess_id, O_RDWR | O_CREAT | O_TRUNC, UFTRACE_SHMEM_PERMISSION_MODE);
 	if (fd < 0) {
 		saved_errno = errno;
 		pr_dbg("failed to open shmem buffer: %s\n", sess_id);

--- a/python/trace-python.c
+++ b/python/trace-python.c
@@ -221,7 +221,8 @@ static void init_symtab(void)
 {
 	snprintf(uftrace_shmem_name, sizeof(uftrace_shmem_name), "/uftrace-python-%d", getpid());
 
-	uftrace_shmem_fd = uftrace_shmem_open(uftrace_shmem_name, O_RDWR | O_CREAT | O_TRUNC, 0600);
+	uftrace_shmem_fd = uftrace_shmem_open(uftrace_shmem_name, O_RDWR | O_CREAT | O_TRUNC,
+					      UFTRACE_SHMEM_PERMISSION_MODE);
 	if (uftrace_shmem_fd < 0)
 		pr_err("failed to open shared memory for %s", uftrace_shmem_name);
 
@@ -340,8 +341,8 @@ static void init_dbginfo(void)
 	snprintf(uftrace_shmem_dbg_name, sizeof(uftrace_shmem_dbg_name), "/uftrace-python-dbg-%d",
 		 getpid());
 
-	uftrace_shmem_dbg_fd =
-		uftrace_shmem_open(uftrace_shmem_dbg_name, O_RDWR | O_CREAT | O_TRUNC, 0600);
+	uftrace_shmem_dbg_fd = uftrace_shmem_open(
+		uftrace_shmem_dbg_name, O_RDWR | O_CREAT | O_TRUNC, UFTRACE_SHMEM_PERMISSION_MODE);
 	if (uftrace_shmem_dbg_fd < 0)
 		pr_err("failed to open shared memory for %s", uftrace_shmem_dbg_name);
 

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -51,6 +51,8 @@
 #define NSEC_PER_SEC 1000000000
 #define NSEC_PER_MSEC 1000000
 
+#define UFTRACE_SHMEM_PERMISSION_MODE 0700
+
 #define BUG_REPORT_MSG "Please report this bug to https://github.com/namhyung/uftrace/issues.\n\n"
 
 extern int debug;


### PR DESCRIPTION
The shmem directory under TMPDIR is used to store named pipe for communication.  Since the named pipe is created under the created 'uftrace' directory, the 'uftrace' directory has to have an exec permission so that named pipe files can be created inside it.

This patch fixes the problem by adding exec permission for 'uftrace' directory creation.

Before:
```
  $ uftrace record --force pwd
  mcount: /data/data/com.termux/files/home/uftrace/libmcount/record.c:81:prepare_shmem_buffer
   ERROR: mmap shmem buffer: Permission denied
```
After:
```
  $ uftrace record --force pwd
  /data/data/com.termux/files/home/uftrace
```