### PR TITLE
test: exclude system_initialize_function in t295 and t296 using filter option

### DIFF
--- a/tests/t295_graph_field_total.py
+++ b/tests/t295_graph_field_total.py
@@ -11,10 +11,6 @@ class TestCase(TestBase):
 ========== FUNCTION CALL GRAPH ==========
 # TOTAL AVG   TOTAL MAX  TOTAL MIN   FUNCTION
    11.725 ms   11.725 ms   11.725 ms : (1) t-sort
-  161.125 us  161.125 us  161.125 us :  +-(1) __monstartup
-                                     :  |
-    0.625 us    0.625 us    0.625 us :  +-(1) __cxa_atexit
-                                     :  |
    11.563 ms   11.563 ms   11.563 ms :  +-(1) main
    28.875 us   47.958 us    9.792 us :     +-(2) foo
     8.736 us   36.625 us    3.125 us :     | (6) loop
@@ -29,7 +25,7 @@ class TestCase(TestBase):
 
     def setup(self):
         self.subcmd = 'graph'
-        self.option = '-f total-avg,total-max,total-min'
+        self.option = '-F main -f total-avg,total-max,total-min'
         self.exearg = ''
 
     def sort(self, output):
@@ -70,10 +66,6 @@ class TestCase(TestBase):
 
                 func_match = re.search(r'\(\d+\)\s+(\S+)', ln)
                 func_name = func_match.group(1) if func_match else 'UNKNOWN'
-
-                #system initializing function is not needed for same comparison
-                if func_name in ('__monstartup','__cxa_atexit'):
-                    continue
 
                 # Functions that are executed only once – compare if times are the same
                 if call_count == 1:

--- a/tests/t296_graph_field_self.py
+++ b/tests/t296_graph_field_self.py
@@ -11,10 +11,6 @@ class TestCase(TestBase):
 ========== FUNCTION CALL GRAPH ==========
 # SELF AVG   SELF MAX   SELF MIN    FUNCTION
                                      : (1) t-sort
-  161.125 us  161.125 us  161.125 us :  +-(1) __monstartup
-                                     :  |
-    0.625 us    0.625 us    0.625 us :  +-(1) __cxa_atexit
-                                     :  |
    69.166 us   69.166 us   69.166 us :  +-(1) main
     2.666 us    4.958 us    0.375 us :     +-(2) foo
     8.736 us   36.625 us    3.125 us :     | (6) loop
@@ -29,7 +25,7 @@ class TestCase(TestBase):
 
     def setup(self):
         self.subcmd = 'graph'
-        self.option = '-f self-avg,self-max,self-min'
+        self.option = '-F main -f self-avg,self-max,self-min'
         self.exearg = ''
 
     def sort(self, output):
@@ -70,10 +66,6 @@ class TestCase(TestBase):
 
                 func_match = re.search(r'\(\d+\)\s+(\S+)', ln)
                 func_name = func_match.group(1) if func_match else 'UNKNOWN'
-
-                #system initializing function is not needed for same comparison
-                if func_name in ('__monstartup','__cxa_atexit'):
-                    continue
 
                 # Functions that are executed only once – compare if times are the same
                 if call_count == 1:


### PR DESCRIPTION
Previously, t295 and t296 excluded system_initialize_function
 by filtering its name in the test logic.

This change moves that logic to use the Filter option instead,
 making the exclusion cleaner and more consistent.
```
 ========== FUNCTION CALL GRAPH ==========
    TOTAL AVG   TOTAL MAX   TOTAL MIN   FUNCTION
    10.758 ms   10.758 ms   10.758 ms : (1) t-sort
    10.758 ms   10.758 ms   10.758 ms : (1) main
   139.750 us  262.084 us   17.416 us :  +-(2) foo
    10.305 us   31.875 us    5.083 us :  | (6) loop
                                      :  |
    10.357 ms   10.357 ms   10.357 ms :  +-(1) bar
    10.172 ms   10.172 ms   10.172 ms :    (1) usleep
```
```
 $ make -j 8 test TESTARG=graph_field

 Running 0 test cases
 ======================

 unit test stats
 ====================
   0 ran successfully
   0 failed
   0 skipped
   0 signal caught
   0 unknown result

   TEST     test_all
 Start 2 tests with 2 worker

 Compiler                  gcc
 Runtime test case         pg             finstrument-fu fpatchable-fun
 ------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os
 295 graph_field_total   : OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK
 296 graph_field_self    : OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK
```