### PR TITLE
tests: Fix s-thread.c and s-exp-mixed.c tests from clang

### DIFF
--- a/tests/s-exp-mixed.c
+++ b/tests/s-exp-mixed.c
@@ -7,6 +7,9 @@ double mixed_add(int a, float b)
 	return a + b;
 }
 
+#if __clang__
+__attribute__((optnone))
+#endif
 long mixed_sub(void *a, unsigned long b)
 {
 	return (long)a - b;

--- a/tests/s-thread.c
+++ b/tests/s-thread.c
@@ -21,7 +21,11 @@ static int b(void *arg)
 	return c(arg) + 1;
 }
 
-static int c(void *arg)
+#if __clang__
+__attribute__((optnone))
+#endif
+static int
+c(void *arg)
 {
 	return *(int *)arg;
 }


### PR DESCRIPTION
Clang optimization can inline some functions unexpectedly even when -fno-inline is given.  This happenes when clang decides some simple functions as a target of constant folding and it ignores -fno-inline as a result for s-thread.c example.

The same issue was also previously fixed at the commmit below.

  f2ac933e tests: Fix 051 return test when using clang

One more similar fix is that `mixed_sub()` of s-exp-mixed.c is renamed as `mixed_sub.specialized.1()` by clang optimization.

To handle those issues, this patch disables clang optimization for some functions explicitly.

Before:
```
  $ ./runtest.py -c clang '003|049|176|244|084|085'
  Compiler                  clang
  Runtime test case         pg             finstrument-fu fpatchable-fun
  ------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os
  003 thread              : OK OK OK NG OK OK OK OK OK OK OK OK OK NG OK
  049 column_view         : OK OK OK NG OK OK OK OK OK OK OK OK OK NG OK
  084 arg_mixed           : OK NG NG NG OK SK SK SK SK SK OK NG NG NG OK
  085 arg_reg             : OK NG NG NG OK SK SK SK SK SK OK NG NG NG OK
  176 arg_fptr            : OK OK OK NG OK OK OK OK OK OK OK OK OK NG OK
  244 report_task_field   : OK OK OK NG OK OK OK OK OK OK OK OK OK NG OK
```
After:
```
  $ ./runtest.py -c clang '003|049|176|244|084|085'
  Compiler                  clang
  Runtime test case         pg             finstrument-fu fpatchable-fun
  ------------------------: O0 O1 O2 O3 Os O0 O1 O2 O3 Os O0 O1 O2 O3 Os
  003 thread              : OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK
  049 column_view         : OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK
  084 arg_mixed           : OK OK OK OK OK SK SK SK SK SK OK OK OK OK OK
  085 arg_reg             : OK OK OK OK OK SK SK SK SK SK OK OK OK OK OK
  176 arg_fptr            : OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK
  244 report_task_field   : OK OK OK OK OK OK OK OK OK OK OK OK OK OK OK
```