### PR TITLE
filter: add time-based trace filter option

### DIFF
--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -47,6 +47,14 @@
  * when no filter is specified in the command line and/or single-thread only.
  */
 
+struct {
+	uint64_t start_ns;
+	uint64_t end_ns;
+	bool enabled;
+} mcount_time_filter = { 0, 0, false };
+
+uint64_t mcount_global_timer;
+
 /* time filter in nsec */
 uint64_t mcount_threshold;
 
@@ -1495,6 +1503,43 @@ void mcount_rstack_inject_return(struct mcount_thread_data *mtdp, unsigned long 
 	mcount_save_filter(mtdp);
 }
 
+static void start_mcount_timer(void)
+{
+	struct timespec ts;
+
+	if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1) {
+		return;
+	}
+
+	mcount_global_timer = (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+}
+
+static uint64_t mcount_global_timer_gettime(void)
+{
+	struct timespec now_ts;
+	uint64_t current_time_ns;
+
+	clock_gettime(CLOCK_MONOTONIC, &now_ts);
+
+	current_time_ns = (uint64_t)now_ts.tv_sec * 1000000000ULL + now_ts.tv_nsec;
+
+	return current_time_ns - mcount_global_timer;
+}
+
+static void check_time_range_tracing(void)
+{
+	if (unlikely(mcount_time_filter.enabled)) {
+		uint64_t now = mcount_global_timer_gettime();
+
+		if (now >= mcount_time_filter.start_ns && now < mcount_time_filter.end_ns) {
+			mcount_enabled = true;
+		}
+		else {
+			mcount_enabled = false;
+		}
+	}
+}
+
 static int __mcount_entry(unsigned long *parent_loc, unsigned long child, struct mcount_regs *regs)
 {
 	enum filter_result filtered;
@@ -1521,6 +1566,9 @@ static int __mcount_entry(unsigned long *parent_loc, unsigned long child, struct
 		mcount_unguard_recursion(mtdp);
 		return -1;
 	}
+
+	/*if using --trace=time~time check to entry */
+	check_time_range_tracing();
 
 	if (unlikely(mtdp->in_exception)) {
 		unsigned long frame_addr;
@@ -1658,6 +1706,9 @@ static int __cygprof_entry(unsigned long parent, unsigned long child)
 	}
 
 	filtered = mcount_entry_filter_check(mtdp, child, &tr, NULL);
+
+	/*if using --trace=time~time check to entry */
+	check_time_range_tracing();
 
 	if (unlikely(mtdp->in_exception)) {
 		unsigned long *frame_ptr;
@@ -1805,6 +1856,9 @@ static void _xray_entry(unsigned long parent, unsigned long child, struct mcount
 	}
 
 	filtered = mcount_entry_filter_check(mtdp, child, &tr, NULL);
+
+	/*if using --trace=time~time check to entry */
+	check_time_range_tracing();
 
 	if (unlikely(mtdp->in_exception)) {
 		unsigned long *frame_ptr;
@@ -1997,6 +2051,7 @@ static __used void mcount_startup(void)
 	char *pattern_str;
 	char *clock_str;
 	char *symdir_str;
+	char *time_filter_str;
 	struct stat statbuf;
 	bool nest_libcall;
 
@@ -2027,6 +2082,7 @@ static __used void mcount_startup(void)
 	pattern_str = getenv("UFTRACE_PATTERN");
 	clock_str = getenv("UFTRACE_CLOCK");
 	symdir_str = getenv("UFTRACE_SYMBOL_DIR");
+	time_filter_str = getenv("UFTRACE_TIME_FILTER");
 
 	page_size_in_kb = getpagesize() / KB;
 
@@ -2112,6 +2168,27 @@ static __used void mcount_startup(void)
 	if (event_str)
 		mcount_setup_events(dirname, event_str, mcount_filter_setting.ptype);
 
+	if (time_filter_str) {
+		char *start_str = time_filter_str;
+		char *end_str = strchr(time_filter_str, '~');
+		uint64_t end_val = -1;
+
+		if (end_str) {
+			*end_str++ = '\0';
+			if (*end_str != '\0') {
+				end_val = parse_time(end_str, 3);
+			}
+		}
+
+		mcount_time_filter.start_ns = parse_time(start_str, 3);
+		mcount_time_filter.end_ns = end_val;
+		mcount_time_filter.enabled = true;
+
+		if (mcount_time_filter.start_ns > 0) {
+			mcount_enabled = false;
+		}
+	}
+
 	if (getenv("UFTRACE_KERNEL_PID_UPDATE"))
 		kernel_pid_update = true;
 
@@ -2139,6 +2216,8 @@ static __used void mcount_startup(void)
 
 	compiler_barrier();
 	pr_dbg("mcount setup done\n");
+
+	start_mcount_timer();
 
 	mcount_global_flags &= ~MCOUNT_GFL_SETUP;
 	mtd.recursion_marker = false;

--- a/uftrace.c
+++ b/uftrace.c
@@ -878,6 +878,9 @@ static int parse_option(struct uftrace_opts *opts, int key, char *arg)
 			opts->trace = TRACE_STATE_ON;
 		else if (!strcmp(arg, "off"))
 			opts->trace = TRACE_STATE_OFF;
+		else if (strchr(arg, '~')) {
+			setenv("UFTRACE_TIME_FILTER", arg, 1);
+		}
 		else
 			pr_use("unknown tracing state: %s (ignoring..)\n", arg);
 		break;


### PR DESCRIPTION
Add global time filter to start and stop tracing
based on elapsed time since program start.

To handle running time added mcount_global_timer
and if option is existing every entry points
check the time range.

This filter can be simply used like this

$ uftrace --trace=time~time ./prog

