### PR TITLE
dump: Add UTC offset to Chrome trace format

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -879,6 +879,16 @@ static void dump_chrome_task_rstack(struct uftrace_dump_ops *ops, struct uftrace
 	size_t len = sizeof(name_buf) - 1;
 	size_t i;
 	struct uftrace_dbg_loc *loc = NULL;
+	uint64_t timestamp;
+	static uint64_t utc_offset_ns = 0;
+
+	/* Initialize the UTC offset */
+	if (utc_offset_ns == 0 && task->h->info.utc_offset) {
+		long offset_sec = strtol(task->h->info.utc_offset, NULL, 10);
+		utc_offset_ns = (uint64_t)offset_sec * 1000000000ULL;
+	}
+
+	timestamp = frs->time + utc_offset_ns;
 
 	if (chrome->opts && chrome->opts->srcline) {
 		loc = task_find_loc_addr(&task->h->sessions, task, frs->time, frs->addr);
@@ -917,12 +927,12 @@ static void dump_chrome_task_rstack(struct uftrace_dump_ops *ops, struct uftrace
 		if (is_process) {
 			/* no need to add "tid" field */
 			pr_out("{\"ts\":%" PRIu64 ".%03d,\"ph\":\"%c\",\"pid\":%d,\"name\":\"%s\"",
-			       frs->time / 1000, (int)(frs->time % 1000), ph, task->tid, name_buf);
+			       timestamp / 1000, (int)(timestamp % 1000), ph, task->tid, name_buf);
 		}
 		else {
 			pr_out("{\"ts\":%" PRIu64
 			       ".%03d,\"ph\":\"%c\",\"pid\":%d,\"tid\":%d,\"name\":\"%s\"",
-			       frs->time / 1000, (int)(frs->time % 1000), ph, task->t->pid,
+			       timestamp / 1000, (int)(timestamp % 1000), ph, task->t->pid,
 			       task->tid, name_buf);
 		}
 
@@ -952,12 +962,12 @@ static void dump_chrome_task_rstack(struct uftrace_dump_ops *ops, struct uftrace
 		if (is_process) {
 			/* no need to add "tid" field */
 			pr_out("{\"ts\":%" PRIu64 ".%03d,\"ph\":\"%c\",\"pid\":%d,\"name\":\"%s\"",
-			       frs->time / 1000, (int)(frs->time % 1000), ph, task->tid, name_buf);
+			       timestamp / 1000, (int)(timestamp % 1000), ph, task->tid, name_buf);
 		}
 		else {
 			pr_out("{\"ts\":%" PRIu64
 			       ".%03d,\"ph\":\"%c\",\"pid\":%d,\"tid\":%d,\"name\":\"%s\"",
-			       frs->time / 1000, (int)(frs->time % 1000), ph, task->t->pid,
+			       timestamp / 1000, (int)(timestamp % 1000), ph, task->t->pid,
 			       task->tid, name_buf);
 		}
 


### PR DESCRIPTION
## Description

This PR adds support for UTC-adjusted timestamps in Chrome trace format output. Before, when using `uftrace dump --chrome`, the timestamps are based on monotonic clock values, which start from an arbitrary point (appearing as timestamps from 1970 when converted to dates). This makes it challenging to correlate trace events with actual wall-clock time (e.g., manually correlating with kernel traces from LTTng or perf).

With this change, we can now get timestamps that represent actual UTC time. The implementation uses the existing UTC offset information already stored in uftrace metadata (in #1923).

## Usage

### Record a trace
   ```bash
   uftrace record ./program
   ```

### Dump to a Chrome JSON file
   ```bash
   uftrace dump --chrome > trace_utc.json
   # timestamps should represent actual wall-clock time
   ```
```json
[
   {
      "ts":1759035568795552.450,
      "ph":"B",
      "pid":4003,
      "name":"main"
   },
   {
      "ts":1759035568795561.123,
      "ph":"B",
      "pid":4003,
      "name":"sqlite3_sourceid"
   },
   {
      "ts":1759035568795561.262,
      "ph":"E",
      "pid":4003,
      "name":"sqlite3_sourceid"
   },
   {
      "ts":1759035568795857.122,
      "ph":"B",
      "pid":4003,
      "name":"cli_strncmp"
   },
   {
      "ts":1759035568795857.745,
      "ph":"E",
      "pid":4003,
      "name":"cli_strncmp"
   },
   {
      "ts":1759035568795858.157,
      "ph":"B",
      "pid":4003,
      "name":"main_init"
   },
...
]
```