### PR TITLE
live: Use $TMPDIR environment variable for temporary directory

### DIFF
--- a/cmds/live.c
+++ b/cmds/live.c
@@ -14,9 +14,8 @@
 #include "utils/utils.h"
 
 #define LIVE_NAME "uftrace-live-XXXXXX"
-#define TMP_LIVE_NAME "/tmp/" LIVE_NAME
 
-#define TMP_DIR_NAME_SIZE 32
+#define TMP_DIR_NAME_SIZE 256
 
 static char tmp_dirname[TMP_DIR_NAME_SIZE];
 static void cleanup_tempdir(void)
@@ -428,7 +427,9 @@ int command_live(int argc, char *argv[], struct uftrace_opts *opts)
 	int ret;
 
 	if (!opts->record) {
-		snprintf(tmp_dirname, sizeof(tmp_dirname), "%s", TMP_LIVE_NAME);
+		const char *tmpdir = getenv("TMPDIR") ?: "/tmp";
+
+		snprintf(tmp_dirname, sizeof(tmp_dirname), "%s/" LIVE_NAME, tmpdir);
 		umask(022);
 		fd = mkstemp(tmp_dirname);
 		if (fd < 0) {


### PR DESCRIPTION
The temporary directory for live tracing was hardcoded to /tmp, ignoring the $TMPDIR environment variable that POSIX specifies for this purpose.

On Termux (Android), /tmp does not exist and $TMPDIR points to the correct writable location, so the hardcoded path caused uftrace live to fail entirely in that environment as follows.
```
  $ uftrace --force -v pwd
  uftrace: running uftrace v0.19 ( aarch64 dwarf perf sched )
  uftrace: /data/data/com.termux/files/home/work/uftrace/cmds/live.c:436:command_live
   ERROR: cannot access to /tmp/uftrace-live-iwJ0v2: Permission denied
```
This change reads $TMPDIR at runtime and falls back to /tmp if it is unset, and increases the path buffer from 32 to 256 bytes to accommodate longer directory paths.