### PR TITLE
report: Support --format=csv option

### DIFF
--- a/cmds/report.c
+++ b/cmds/report.c
@@ -26,6 +26,44 @@ static void print_field(struct uftrace_report_node *node, int space)
 	print_field_data(&output_fields, &fd, space);
 }
 
+static bool print_csv_field(struct uftrace_report_node *node)
+{
+	struct field_data fd = {
+		.arg = node,
+	};
+	struct display_field *field;
+	bool first = true;
+
+	if (list_empty(&output_fields))
+		return false;
+
+	list_for_each_entry(field, &output_fields, list) {
+		pr_out("%s", first ? "" : ",");
+		field->print(&fd);
+		first = false;
+	}
+
+	return true;
+}
+
+static void print_csv_header(const char *postfix)
+{
+	struct display_field *field;
+	bool first = true;
+
+	if (list_empty(&output_fields)) {
+		pr_out("#%s\n", postfix);
+		return;
+	}
+
+	list_for_each_entry(field, &output_fields, list) {
+		pr_out("%s%s", first ? "#" : ",", field->header);
+		first = false;
+	}
+
+	pr_out(",%s\n", postfix);
+}
+
 static void insert_node(struct rb_root *root, struct uftrace_task_reader *task, char *symname,
 			struct uftrace_dbg_loc *loc)
 {
@@ -233,6 +271,19 @@ static void print_function(struct uftrace_report_node *node, void *unused, int s
 	pr_out("\n");
 }
 
+static void print_function_csv(struct uftrace_report_node *node, void *unused, int space)
+{
+	if (print_csv_field(node))
+		pr_out(",%s", node->name);
+	else
+		pr_out("%s", node->name);
+
+	if (node->loc)
+		pr_out(" [%s:%d]", node->loc->file->name, node->loc->line);
+
+	pr_out("\n");
+}
+
 static void print_line(struct list_head *output_fields, int space)
 {
 	struct display_field *field;
@@ -265,6 +316,12 @@ static void report_functions(struct uftrace_data *handle, struct uftrace_opts *o
 		return;
 
 	setup_report_field(&output_fields, opts, avg_mode);
+
+	if (format_mode == FORMAT_CSV) {
+		print_csv_header("Function");
+		print_and_delete(&sort_root, true, NULL, print_function_csv, field_space);
+		return;
+	}
 
 	print_header_align(&output_fields, "  ", "Function", field_space, ALIGN_RIGHT, false);
 	if (!list_empty(&output_fields)) {
@@ -364,6 +421,21 @@ static void print_task(struct uftrace_report_node *node, void *arg, int space)
 	pr_out("%-*s\n", TASK_COMM_LEN, t->comm);
 }
 
+static void print_task_csv(struct uftrace_report_node *node, void *arg, int space)
+{
+	int pid;
+	struct uftrace_task *t;
+	struct uftrace_data *handle = arg;
+
+	pid = strtol(node->name, NULL, 10);
+	t = find_task(&handle->sessions, pid);
+
+	if (print_csv_field(node))
+		pr_out(",%s\n", t->comm);
+	else
+		pr_out("%s\n", t->comm);
+}
+
 static void report_task(struct uftrace_data *handle, struct uftrace_opts *opts)
 {
 	struct uftrace_record *rstack;
@@ -415,6 +487,12 @@ static void report_task(struct uftrace_data *handle, struct uftrace_opts *opts)
 	report_sort_tasks(handle, &task_tree, &sort_tree);
 
 	setup_report_field(&output_fields, opts, avg_mode);
+
+	if (format_mode == FORMAT_CSV) {
+		print_csv_header("Task name");
+		print_and_delete(&sort_tree, true, handle, print_task_csv, field_space);
+		return;
+	}
 
 	print_header_align(&output_fields, "  ", "Task name", field_space, ALIGN_RIGHT, true);
 
@@ -469,6 +547,12 @@ static void report_diff(struct uftrace_data *handle, struct uftrace_opts *opts)
 	pr_out("#\n");
 
 	setup_report_field(&output_fields, opts, avg_mode);
+
+	if (format_mode == FORMAT_CSV) {
+		print_csv_header("Function");
+		print_and_delete(&diff_tree, true, NULL, print_function_csv, field_space);
+		goto out;
+	}
 
 	print_header_align(&output_fields, "  ", "Function", field_space, ALIGN_RIGHT, false);
 	if (!list_empty(&output_fields)) {

--- a/doc/uftrace-report.md
+++ b/doc/uftrace-report.md
@@ -84,7 +84,7 @@ REPORT OPTIONS
 :   Show source location of each function if available.
 
 \--format=*TYPE*
-:   Show format style output. Currently, normal and html styles are supported.
+:   Show format style output. Currently, normal, html and csv styles are supported.
 
 
 COMMON OPTIONS

--- a/tests/t302_report_csv.py
+++ b/tests/t302_report_csv.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+from runtest import TestBase
+
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'sort', """
+#Total time,Self time,Calls,Function
+10184916,73343,1,main
+10081112,24541,1,bar
+10056571,10056571,1,usleep
+30461,1020,2,foo
+29441,29441,6,loop
+""")
+
+    def prepare(self):
+        self.subcmd = 'record'
+        self.option = '-F main'
+        return self.runcmd()
+
+    def setup(self):
+        self.subcmd = 'report'
+        self.option = '--format=csv'
+
+    def sort(self, output):
+        result = []
+
+        for ln in output.split('\n'):
+            if ln.strip() == '' or ln.startswith('#'):
+                continue
+
+            if ln.count(',') != 3:
+                return 'invalid csv field count'
+
+            line = [item.strip() for item in ln.split(',')]
+            result.append('%s %s' % (line[2], line[3]))
+
+        return '\n'.join(result)

--- a/uftrace.c
+++ b/uftrace.c
@@ -158,7 +158,7 @@ __used static const char uftrace_help[] =
 "      --flame-graph          Dump recorded data in FlameGraph format\n"
 "      --flat                 Use flat output format\n"
 "      --force                Trace even if executable is not instrumented\n"
-"      --format=FORMAT        Use FORMAT for output: normal, html (default: normal)\n"
+"      --format=FORMAT        Use FORMAT for output: normal, html, csv (default: normal)\n"
 "  -f, --output-fields=FIELD  Show FIELDs in the replay or graph output\n"
 "  -F, --filter=FUNC          Only trace those FUNCs\n"
 "  -g  --agent                Start an agent in mcount to listen to commands\n"
@@ -947,6 +947,9 @@ static int parse_option(struct uftrace_opts *opts, int key, char *arg)
 			format_mode = FORMAT_HTML;
 			if (opts->color == COLOR_AUTO)
 				opts->color = COLOR_ON;
+		}
+		else if (!strcmp(arg, "csv")) {
+			format_mode = FORMAT_CSV;
 		}
 		else {
 			pr_use("invalid format argument: %s\n", arg);

--- a/utils/report.c
+++ b/utils/report.c
@@ -788,7 +788,10 @@ void report_sort_tasks(struct uftrace_data *handle, struct rb_root *name_root,
 	static void print_##_func(struct field_data *fd)                                           \
 	{                                                                                          \
 		struct uftrace_report_node *node = fd->arg;                                        \
-		print_time_unit(node->_field);                                                     \
+		if (format_mode == FORMAT_CSV)                                                     \
+			pr_out("%" PRIu64, node->_field);                                          \
+		else                                                                               \
+			print_time_unit(node->_field);                                             \
 	}                                                                                          \
 	FIELD_STRUCT(_id, _name, _func, _header, 10)
 
@@ -804,7 +807,10 @@ void report_sort_tasks(struct uftrace_data *handle, struct rb_root *name_root,
 	static void print_##_func(struct field_data *fd)                                           \
 	{                                                                                          \
 		struct uftrace_report_node *node = fd->arg;                                        \
-		pr_out("%10" PRIu64 "", node->_field);                                             \
+		if (format_mode == FORMAT_CSV)                                                     \
+			pr_out("%" PRIu64, node->_field);                                          \
+		else                                                                               \
+			pr_out("%10" PRIu64 "", node->_field);                                     \
 	}                                                                                          \
 	FIELD_STRUCT(_id, _name, _func, _header, 10)
 
@@ -812,7 +818,10 @@ void report_sort_tasks(struct uftrace_data *handle, struct rb_root *name_root,
 	static void print_##_func(struct field_data *fd)                                           \
 	{                                                                                          \
 		struct uftrace_report_node *node = fd->arg;                                        \
-		pr_out("%9.2f%%", node->_field);                                                   \
+		if (format_mode == FORMAT_CSV)                                                     \
+			pr_out("%.2f", node->_field);                                              \
+		else                                                                               \
+			pr_out("%9.2f%%", node->_field);                                           \
 	}                                                                                          \
 	FIELD_STRUCT(_id, _name, _func, _header, 10)
 

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -98,6 +98,7 @@ enum color_setting {
 enum format_mode {
 	FORMAT_NORMAL,
 	FORMAT_HTML,
+	FORMAT_CSV,
 };
 
 #define COLOR_CODE_NORMAL '.'


### PR DESCRIPTION
report: Support --format=csv option

Add the --format=csv option to print CSV output.

```
Example:
  $ gcc -pg -o abc tests/s-abc.c
  $ uftrace record ./abc
  $ uftrace report --format=csv
  #Total time,Self time,Calls,Function
  1450,210,1,main
  1240,170,1,a
  1070,230,1,b
  840,450,1,c
  600,600,1,__monstartup
  390,390,1,getpid
  180,180,1,__cxa_atexit
```