### PR TITLE
demangle,session: Fix compiler warnings

### DIFF
--- a/utils/demangle.h
+++ b/utils/demangle.h
@@ -145,7 +145,7 @@ static inline int dd_append_len(struct demangle_data *dd, const char *str, int s
 	}
 
 	/* copy including the last NUL byte (but usually not) */
-	strncpy(&dd->new[dd->newpos], str, size + 1);
+	memcpy(&dd->new[dd->newpos], str, size + 1);
 	dd->newpos += size;
 	dd->new[dd->newpos] = '\0';
 

--- a/utils/session.c
+++ b/utils/session.c
@@ -1301,8 +1301,6 @@ TEST_CASE(session_map_build_id)
 TEST_CASE(session_autoarg_dlopen)
 {
 	struct uftrace_session *sess;
-	struct uftrace_filter *filter;
-	struct uftrace_trigger tr = {};
 	struct uftrace_record rec = {
 		.time = 234,
 		.addr = 0x7003456,
@@ -1370,13 +1368,18 @@ TEST_CASE(session_autoarg_dlopen)
 	session_setup_dlopen_argspec(sess, &setting, true);
 
 #ifdef HAVE_LIBDW
-	pr_dbg("try to find a filter for the dlopen address\n");
-	filter = session_find_filter(sess, &rec, &tr);
+	{
+		struct uftrace_filter *filter;
+		struct uftrace_trigger tr = {};
 
-	TEST_NE(filter, NULL);
-	TEST_EQ(filter->trigger.flags, TRIGGER_FL_ARGUMENT | TRIGGER_FL_RETVAL);
-	TEST_NE(filter->trigger.pargs, NULL);
-	TEST_STREQ(filter->name, "foo");
+		pr_dbg("try to find a filter for the dlopen address\n");
+		filter = session_find_filter(sess, &rec, &tr);
+
+		TEST_NE(filter, NULL);
+		TEST_EQ(filter->trigger.flags, TRIGGER_FL_ARGUMENT | TRIGGER_FL_RETVAL);
+		TEST_NE(filter->trigger.pargs, NULL);
+		TEST_STREQ(filter->name, "foo");
+	}
 #endif /* HAVE_LIBDW */
 
 	delete_sessions(&test_sessions);


### PR DESCRIPTION
While building uftrace after the recent patches, I noticed several compiler warnings.
This patch addresses these issues to ensure a cleaner build process and prevent potential side effects.

```bash
  CC       utils/kernel-parser.ot
In file included from /uftrace/utils/demangle.c:46:
In function ‘dd_append_len’,
    inlined from ‘dd_ctor_dtor_name’ at /uftrace/utils/demangle.c:1224:2:
/uftrace/utils/demangle.h:148:9: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-truncation]
  148 |         strncpy(&dd->new[dd->newpos], str, size + 1);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/uftrace/utils/demangle.c: In function ‘dd_ctor_dtor_name’:
/uftrace/utils/demangle.c:1217:15: note: length computed here
 1217 |         len = strlen(pos);
      |               ^~~~~~~~~~~
  CC       utils/pager.ot
  CC       utils/perf.ot

  CC       utils/session.ot
  CC       utils/shmem.ot
/uftrace/utils/session.c: In function ‘func_session_autoarg_dlopen’:
/uftrace/utils/session.c:1305:32: warning: unused variable ‘tr’ [-Wunused-variable]
 1305 |         struct uftrace_trigger tr = {};
      |                                ^~
/uftrace/utils/session.c:1304:32: warning: unused variable ‘filter’ [-Wunused-variable]
 1304 |         struct uftrace_filter *filter;
      |                                ^~~~~~
  CC       utils/socket.ot
  CC       utils/symbol.ot
```

After this patch in Rocky9
```bash
[root@localhost uftrace]# git switch build_warn_fix0420
branch 'build_warn_fix0420' set up to track 'origin/build_warn_fix0420'.
Switched to a new branch 'build_warn_fix0420'
[root@localhost uftrace]# ls
arch             COPYING     Makefile          python     uftrace.c
check-deps       doc         Makefile.include  README.md  uftrace-gdb.py
cmds             gdb         misc              scripts    uftrace.h
configure        INSTALL.md  NEWS              tests      utils
CONTRIBUTING.md  libmcount   pyproject.toml    TODO
[root@localhost uftrace]# ./configure
uftrace detected system features:
...         prefix: /usr/local
...         libelf: [ on  ] - more flexible ELF data handling
...          libdw: [ OFF ] - DWARF debug info support
...      libpython: [ OFF ] - python tracing & scripting support
...      libluajit: [ OFF ] - luajit scripting support
...    libncursesw: [ on  ] - TUI support
...   cxa_demangle: [ on  ] - full demangler support with libstdc++
...     perf_event: [ on  ] - perf (PMU) event support
...       schedule: [ on  ] - scheduler event support
...       capstone: [ on  ] - full dynamic tracing support
...  libtraceevent: [ on  ] - kernel tracing support
...      libunwind: [ OFF ] - stacktrace support (optional for debugging)
[root@localhost uftrace]# make -j 8
  GEN      version.h
  GEN      utils/mermaid.js.cstr
  GEN      utils/mermaid.html.cstr
  CC       cmds/graph.o
  CC       cmds/info.o
  CC       cmds/live.o
  CC       cmds/record.o
  CC       cmds/recv.o
  CC       cmds/replay.o
  CC       cmds/report.o
  CC       cmds/script.o
  CC       cmds/tui.o
  CC       utils/argspec.o
  CC       utils/auto-args.o
  CC       utils/data-file.o
  CC       utils/debug.o
  CC       utils/demangle.o
  CC       utils/demangle-rust.o
  CC       utils/dwarf.o
  CC       utils/event.o
  CC       utils/extern.o
  CC       utils/field.o
  CC       utils/filter.o
  CC       utils/fstack.o
  CC       utils/graph.o
  CC       utils/hashmap.o
  CC       utils/kernel.o
  CC       utils/kernel-parser.o
  CC       utils/pager.o
  CC       utils/perf.o
  CC       utils/rbtree.o
  CC       utils/regs.o
  CC       utils/report.o
  CC       utils/script.o
  CC       utils/script-luajit.o
  CC       utils/script-python.o
  CC       utils/session.o
  CC       utils/shmem.o
  CC       utils/socket.o
  CC       utils/symbol.o
  CC       utils/symbol-libelf.o
  CC       utils/symbol-rawelf.o
  CC       utils/tracefs.o
  CC       utils/utils.o
  CC       arch/aarch64/cpuinfo.o
  CC       arch/aarch64/common.o
  CC FPIC  libmcount/agent.op
  CC FPIC  libmcount/dynamic.op
  AR       arch/aarch64/uftrace-arch.a
  CC FPIC  libmcount/event.op
  CC FPIC  libmcount/mcount.op
  CC FPIC  libmcount/misc.op
  CC FPIC  libmcount/plthook.op
  CC FPIC  libmcount/pmu.op
  CC FPIC  libmcount/record.op
  CC FPIC  libmcount/wrap.op
  CC FPIC  libmcount/debug.op
  CC FPIC  libmcount/regs.op
  CC FPIC  libmcount/rbtree.op
  CC FPIC  libmcount/filter.op
  CC FPIC  libmcount/shmem.op
  CC FPIC  libmcount/utils.op
  CC FPIC  libmcount/script.op
  CC FPIC  libmcount/script-python.op
  CC FPIC  libmcount/script-luajit.op
  CC FPIC  libmcount/auto-args.op
  CC FPIC  libmcount/dwarf.op
  CC FPIC  libmcount/hashmap.op
  CC FPIC  libmcount/argspec.op
  CC FPIC  libmcount/tracefs.op
  CC FPIC  libmcount/socket.op
  CC FPIC  libmcount/demangle.op
  CC FPIC  libmcount/demangle-rust.op
  CC FPIC  libmcount/symbol.op
  CC FPIC  libmcount/symbol-libelf.op
  CC FPIC  libmcount/symbol-rawelf.op
  ASM      arch/aarch64/dynamic.op
  ASM      arch/aarch64/fentry.op
  ASM      arch/aarch64/mcount.op
  ASM      arch/aarch64/plthook.op
  CC FPIC  arch/aarch64/mcount-dynamic.op
  CC FPIC  libmcount/agent-fast.op
  CC FPIC  arch/aarch64/mcount-insn.op
  CC FPIC  arch/aarch64/mcount-support.op
  CC FPIC  libmcount/dynamic-fast.op
  CC FPIC  arch/aarch64/common.op
  CC FPIC  libmcount/event-fast.op
  AR       arch/aarch64/mcount-arch.a
  CC FPIC  libmcount/mcount-fast.op
  CC FPIC  libmcount/misc-fast.op
  CC FPIC  libmcount/plthook-fast.op
  CC FPIC  libmcount/pmu-fast.op
  CC FPIC  libmcount/record-fast.op
  CC FPIC  libmcount/wrap-fast.op
  CC FPIC  libmcount/agent-single.op
  CC FPIC  libmcount/dynamic-single.op
  CC FPIC  libmcount/event-single.op
  CC FPIC  libmcount/mcount-single.op
  CC FPIC  libmcount/misc-single.op
  CC FPIC  libmcount/plthook-single.op
  CC FPIC  libmcount/pmu-single.op
  CC FPIC  libmcount/record-single.op
  CC FPIC  libmcount/wrap-single.op
  CC FPIC  libmcount/agent-fast-single.op
  CC FPIC  libmcount/dynamic-fast-single.op
  CC FPIC  libmcount/event-fast-single.op
  CC FPIC  libmcount/mcount-fast-single.op
  CC FPIC  libmcount/misc-fast-single.op
  CC FPIC  libmcount/plthook-fast-single.op
  CC FPIC  libmcount/pmu-fast-single.op
  CC FPIC  libmcount/record-fast-single.op
  CC FPIC  libmcount/wrap-fast-single.op
  CC FPIC  libmcount/mcount-nop.op
  CC       misc/demangler.o
  CC       misc/symbols.o
  CC       misc/dbginfo.o
  CC       uftrace.o
  CC       cmds/dump.o
  LINK     libmcount/libmcount.so
  LINK     libmcount/libmcount-fast.so
  LINK     libmcount/libmcount-single.so
  LINK     libmcount/libmcount-fast-single.so
  LINK     libmcount/libmcount-nop.so
  LINK     misc/demangler
  LINK     misc/symbols
  LINK     misc/dbginfo
  LINK     uftrace
[root@localhost uftrace]#
```