### PR TITLE
github: Fix exit code of nightly check_commits step

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -16,7 +16,12 @@ jobs:
       - id: should_run
         name: "check lateset version is less than a day"
         if: ${{ github.event_name == 'schedule' }}
-        run: test -z $(git rev-list --after 1day ${{ github.sha }}) && echo "should_run=false" >> $GITHUB_OUTPUT
+        env:
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          if [ -z "$(git rev-list --after=1day "$HEAD_SHA")" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
 
   run-uftrace-tests:
     needs: check_commits


### PR DESCRIPTION
After the nightly workflow was changed to skip when no commits were merged to master, the check step returned a non-zero exit code in the "commits exist" case and caused the run to fail instead of proceeding to the tests.  Rewrite it as a plain 'if' so the step always exits cleanly and only sets should_run=false when there really are no recent commits.