### PR TITLE
replay: Show callsite location with --srcline

### DIFF
--- a/cmds/info.c
+++ b/cmds/info.c
@@ -480,11 +480,11 @@ static int fill_taskinfo(void *arg)
 		.root = RB_ROOT,
 		.tasks = RB_ROOT,
 	};
+	char *dir = fha->opts->dirname;
 	int i;
 
-	if (read_task_txt_file(&link, fha->opts->dirname, fha->opts->dirname, false, false, false) <
-		    0 &&
-	    read_task_file(&link, fha->opts->dirname, false, false, false) < 0)
+	if (read_task_txt_file(&link, dir, dir, false, false, false, false) < 0 &&
+	    read_task_file(&link, dir, false, false, false, false) < 0)
 		return -1;
 
 	walk_tasks(&link, build_tid_list, &tlist);
@@ -1140,7 +1140,7 @@ void process_uftrace_info(struct uftrace_data *handle, struct uftrace_opts *opts
 
 		/* ignore errors */
 		read_task_txt_file(&handle->sessions, opts->dirname, opts->dirname, false, false,
-				   false);
+				   false, false);
 
 		process(data, "# %-20s: %d\n", "number of tasks", nr);
 
@@ -1401,7 +1401,7 @@ int command_info(int argc, char *argv[], struct uftrace_opts *opts)
 	if (opts->show_task) {
 		/* ignore errors */
 		read_task_txt_file(&handle.sessions, opts->dirname, opts->dirname, false, false,
-				   false);
+				   false, false);
 
 		if (handle.hdr.feat_mask & PERF_EVENT) {
 			if (setup_perf_data(&handle) == 0)

--- a/cmds/record.c
+++ b/cmds/record.c
@@ -431,6 +431,9 @@ static uint64_t calc_feat_mask(struct uftrace_opts *opts)
 	globfree(&g);
 	free(buf);
 
+	if (opts->trigger && strstr(opts->trigger, "callsite"))
+		features |= CALLSITE;
+
 	return features;
 }
 

--- a/cmds/replay.c
+++ b/cmds/replay.c
@@ -731,6 +731,38 @@ next:
 	}
 }
 
+/*
+ * Fallback for the @callsite trigger when DWARF info isn't available:
+ * format the address as "symbol+offset" using the ELF symbol table.
+ * Returns a pointer to @buf on success, NULL when no symbol matches.
+ */
+static const char *format_callsite_symbol(struct uftrace_session_link *sessions,
+					  struct uftrace_task_reader *task, uint64_t time,
+					  uint64_t addr, char *buf, size_t bufsize)
+{
+	struct uftrace_session *sess;
+	struct uftrace_mmap *map;
+	struct uftrace_symbol *sym;
+	uint64_t mod_addr;
+
+	sess = find_task_session(sessions, task->t, time);
+	if (sess == NULL)
+		return NULL;
+
+	map = find_map(&sess->sym_info, addr);
+	if (map == NULL || map->mod == NULL)
+		return NULL;
+
+	mod_addr = addr - map->start;
+	sym = find_sym(&map->mod->symtab, mod_addr);
+	if (sym == NULL)
+		return NULL;
+
+	snprintf(buf, bufsize, "%s+%#lx", sym->name, (unsigned long)(mod_addr - sym->addr));
+	buf[bufsize - 1] = '\0';
+	return buf;
+}
+
 static int print_graph_rstack(struct uftrace_data *handle, struct uftrace_task_reader *task,
 			      struct uftrace_opts *opts)
 {
@@ -781,11 +813,40 @@ static int print_graph_rstack(struct uftrace_data *handle, struct uftrace_task_r
 		}
 	}
 
-	if (opts->srcline) {
-		loc = task_find_loc_addr(sessions, task, rstack->time, rstack->addr);
-		if (opts->comment && loc)
+	if (opts->comment) {
+		struct uftrace_dbg_loc csloc;
+		char cs_buf[128];
+		const char *cs_str = NULL;
+
+		if (opts->srcline)
+			loc = task_find_loc_addr(sessions, task, rstack->time, rstack->addr);
+
+		if (opts->callsite && rstack->type == UFTRACE_ENTRY && task->callsite_ip) {
+			if (task_find_exact_loc_addr(sessions, task, rstack->time,
+						     task->callsite_ip, &csloc)) {
+				snprintf(cs_buf, sizeof(cs_buf), "%s:%d", csloc.file->name,
+					 csloc.line);
+				cs_buf[sizeof(cs_buf) - 1] = '\0';
+				cs_str = cs_buf;
+			}
+			else {
+				/* fallback to function+offset when no dwarf info */
+				cs_str = format_callsite_symbol(sessions, task, rstack->time,
+								task->callsite_ip, cs_buf,
+								sizeof(cs_buf));
+			}
+		}
+
+		if (loc && cs_str)
+			xasprintf(&str_loc, "%s:%d from %s", loc->file->name, loc->line, cs_str);
+		else if (loc)
 			xasprintf(&str_loc, "%s:%d", loc->file->name, loc->line);
+		else if (cs_str)
+			xasprintf(&str_loc, "from %s", cs_str);
 	}
+
+	if (rstack->type == UFTRACE_ENTRY)
+		task->callsite_ip = 0;
 
 	if (rstack->type == UFTRACE_ENTRY) {
 		struct uftrace_task_reader *next = NULL;
@@ -944,6 +1005,13 @@ lost:
 		struct uftrace_task_reader *next = NULL;
 		struct uftrace_record rec = *rstack;
 		uint64_t evt_id = rstack->addr;
+
+		/* stash callsite return address for the next ENTRY to consume */
+		if (evt_id == EVENT_ID_CALLSITE) {
+			if (task->args.data && task->args.len >= sizeof(uint64_t))
+				memcpy(&task->callsite_ip, task->args.data, sizeof(uint64_t));
+			goto out;
+		}
 
 		depth = task->display_depth;
 

--- a/doc/uftrace-live.md
+++ b/doc/uftrace-live.md
@@ -537,8 +537,8 @@ The BNF for trigger specification is as follows:
     <actions>    :=  <action>  | <action> "," <actions>
     <action>     :=  "depth="<num> | "backtrace" | "trace" | "trace_on" | "trace_off" |
                      "recover" | "color="<color> | "time="<time_spec> | "read="<read_spec> |
-                     "finish" | "filter" | "notrace" | "hide" | "clear" [ "="<clear_spec> ] |
-		     "if:"<cond_spec>
+                     "callsite" | "finish" | "filter" | "notrace" | "hide" |
+                     "clear" [ "="<clear_spec> ] | "if:"<cond_spec>
     <time_spec>  :=  <num> [ <time_unit> ]
     <time_unit>  :=  "ns" | "nsec" | "us" | "usec" | "ms" | "msec" | "s" | "sec" | "m" | "min"
     <read_spec>  :=  "proc/statm" | "page-fault" | "pmu-cycle" | "pmu-cache" | "pmu-branch"
@@ -609,6 +609,27 @@ The results are printed as events (comments) like below.
                 [ 1234] |     /* diff:proc/statm (size=+4KB, rss=+0KB, shared=+0KB) */
       18.380 us [ 1234] |   } /* a */
       19.537 us [ 1234] | } /* main */
+
+The `callsite` trigger records the return address of the matching function
+call so that the replay output can show where the function was called from.
+The trigger automatically saves debug info too, so a separate `--srcline`
+is not required and the call site is shown by default like below.
+
+    $ uftrace -T 'a@callsite' ./abc
+    # DURATION     TID     FUNCTION
+                [ 1234] | main() {
+                [ 1234] |   a() { /* from tests/s-abc.c:33 */
+                [ 1234] |     b() {
+                ...
+
+Combine it with `--srcline` to also show the callee's definition line:
+
+    $ uftrace -T 'a@callsite' --srcline ./abc
+                [ 1234] |   a() { /* tests/s-abc.c:11 from tests/s-abc.c:33 */
+
+The call site display can be suppressed with `--no-callsite` at replay
+time.  The reported line itself comes from the compiler's dwarf line
+program and is shown as-is.
 
 The `finish` trigger is to end recording.  The process can still run, which
 can be useful to trace non-terminating processes like daemon.

--- a/doc/uftrace-record.md
+++ b/doc/uftrace-record.md
@@ -459,7 +459,7 @@ The BNF for trigger specification is as follows:
     <actions>    :=  <action>  | <action> "," <actions>
     <action>     :=  "depth="<num> | "trace" | "trace_on" | "trace_off" |
                      "time="<time_spec> | "size="<num> | "read="<read_spec> |
-                     "finish" | "filter" | "notrace" | "recover"
+                     "finish" | "filter" | "notrace" | "recover" | "callsite" |
                      "filter" | "notrace" | "recover" | "if:"<cond_spec>
     <time_unit>  :=  "ns" | "nsec" | "us" | "usec" | "ms" | "msec" | "s" | "sec" | "m" | "min"
     <read_spec>  :=  "proc/statm" | "page-fault" | "pmu-cycle" | "pmu-cache" | "pmu-branch"
@@ -524,6 +524,29 @@ The results are printed as events (comments) like below.
 
 The 'finish' trigger is to end recording.  The process still can run and this
 can be useful to trace unterminated processes like daemon.
+
+The 'callsite' trigger records the return address of the matching function
+call so that the replay command can show where the function was called from.
+The trigger automatically saves debug info too, so a separate `--srcline`
+is not required at record time and `uftrace replay` shows the call site by
+default like below.
+
+    $ uftrace record -T 'a@callsite' ./abc
+    $ uftrace replay
+    # DURATION     TID     FUNCTION
+                [ 1234] | main() {
+                [ 1234] |   a() { /* from tests/s-abc.c:33 */
+                [ 1234] |     b() {
+                ...
+
+Combine it with `--srcline` to also show the callee's definition line:
+
+    $ uftrace replay --srcline
+                [ 1234] |   a() { /* tests/s-abc.c:11 from tests/s-abc.c:33 */
+
+The call site display can be suppressed with `--no-callsite` at replay
+time.  The reported line itself comes from the compiler's dwarf line
+program and is shown as-is.
 
 The 'filter' and 'notrace' triggers have same effect as `-F`/`--filter` and
 `-N`/`--notrace` options respectively.  And it can have a condition.

--- a/doc/uftrace-replay.md
+++ b/doc/uftrace-replay.md
@@ -49,7 +49,14 @@ REPLAY OPTIONS
 :   Show libname name along with function name.
 
 \--srcline
-:   Show source location of each function if available.
+:   Show source location (definition line) of each function if available.
+
+\--no-callsite
+:   Do not show the call site location of each function.  Call site info
+    is normally shown by default when the function was recorded with the
+    `callsite` trigger (see *TRIGGERS* in `uftrace-record`(1)).  It is
+    shown as `/* from file.c:33 */`, or combined with `--srcline` as
+    `/* file.c:11 from file.c:33 */`.
 
 \--format=*TYPE*
 :   Select the output format.  Supported values are `normal` (default) and `html`.

--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -435,6 +435,7 @@ extern void save_argument(struct mcount_thread_data *mtdp, struct mcount_ret_sta
 void save_retval(struct mcount_thread_data *mtdp, struct mcount_ret_stack *rstack, long *retval);
 void save_trigger_read(struct mcount_thread_data *mtdp, struct mcount_ret_stack *rstack,
 		       enum trigger_read_type type, bool diff);
+void save_callsite_event(struct mcount_thread_data *mtdp, struct mcount_ret_stack *rstack);
 struct uftrace_triggers_info *mcount_trigger_init(struct uftrace_filter_setting *filter_setting);
 #endif /* DISABLE_MCOUNT_FILTER */
 

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -414,6 +414,10 @@ struct uftrace_triggers_info *mcount_trigger_init(struct uftrace_filter_setting 
 	if (getenv("UFTRACE_SRCLINE"))
 		needs_debug_info = true;
 
+	/* @callsite trigger needs dwarf info to resolve callsite addresses */
+	if (trigger_str && strstr(trigger_str, "callsite"))
+		needs_debug_info = true;
+
 	/* use debug info if available */
 	if (needs_debug_info) {
 		prepare_debug_info(&mcount_sym_info, filter_setting->ptype, argument_str,
@@ -1247,6 +1251,8 @@ void mcount_entry_filter_record(struct mcount_thread_data *mtdp, struct mcount_r
 				save_trigger_read(mtdp, rstack, tr->read, false);
 				rstack->flags |= MCOUNT_FL_READ;
 			}
+			if (tr->flags & TRIGGER_FL_CALLSITE)
+				save_callsite_event(mtdp, rstack);
 			if (mcount_watchpoints)
 				save_watchpoint(mtdp, rstack, mcount_watchpoints);
 

--- a/libmcount/record.c
+++ b/libmcount/record.c
@@ -821,6 +821,27 @@ void save_watchpoint(struct mcount_thread_data *mtdp, struct mcount_ret_stack *r
 	}
 }
 
+void save_callsite_event(struct mcount_thread_data *mtdp, struct mcount_ret_stack *rstack)
+{
+	struct mcount_event *event;
+	uint64_t timestamp = rstack->start_time;
+	uint64_t callsite = rstack->parent_ip;
+
+	if (mtdp->nr_events >= MAX_EVENT)
+		return;
+
+	/* place event before the entry record */
+	timestamp -= 1;
+
+	event = &mtdp->event[mtdp->nr_events++];
+	event->id = EVENT_ID_CALLSITE;
+	event->time = timestamp;
+	event->idx = rstack - mtdp->rstack;
+	event->dsize = sizeof(callsite);
+
+	mcount_memcpy1(event->data, &callsite, sizeof(callsite));
+}
+
 #else
 /*
  * These are for fast libmcount libraries without filters.
@@ -842,6 +863,10 @@ void save_trigger_read(struct mcount_thread_data *mtdp, struct mcount_ret_stack 
 
 void save_watchpoint(struct mcount_thread_data *mtdp, struct mcount_ret_stack *rstack,
 		     unsigned long watchpoints)
+{
+}
+
+void save_callsite_event(struct mcount_thread_data *mtdp, struct mcount_ret_stack *rstack)
 {
 }
 

--- a/misc/symbols.c
+++ b/misc/symbols.c
@@ -140,7 +140,8 @@ static int read_sessions(struct uftrace_session_link *link, char *dirname)
 			smsg.task.time = (uint64_t)sec * NSEC_PER_SEC + nsec;
 			smsg.namelen = strlen(exename);
 
-			create_session(link, &smsg, dirname, dirname, exename, true, true, false);
+			create_session(link, &smsg, dirname, dirname, exename, true, true, false,
+				       false);
 			count++;
 		}
 		else if (!strncmp(line, "DLOP", 4)) {
@@ -162,7 +163,8 @@ static int read_sessions(struct uftrace_session_link *link, char *dirname)
 			dlop.namelen = strlen(exename);
 
 			s = get_session_from_sid(link, dlop.sid);
-			session_add_dlopen(s, dlop.task.time, dlop.base_addr, exename, false);
+			session_add_dlopen(s, dlop.task.time, dlop.base_addr, exename, false,
+					   false);
 		}
 	}
 

--- a/tests/t305_replay_callsite.py
+++ b/tests/t305_replay_callsite.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import re
+
+from runtest import TestBase
+
+class TestCase(TestBase):
+    def __init__(self):
+        TestBase.__init__(self, 'abc', """
+# DURATION     TID     FUNCTION [SOURCE]
+   0.234 us [ 19939] | __cxa_atexit();
+            [ 19939] | main() {
+            [ 19939] |   a() { /* from s-abc.c:N */
+            [ 19939] |     b() { /* from s-abc.c:N */
+            [ 19939] |       c() { /* from s-abc.c:N */
+   1.120 us [ 19939] |         getpid();
+   1.697 us [ 19939] |       } /* c */
+   2.044 us [ 19939] |     } /* b */
+   2.329 us [ 19939] |   } /* a */
+   2.644 us [ 19939] | } /* main */
+""", cflags='-g')
+
+    def build(self, name, cflags='', ldflags=''):
+        if not 'dwarf' in self.feature:
+            return TestBase.TEST_SKIP
+        return TestBase.build(self, name, cflags, ldflags)
+
+    def setup(self):
+        self.option = "-T '^.$@callsite'"
+
+    def runcmd(self):
+        # callsite events must not be filtered out by the default --no-event
+        return TestBase.runcmd(self).replace('--no-event', '')
+
+    def sort(self, output):
+        """ Replace exact line numbers with N to ignore compiler-dependent
+            shifts, and strip directory prefix from paths so the test is
+            stable across optimization levels and build environments. """
+        result = []
+        before_main = True
+        for ln in output.split('\n'):
+            if ln.find(' | main()') > 0:
+                before_main = False
+            if before_main:
+                continue
+            if ln.strip() == '':
+                break
+
+            rest = ln.split('|', 1)[-1]
+            # strip directory prefix from filenames and normalize line numbers
+            rest = re.sub(r'/[\w./-]+/(\S+\.c):\d+', r'\1:N', rest)
+            result.append(rest.rstrip())
+
+        return '\n'.join(result)

--- a/uftrace.c
+++ b/uftrace.c
@@ -97,6 +97,7 @@ enum uftrace_short_options {
 	OPT_match_type,
 	OPT_no_randomize_addr,
 	OPT_no_event,
+	OPT_no_callsite,
 	OPT_no_sched,
 	OPT_no_sched_preempt,
 	OPT_signal,
@@ -327,6 +328,7 @@ static const struct option uftrace_options[] = {
 	REQ_ARG(time-range, 'r'),
 	REQ_ARG(Event, 'E'),
 	NO_ARG(no-event, OPT_no_event),
+	NO_ARG(no-callsite, OPT_no_callsite),
 	NO_ARG(no-sched, OPT_no_sched),
 	NO_ARG(no-sched-preempt, OPT_no_sched_preempt),
 	NO_ARG(list-event, OPT_list_event),
@@ -1095,6 +1097,10 @@ static int parse_option(struct uftrace_opts *opts, int key, char *arg)
 		opts->no_event = true;
 		break;
 
+	case OPT_no_callsite:
+		opts->callsite = false;
+		break;
+
 	case OPT_no_sched:
 		opts->no_sched = true;
 		break;
@@ -1519,6 +1525,7 @@ int main(int argc, char *argv[])
 		.event_skip_out = true,
 		.patt_type = PATT_REGEX,
 		.show_args = true,
+		.callsite = true,
 		.clock = "mono",
 	};
 	int ret = -1;

--- a/uftrace.h
+++ b/uftrace.h
@@ -305,6 +305,7 @@ struct uftrace_opts {
 	bool list_event;
 	bool event_skip_out;
 	bool no_event;
+	bool callsite;
 	bool no_sched;
 	bool no_sched_preempt;
 	bool nest_libcall;
@@ -354,9 +355,10 @@ static inline void close_data_file(struct uftrace_opts *opts, struct uftrace_dat
 }
 
 int read_task_file(struct uftrace_session_link *sess, char *dirname, bool needs_symtab,
-		   bool sym_rel_addr, bool needs_srcline);
+		   bool sym_rel_addr, bool needs_srcline, bool needs_callsite);
 int read_task_txt_file(struct uftrace_session_link *sess, char *dirname, char *symdir,
-		       bool needs_symtab, bool sym_rel_addr, bool needs_srcline);
+		       bool needs_symtab, bool sym_rel_addr, bool needs_srcline,
+		       bool needs_callsite);
 
 char *get_libmcount_path(struct uftrace_opts *opts);
 void put_libmcount_path(char *libpath);
@@ -484,7 +486,7 @@ extern struct uftrace_session *first_session;
 
 void create_session(struct uftrace_session_link *sess, struct uftrace_msg_sess *msg, char *dirname,
 		    char *symdir, char *exename, bool sym_rel_addr, bool needs_symtab,
-		    bool needs_srcline);
+		    bool needs_srcline, bool needs_callsite);
 struct uftrace_session *find_task_session(struct uftrace_session_link *sess,
 					  struct uftrace_task *task, uint64_t timestamp);
 void create_task(struct uftrace_session_link *sess, struct uftrace_msg_task *msg, bool fork);
@@ -494,7 +496,7 @@ void delete_session_map(struct uftrace_sym_info *sinfo);
 void update_session_map(const char *filename);
 struct uftrace_session *get_session_from_sid(struct uftrace_session_link *sess, char sid[]);
 void session_add_dlopen(struct uftrace_session *sess, uint64_t timestamp, unsigned long base_addr,
-			const char *libname, bool needs_srcline);
+			const char *libname, bool needs_srcline, bool needs_callsite);
 void session_setup_dlopen_argspec(struct uftrace_session *sess,
 				  struct uftrace_filter_setting *setting, bool is_retval);
 struct uftrace_dlopen_list *session_find_dlopen(struct uftrace_session *sess, uint64_t timestamp,

--- a/uftrace.h
+++ b/uftrace.h
@@ -63,6 +63,7 @@ enum uftrace_feat_bits {
 	DEBUG_INFO_BIT,
 	ESTIMATE_RETURN_BIT,
 	SYM_SIZE_BIT,
+	CALLSITE_BIT,
 
 	FEAT_BIT_MAX,
 
@@ -80,6 +81,7 @@ enum uftrace_feat_bits {
 	DEBUG_INFO = (1U << DEBUG_INFO_BIT),
 	ESTIMATE_RETURN = (1U << ESTIMATE_RETURN_BIT),
 	SYM_SIZE = (1U << SYM_SIZE_BIT),
+	CALLSITE = (1U << CALLSITE_BIT),
 };
 
 enum uftrace_info_bits {

--- a/uftrace.h
+++ b/uftrace.h
@@ -629,6 +629,7 @@ enum uftrace_event_id {
 	EVENT_ID_DIFF_PMU_BRANCH,
 	EVENT_ID_WATCH_CPU,
 	EVENT_ID_WATCH_VAR,
+	EVENT_ID_CALLSITE,
 
 	/* supported perf events */
 	EVENT_ID_PERF = 200000U,

--- a/uftrace.h
+++ b/uftrace.h
@@ -514,6 +514,8 @@ struct uftrace_symbol *task_find_sym_addr(struct uftrace_session_link *sess,
 struct uftrace_dbg_loc *task_find_loc_addr(struct uftrace_session_link *sess,
 					   struct uftrace_task_reader *task, uint64_t time,
 					   uint64_t addr);
+bool task_find_exact_loc_addr(struct uftrace_session_link *sess, struct uftrace_task_reader *task,
+			      uint64_t time, uint64_t addr, struct uftrace_dbg_loc *out);
 
 typedef int (*walk_sessions_cb_t)(struct uftrace_session *session, void *arg);
 void walk_sessions(struct uftrace_session_link *sess, walk_sessions_cb_t callback, void *arg);

--- a/utils/data-file.c
+++ b/utils/data-file.c
@@ -34,7 +34,7 @@
  * It returns 0 for success, -1 for error.
  */
 int read_task_file(struct uftrace_session_link *sess, char *dirname, bool needs_symtab,
-		   bool sym_rel_addr, bool needs_srcline)
+		   bool sym_rel_addr, bool needs_srcline, bool needs_callsite)
 {
 	int fd;
 	char pad[8];
@@ -64,7 +64,7 @@ int read_task_file(struct uftrace_session_link *sess, char *dirname, bool needs_
 				goto out;
 
 			create_session(sess, &smsg, dirname, dirname, buf, sym_rel_addr,
-				       needs_symtab, needs_srcline);
+				       needs_symtab, needs_srcline, needs_callsite);
 			break;
 
 		case UFTRACE_MSG_TASK_START:
@@ -107,7 +107,8 @@ out:
  * It returns 0 for success, -1 for error.
  */
 int read_task_txt_file(struct uftrace_session_link *sess, char *dirname, char *symdir,
-		       bool needs_symtab, bool sym_rel_addr, bool needs_srcline)
+		       bool needs_symtab, bool sym_rel_addr, bool needs_srcline,
+		       bool needs_callsite)
 {
 	FILE *fp;
 	char *fname = NULL;
@@ -170,7 +171,7 @@ int read_task_txt_file(struct uftrace_session_link *sess, char *dirname, char *s
 			smsg.namelen = strlen(exename);
 
 			create_session(sess, &smsg, dirname, symdir, exename, sym_rel_addr,
-				       needs_symtab, needs_srcline);
+				       needs_symtab, needs_srcline, needs_callsite);
 		}
 		else if (!strncmp(line, "DLOP", 4)) {
 			struct uftrace_session *s;
@@ -200,7 +201,7 @@ int read_task_txt_file(struct uftrace_session_link *sess, char *dirname, char *s
 			s = get_session_from_sid(sess, dlop.sid);
 			ASSERT(s);
 			session_add_dlopen(s, dlop.task.time, dlop.base_addr, exename,
-					   needs_srcline);
+					   needs_srcline, needs_callsite);
 		}
 	}
 	ret = 0;
@@ -456,17 +457,27 @@ int open_data_file(struct uftrace_opts *opts, struct uftrace_data *handle)
 
 	if (handle->hdr.feat_mask & TASK_SESSION) {
 		bool sym_rel = false;
+		bool needs_srcline;
+		bool needs_callsite;
 		struct uftrace_session_link *sessions = &handle->sessions;
 		int i;
 
 		if (handle->hdr.feat_mask & SYM_REL_ADDR)
 			sym_rel = true;
 
+		needs_srcline = opts->srcline | (opts->loc_filter != NULL);
+
+		/*
+		 * also load debug info if the trace has @callsite data,
+		 * unless the user opted out with --no-callsite
+		 */
+		needs_callsite = opts->callsite && (handle->hdr.feat_mask & CALLSITE);
+
 		/* read old task file first and then try task.txt file */
-		if (read_task_file(sessions, opts->dirname, true, sym_rel, opts->srcline) < 0 &&
+		if (read_task_file(sessions, opts->dirname, true, sym_rel, opts->srcline,
+				   needs_callsite) < 0 &&
 		    read_task_txt_file(sessions, opts->dirname, opts->with_syms ?: opts->dirname,
-				       true, sym_rel,
-				       opts->srcline | (opts->loc_filter != NULL)) < 0) {
+				       true, sym_rel, needs_srcline, needs_callsite) < 0) {
 			if (errno == ENOENT)
 				saved_errno = ENODATA;
 			else

--- a/utils/dwarf.c
+++ b/utils/dwarf.c
@@ -1927,7 +1927,7 @@ void prepare_debug_info(struct uftrace_sym_info *sinfo, enum uftrace_pattern_typ
 	struct strv dwarf_rets = STRV_INIT;
 
 	if (sinfo->flags & SYMTAB_FL_SYMS_DIR) {
-		load_debug_info(sinfo, true);
+		load_debug_info(sinfo, true, false);
 		return;
 	}
 
@@ -2297,7 +2297,8 @@ out:
 	return ret;
 }
 
-void load_module_debug_info(struct uftrace_module *mod, const char *dirname, bool needs_srcline)
+void load_module_debug_info(struct uftrace_module *mod, const char *dirname, bool needs_srcline,
+			    bool needs_callsite)
 {
 	struct uftrace_dbg_info *dinfo;
 
@@ -2307,9 +2308,17 @@ void load_module_debug_info(struct uftrace_module *mod, const char *dirname, boo
 		load_debug_file(dinfo, &mod->symtab, dirname, mod->name, mod->build_id,
 				needs_srcline);
 	}
+
+	/*
+	 * Keep libdw open per-module so PC-precise line lookups (used by the
+	 * @callsite trigger) can query the dwarf line program at replay time.
+	 * finish_debug_info() releases it.
+	 */
+	if (needs_callsite && dinfo->dw == NULL)
+		setup_dwarf_info(mod->name, dinfo, 0, true);
 }
 
-void load_debug_info(struct uftrace_sym_info *sinfo, bool needs_srcline)
+void load_debug_info(struct uftrace_sym_info *sinfo, bool needs_srcline, bool needs_callsite)
 {
 	struct uftrace_mmap *map;
 
@@ -2328,6 +2337,14 @@ void load_debug_info(struct uftrace_sym_info *sinfo, bool needs_srcline)
 			load_debug_file(dinfo, stab, sinfo->symdir, map->libname, map->build_id,
 					needs_srcline);
 		}
+
+		/*
+		 * Keep libdw open per-module so PC-precise line lookups (used
+		 * by the @callsite trigger) can query the dwarf line program
+		 * at replay time.  finish_debug_info() releases it.
+		 */
+		if (needs_callsite && dinfo->dw == NULL)
+			setup_dwarf_info(map->libname, dinfo, map->start, true);
 	}
 }
 

--- a/utils/dwarf.c
+++ b/utils/dwarf.c
@@ -1768,7 +1768,81 @@ static void build_dwarf_info(struct uftrace_dbg_info *dinfo, struct uftrace_symt
 	free(ret_patt);
 }
 
+/*
+ * match the trailing path against existing entries so callsite filenames
+ * stay consistent with the --srcline output
+ */
+static struct uftrace_dbg_file *get_debug_file_suffix(struct uftrace_dbg_info *dinfo,
+						      const char *filename)
+{
+	struct rb_node *n;
+
+	for (n = rb_first(&dinfo->files); n != NULL; n = rb_next(n)) {
+		struct uftrace_dbg_file *df = rb_entry(n, struct uftrace_dbg_file, node);
+		size_t flen = strlen(filename);
+		size_t dflen = strlen(df->name);
+
+		if (dflen > flen)
+			continue;
+
+		if (dflen == flen) {
+			if (!strcmp(df->name, filename))
+				return df;
+			continue;
+		}
+
+		/* match suffix preceded by a path separator */
+		if (filename[flen - dflen - 1] == '/' && !strcmp(filename + flen - dflen, df->name))
+			return df;
+	}
+
+	return get_debug_file(dinfo, filename);
+}
+
+/* resolve an instruction address to its source location via libdw */
+bool find_dbg_line_at(struct uftrace_dbg_info *dinfo, uint64_t addr,
+		      struct uftrace_dbg_file **out_file, int *out_line)
+{
+	Dwarf_Die cudie;
+	Dwarf_Line *line;
+	int dline;
+	const char *filename;
+	unsigned long dwarf_addr;
+
+	if (dinfo->dw == NULL)
+		return false;
+
+	dwarf_addr = sym_to_dwarf_addr(dinfo, addr);
+
+	if (dwarf_addrdie(dinfo->dw, dwarf_addr, &cudie) == NULL)
+		return false;
+
+	line = dwarf_getsrc_die(&cudie, dwarf_addr);
+	if (line == NULL)
+		return false;
+
+	filename = dwarf_linesrc(line, NULL, NULL);
+	if (filename == NULL)
+		return false;
+
+	if (dwarf_lineno(line, &dline) != 0)
+		return false;
+
+	*out_file = get_debug_file_suffix(dinfo, filename);
+	if (*out_file == NULL)
+		return false;
+
+	*out_line = dline;
+	return true;
+}
+
 #else /* !HAVE_LIBDW */
+
+bool find_dbg_line_at(struct uftrace_dbg_info *dinfo, uint64_t addr,
+		      struct uftrace_dbg_file **out_file, int *out_line)
+{
+	return false;
+}
 
 static int setup_dwarf_info(const char *filename, struct uftrace_dbg_info *dinfo,
 			    unsigned long offset, bool force)
@@ -1899,6 +1973,7 @@ void finish_debug_info(struct uftrace_sym_info *sinfo)
 		if (map->mod == NULL || !map->mod->dinfo.loaded)
 			continue;
 
+		release_dwarf_info(&map->mod->dinfo);
 		release_debug_info(&map->mod->dinfo);
 	}
 }

--- a/utils/dwarf.h
+++ b/utils/dwarf.h
@@ -69,6 +69,8 @@ extern void prepare_debug_info(struct uftrace_sym_info *sinfo, enum uftrace_patt
 extern void finish_debug_info(struct uftrace_sym_info *sinfo);
 extern bool debug_info_has_argspec(struct uftrace_dbg_info *dinfo);
 extern bool debug_info_has_location(struct uftrace_dbg_info *dinfo);
+extern bool find_dbg_line_at(struct uftrace_dbg_info *dinfo, uint64_t addr,
+			     struct uftrace_dbg_file **out_file, int *out_line);
 extern char *get_dwarf_argspec(struct uftrace_dbg_info *dinfo, char *name, unsigned long addr);
 extern char *get_dwarf_retspec(struct uftrace_dbg_info *dinfo, char *name, unsigned long addr);
 struct uftrace_dbg_loc *find_file_line(struct uftrace_sym_info *sinfo, uint64_t addr);

--- a/utils/dwarf.h
+++ b/utils/dwarf.h
@@ -75,9 +75,10 @@ extern char *get_dwarf_argspec(struct uftrace_dbg_info *dinfo, char *name, unsig
 extern char *get_dwarf_retspec(struct uftrace_dbg_info *dinfo, char *name, unsigned long addr);
 struct uftrace_dbg_loc *find_file_line(struct uftrace_sym_info *sinfo, uint64_t addr);
 extern void save_debug_info(struct uftrace_sym_info *sinfo, const char *dirname);
-extern void load_debug_info(struct uftrace_sym_info *sinfo, bool needs_srcline);
+extern void load_debug_info(struct uftrace_sym_info *sinfo, bool needs_srcline,
+			    bool needs_callsite);
 extern void save_debug_file(FILE *fp, char code, char *str, unsigned long val);
 extern void load_module_debug_info(struct uftrace_module *mod, const char *dirname,
-				   bool needs_srcline);
+				   bool needs_srcline, bool needs_callsite);
 
 #endif /* UFTRACE_DWARF_H */

--- a/utils/event.c
+++ b/utils/event.c
@@ -121,6 +121,9 @@ char *event_get_name(struct uftrace_data *handle, unsigned evt_id)
 		case EVENT_ID_WATCH_VAR:
 			xasprintf(&evt_name, "watch:var");
 			break;
+		case EVENT_ID_CALLSITE:
+			xasprintf(&evt_name, "callsite");
+			break;
 		default:
 			xasprintf(&evt_name, "builtin_event:%u", evt_id);
 			break;
@@ -267,6 +270,16 @@ char *event_get_data_str(struct uftrace_data *handle, unsigned evt_id, void *dat
 			xasprintf(&str, "[%#" PRIx64 "]=%" PRIx64, u.watch.var.addr,
 				  u.watch.var.data);
 		break;
+
+	case EVENT_ID_CALLSITE: {
+		uint64_t callsite_ip = 0;
+
+		if ((size_t)len >= sizeof(callsite_ip))
+			memcpy(&callsite_ip, data, sizeof(callsite_ip));
+
+		xasprintf(&str, "callsite=%#" PRIx64, callsite_ip);
+		break;
+	}
 
 	default:
 		/* kernel tracepoints */

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -82,6 +82,8 @@ static void print_trigger(struct uftrace_trigger *tr)
 		pr_dbg("\ttrigger: recover\n");
 	if (tr->flags & TRIGGER_FL_FINISH)
 		pr_dbg("\ttrigger: finish\n");
+	if (tr->flags & TRIGGER_FL_CALLSITE)
+		pr_dbg("\ttrigger: callsite\n");
 
 	if (tr->flags & TRIGGER_FL_ARGUMENT) {
 		struct uftrace_arg_spec *arg;
@@ -750,6 +752,13 @@ static int parse_finish_action(char *action, struct uftrace_trigger *tr,
 	return 0;
 }
 
+static int parse_callsite_action(char *action, struct uftrace_trigger *tr,
+				 struct uftrace_filter_setting *setting)
+{
+	tr->flags |= TRIGGER_FL_CALLSITE;
+	return 0;
+}
+
 static int parse_filter_action(char *action, struct uftrace_trigger *tr,
 			       struct uftrace_filter_setting *setting)
 {
@@ -881,6 +890,8 @@ static int parse_clear_action(char *action, struct uftrace_trigger *tr,
 					   TRIGGER_FL_TRACE_OFF;
 		else if (!strcmp(pos, "finish"))
 			tr->clear_flags |= TRIGGER_FL_FINISH;
+		else if (!strcmp(pos, "callsite"))
+			tr->clear_flags |= TRIGGER_FL_CALLSITE;
 		else if (!strcmp(pos, "read"))
 			tr->clear_flags |= TRIGGER_FL_READ;
 		else if (!strcmp(pos, "color"))
@@ -966,6 +977,10 @@ static const struct trigger_action_parser actions[] = {
 		"finish",
 		parse_finish_action,
 		TRIGGER_FL_SIGNAL,
+	},
+	{
+		"callsite",
+		parse_callsite_action,
 	},
 	{
 		"read=",

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -39,6 +39,7 @@ enum trigger_flag {
 	TRIGGER_FL_LOC = (1U << 18),
 	TRIGGER_FL_SIZE_FILTER = (1U << 19),
 	TRIGGER_FL_CONDITION = (1U << 20),
+	TRIGGER_FL_CALLSITE = (1U << 21),
 
 	TRIGGER_FL_CLEAR = (1U << 30), /* Reverse other flags when set */
 };

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -1552,6 +1552,18 @@ int read_task_event(struct uftrace_task_reader *task, struct uftrace_record *rec
 		save_task_event(task, &u.watch, len);
 		break;
 
+	case EVENT_ID_CALLSITE: {
+		uint64_t callsite_ip;
+
+		if (read_task_event_size(task, &callsite_ip, sizeof(callsite_ip)) < 0)
+			return -1;
+		if (task->h->needs_byte_swap)
+			callsite_ip = bswap_64(callsite_ip);
+
+		save_task_event(task, &callsite_ip, sizeof(callsite_ip));
+		break;
+	}
+
 	default:
 		pr_err_ns("unknown event has data: %u\n", rec->addr);
 		break;

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -2767,7 +2767,7 @@ static int fstack_test_setup_exec(struct uftrace_data *handle)
 	};
 	char name[] = "unittest";
 
-	create_session(&handle->sessions, &smsg, "tests", "tests", name, true, false, false);
+	create_session(&handle->sessions, &smsg, "tests", "tests", name, true, false, false, false);
 	create_task(&handle->sessions, &smsg.task, false);
 
 	handle->sessions.first->sym_info.maps = &map;

--- a/utils/fstack.h
+++ b/utils/fstack.h
@@ -63,6 +63,8 @@ struct uftrace_task_reader {
 	int event_color;
 	int sched_cpu;
 	int current_cpu;
+	/* return address from a pending CALLSITE event, consumed by next ENTRY */
+	uint64_t callsite_ip;
 	enum uftrace_fstack_context ctx;
 	uint64_t timestamp;
 	uint64_t timestamp_last;

--- a/utils/session.c
+++ b/utils/session.c
@@ -187,7 +187,8 @@ next:
  * @exename: executable name started this session
  * @sym_rel_addr: whether symbol table uses relative address
  * @needs_symtab: whether symbol table loading is needed
- * @needs_srcline: whether debug info loading is needed
+ * @needs_srcline: whether debug info loading is needed for srcline/loc-filter
+ * @needs_callsite: whether libdw runtime handle is needed for @callsite
  *
  * This function allocates a new session started by a task.  The new
  * session will be added to sessions tree sorted by pid and timestamp.
@@ -195,7 +196,7 @@ next:
  */
 void create_session(struct uftrace_session_link *sessions, struct uftrace_msg_sess *msg,
 		    char *dirname, char *symdir, char *exename, bool sym_rel_addr,
-		    bool needs_symtab, bool needs_srcline)
+		    bool needs_symtab, bool needs_srcline, bool needs_callsite)
 {
 	struct uftrace_session *s;
 	struct uftrace_task *t;
@@ -242,7 +243,7 @@ void create_session(struct uftrace_session_link *sessions, struct uftrace_msg_se
 		read_session_map(dirname, &s->sym_info, s->sid);
 
 		load_module_symtabs(&s->sym_info);
-		load_debug_info(&s->sym_info, needs_srcline);
+		load_debug_info(&s->sym_info, needs_srcline, needs_callsite);
 	}
 
 	if (sessions->first == NULL)
@@ -339,14 +340,15 @@ struct uftrace_session *get_session_from_sid(struct uftrace_session_link *sessio
  * @timestamp: timestamp at the dlopen call
  * @base_addr: load address of text segment of the library
  * @libname: name of the library
- * @needs_srcline: whether debug info loading is needed
+ * @needs_srcline: whether debug info loading is needed for srcline/loc-filter
+ * @needs_callsite: whether libdw runtime handle is needed for @callsite
  *
  * This functions adds the info of a library which was loaded by dlopen.
  * Instead of creating a new session, it just adds the library information
  * to the @sess.
  */
 void session_add_dlopen(struct uftrace_session *sess, uint64_t timestamp, unsigned long base_addr,
-			const char *libname, bool needs_srcline)
+			const char *libname, bool needs_srcline, bool needs_callsite)
 {
 	struct uftrace_dlopen_list *udl, *pos;
 	char build_id[BUILD_ID_STR_SIZE];
@@ -357,7 +359,7 @@ void session_add_dlopen(struct uftrace_session *sess, uint64_t timestamp, unsign
 
 	read_build_id(libname, build_id, sizeof(build_id));
 	udl->mod = load_module_symtab(&sess->sym_info, libname, build_id);
-	load_module_debug_info(udl->mod, sess->sym_info.symdir, needs_srcline);
+	load_module_debug_info(udl->mod, sess->sym_info.symdir, needs_srcline, needs_callsite);
 
 	udl->filter_info.root = RB_ROOT;
 
@@ -938,7 +940,8 @@ TEST_CASE(session_search)
 		fd = creat("sid-test.map", 0400);
 		write_all(fd, session_map, sizeof(session_map) - 1);
 		close(fd);
-		create_session(&test_sessions, &msg, ".", ".", "unittest", false, false, false);
+		create_session(&test_sessions, &msg, ".", ".", "unittest", false, false, false,
+			       false);
 		remove("sid-test.map");
 	}
 
@@ -992,7 +995,8 @@ TEST_CASE(task_search)
 		fd = creat("sid-initial.map", 0400);
 		write_all(fd, session_map, sizeof(session_map) - 1);
 		close(fd);
-		create_session(&test_sessions, &smsg, ".", ".", "unittest", false, false, false);
+		create_session(&test_sessions, &smsg, ".", ".", "unittest", false, false, false,
+			       false);
 		create_task(&test_sessions, &tmsg, false);
 		remove("sid-initial.map");
 
@@ -1096,7 +1100,8 @@ TEST_CASE(task_search)
 		fd = creat("sid-after_exec.map", 0400);
 		write_all(fd, session_map, sizeof(session_map) - 1);
 		close(fd);
-		create_session(&test_sessions, &smsg, ".", ".", "unittest", false, false, false);
+		create_session(&test_sessions, &smsg, ".", ".", "unittest", false, false, false,
+			       false);
 		create_task(&test_sessions, &tmsg, false);
 		remove("sid-after_exec.map");
 
@@ -1230,7 +1235,7 @@ TEST_CASE(task_symbol)
 	fprintf(fp, "00000500 T __sym_end\n");
 	fclose(fp);
 
-	create_session(&test_sessions, &msg, ".", ".", "unittest", false, true, false);
+	create_session(&test_sessions, &msg, ".", ".", "unittest", false, true, false, false);
 	create_task(&test_sessions, &tmsg, false);
 	remove("sid-test.map");
 	remove("unittest.sym");
@@ -1280,14 +1285,15 @@ TEST_CASE(task_symbol_dlopen)
 	fprintf(fp, "0500 T __sym_end\n");
 	fclose(fp);
 
-	create_session(&test_sessions, &msg, ".", ".", "unittest", false, true, false);
+	create_session(&test_sessions, &msg, ".", ".", "unittest", false, true, false, false);
 	remove("sid-test.map");
 
 	TEST_NE(test_sessions.first, NULL);
 	TEST_EQ(test_sessions.first->pid, 1);
 
 	pr_dbg("add dlopen info message\n");
-	session_add_dlopen(test_sessions.first, 200, 0x7003000, "libuftrace-test.so.0", false);
+	session_add_dlopen(test_sessions.first, 200, 0x7003000, "libuftrace-test.so.0", false,
+			   false);
 	remove("libuftrace-test.so.0.sym");
 
 	TEST_EQ(list_empty(&test_sessions.first->dlopen_libs), false);
@@ -1388,7 +1394,7 @@ TEST_CASE(session_autoarg_dlopen)
 	fprintf(fp, "R: @retval\n");
 	fclose(fp);
 
-	create_session(&test_sessions, &msg, ".", ".", "unittest", false, true, true);
+	create_session(&test_sessions, &msg, ".", ".", "unittest", false, true, true, false);
 	remove("sid-test.map");
 
 	sess = test_sessions.first;
@@ -1396,7 +1402,7 @@ TEST_CASE(session_autoarg_dlopen)
 	TEST_EQ(sess->pid, 1);
 
 	pr_dbg("add dlopen info message\n");
-	session_add_dlopen(sess, 200, 0x7003000, "libuftrace-test.so.0", false);
+	session_add_dlopen(sess, 200, 0x7003000, "libuftrace-test.so.0", false, false);
 	remove("libuftrace-test.so.0.sym");
 	remove("libuftrace-test.so.0.dbg");
 

--- a/utils/session.c
+++ b/utils/session.c
@@ -762,17 +762,15 @@ struct uftrace_symbol *task_find_sym_addr(struct uftrace_session_link *sessions,
  * This function returns a debug location of symbol
  * that looked up in symbol table in current session
  */
-struct uftrace_dbg_loc *task_find_loc_addr(struct uftrace_session_link *sessions,
-					   struct uftrace_task_reader *task, uint64_t time,
-					   uint64_t addr)
+/* shared lookup used by task_find_loc_addr() and task_find_exact_loc_addr() */
+static int task_find_addr_module(struct uftrace_session_link *sessions,
+				 struct uftrace_task_reader *task, uint64_t time, uint64_t addr,
+				 struct uftrace_module **out_mod, struct uftrace_symbol **out_sym,
+				 uint64_t *out_mod_addr)
 {
 	struct uftrace_session *sess;
 	struct uftrace_symbol *sym;
 	struct uftrace_mmap *map;
-	struct uftrace_module *mod;
-	struct uftrace_dbg_info *dinfo;
-	struct uftrace_dbg_loc *loc;
-	ptrdiff_t sym_idx;
 
 	sess = find_task_session(sessions, task->t, time);
 
@@ -782,7 +780,7 @@ struct uftrace_dbg_loc *task_find_loc_addr(struct uftrace_session_link *sessions
 		if (is_kernel_address(&fsess->sym_info, addr))
 			sess = fsess;
 		else
-			return NULL;
+			return -1;
 	}
 
 	sym = find_symtabs(&sess->sym_info, addr);
@@ -790,35 +788,78 @@ struct uftrace_dbg_loc *task_find_loc_addr(struct uftrace_session_link *sessions
 		sym = session_find_dlsym(sess, time, addr);
 
 	if (sym == NULL)
-		return NULL;
+		return -1;
 
-	if (sym->type == ST_LOCAL_FUNC || sym->type == ST_GLOBAL_FUNC) {
-		map = find_map(&sess->sym_info, addr);
-		if (map) {
-			mod = map->mod;
-			dinfo = &mod->dinfo;
-		}
-		else {
-			struct uftrace_dlopen_list *udl;
+	if (sym->type != ST_LOCAL_FUNC && sym->type != ST_GLOBAL_FUNC)
+		return -1;
 
-			udl = session_find_dlopen(sess, time, addr);
-			if (udl == NULL)
-				return NULL;
+	map = find_map(&sess->sym_info, addr);
+	if (map) {
+		*out_mod = map->mod;
+		if (out_mod_addr)
+			*out_mod_addr = addr - map->start;
+	}
+	else {
+		struct uftrace_dlopen_list *udl;
 
-			mod = udl->mod;
-			dinfo = &mod->dinfo;
-		}
+		udl = session_find_dlopen(sess, time, addr);
+		if (udl == NULL)
+			return -1;
 
-		if (dinfo == NULL || dinfo->nr_locs_used == 0)
-			return NULL;
-
-		sym_idx = sym - mod->symtab.sym;
-		loc = &dinfo->locs[sym_idx];
-		if (loc->file != NULL)
-			return loc;
+		*out_mod = udl->mod;
+		if (out_mod_addr)
+			*out_mod_addr = addr - udl->base;
 	}
 
+	*out_sym = sym;
+	return 0;
+}
+
+struct uftrace_dbg_loc *task_find_loc_addr(struct uftrace_session_link *sessions,
+					   struct uftrace_task_reader *task, uint64_t time,
+					   uint64_t addr)
+{
+	struct uftrace_module *mod;
+	struct uftrace_symbol *sym;
+	struct uftrace_dbg_info *dinfo;
+	struct uftrace_dbg_loc *loc;
+	ptrdiff_t sym_idx;
+
+	if (task_find_addr_module(sessions, task, time, addr, &mod, &sym, NULL) < 0)
+		return NULL;
+
+	dinfo = &mod->dinfo;
+	if (dinfo->nr_locs_used == 0)
+		return NULL;
+
+	sym_idx = sym - mod->symtab.sym;
+	loc = &dinfo->locs[sym_idx];
+	if (loc->file != NULL)
+		return loc;
+
 	return NULL;
+}
+
+/*
+ * PC-precise variant of task_find_loc_addr().  Unlike that function, this
+ * uses DWARF directly via find_dbg_line_at() so a PC anywhere inside a
+ * function resolves to the matching source line (not the enclosing
+ * function's entry).  Writes the result to *out and returns true on
+ * success, false otherwise.
+ */
+bool task_find_exact_loc_addr(struct uftrace_session_link *sessions,
+			      struct uftrace_task_reader *task, uint64_t time, uint64_t addr,
+			      struct uftrace_dbg_loc *out)
+{
+	struct uftrace_module *mod;
+	struct uftrace_symbol *sym;
+	uint64_t mod_addr;
+
+	if (task_find_addr_module(sessions, task, time, addr, &mod, &sym, &mod_addr) < 0)
+		return false;
+
+	out->sym = sym;
+	return find_dbg_line_at(&mod->dinfo, mod_addr, &out->file, &out->line);
 }
 
 void session_setup_dlopen_argspec(struct uftrace_session *sess,


### PR DESCRIPTION
closes #2027

I've added the `callsite` trigger action proposed in the issue.
Setting `-T <func>@callsite` records the return address of the matched
call, and `uftrace replay --srcline` shows it after the existing source
line, e.g. `a() { /* file.c:11 from file.c:33 */`.

Changes:
* Added `TRIGGER_FL_CALLSITE` / `EVENT_ID_CALLSITE` and the `callsite`
  trigger action parser.
* libmcount emits the event (8-byte return address payload) right
  before the matching ENTRY when the trigger fires.
* Added `task_find_exact_loc_addr()` that uses libdw's
  `dwarf_addrdie()` + `dwarf_getsrc_die()` for PC-precise line lookup
  (the existing `task_find_loc_addr()` only knows the symbol's entry
  line). `load_debug_info()` now keeps libdw open at replay time so
  this lookup works there.
* replay intercepts the CALLSITE event, stashes the address on the
  task, and appends `from file:line` to the source comment on the
  next ENTRY.
* Added t305 covering both the live and `--srcline` paths.
* Documented the new action in `doc/uftrace-record.md` with an example
  and a short note about line precision under optimization.

Testing on Rocky Linux 9.7 (GCC 11.5, x86_64):

```
DURATION     TID      FUNCTION [SOURCE]
   0.510 us [3615820] | __monstartup();
   0.187 us [3615820] | __cxa_atexit();
            [3615820] | main() { /* s-abc.c:26 */
            [3615820] |   a() { /* s-abc.c:11 from s-abc.c:33 */
            [3615820] |     b() { /* s-abc.c:16 from s-abc.c:13 */
            [3615820] |       c() { /* s-abc.c:21 from s-abc.c:18 */
   0.250 us [3615820] |         getpid();
   1.449 us [3615820] |       } /* c */
   1.744 us [3615820] |     } /* b */
   2.317 us [3615820] |   } /* a */
   2.604 us [3615820] | } /* main */
```

One thing I'd like your feedback on:
`save_callsite_event()` writes the 8-byte payload with a direct
`*(uint64_t *)event->data = ...` rather than the existing
`mcount_memcpy4()`. Using the memcpy helper here recorded zero on my
setup. My guess is strict aliasing — `mcount_memcpy4` reinterprets the
source as `unsigned int *`, and the 8-byte return address write through
that path gets optimized away. The direct write goes through the
`uint8_t event->data[]` member, which is well-defined. I'm happy to add
an `mcount_memcpy8` helper (or update `mcount_memcpy4` to use byte-wise
loads) if you prefer either of those.

Also a precision note (also in the doc): the resolved call site line
depends on the dwarf line program. `-O0` / `-Og` builds report the
exact line; with `-O1` or higher the call instruction can be folded
with surrounding code so the reported line may shift by 1–2 lines.
`-finstrument-functions` builds are stable across optimization levels.
t305 forces `-O0` in cflags for this reason.

Please let me know if you'd like changes to the approach or naming.
Thanks!