### PR TITLE
mcount: Fix lost diff event from read trigger with argument tracing

### DIFF
--- a/libmcount/record.c
+++ b/libmcount/record.c
@@ -699,7 +699,7 @@ void save_trigger_read(struct mcount_thread_data *mtdp, struct mcount_ret_stack 
 	size_t i;
 
 	if (rstack->flags & (MCOUNT_FL_ARGUMENT | MCOUNT_FL_RETVAL))
-		arg_data += *(uint32_t *)ptr;
+		arg_data += sizeof(uint32_t) + *(uint32_t *)arg_data;
 
 	for (i = 0; i < ARRAY_SIZE(read_events); i++) {
 		struct read_event_data *red = &read_events[i];


### PR DESCRIPTION
When `-A`, `-R`, or `-a` is combined with a function-level `@read` trigger, the `diff` event at function exit is lost:

    $ uftrace -A 'a@arg1/u64' -T a@read=proc/statm -F main tests/t-abc
    # DURATION     TID      FUNCTION
                [3162404] | main() {
                [3162404] |   a(1) {
                [3162404] |     /* read:proc/statm (vmsize=13192KB vmrss=7192KB ...) */
                [3162404] |     b() {
                [3162404] |       c() {
       0.303 us [3162404] |         getpid();
       1.602 us [3162404] |       } /* c */
       1.902 us [3162404] |     } /* b */
      19.249 us [3162404] |   } /* a */          <-- diff:proc/statm is missing
      19.793 us [3162404] | } /* main */

In save_trigger_read(), arg_data is meant to point to the end of the argument region so that an event written at the buffer tail does not overwrite it.  The argument size lives at the start of argbuf as a uint32_t, but the code reads it from ptr (= argbuf + event_idx), which on the exit-time call points to the read event header saved at entry.  Its first 4 bytes are the lower 32 bits of event->time, so arg_data jumps far outside the buffer and the overwrite check rejects the new diff event.

Fix it by reading the size from the start of the argbuf, and adding the size header itself when computing the end of the region.