### PR TITLE
python: Use HDRSZ macro in symtab header size warning

### DIFF
--- a/python/trace-python.c
+++ b/python/trace-python.c
@@ -317,7 +317,7 @@ static void write_symtab(const char *dirname)
 	len += fprintf(fp, "#%*s\n", UFTRACE_PYTHON_SYMTAB_HDRSZ - 2 - len, "");
 
 	if (len != UFTRACE_PYTHON_SYMTAB_HDRSZ)
-		pr_warn("symbol header size should be 64: %u", len);
+		pr_warn("symbol header size should be %d: %u", UFTRACE_PYTHON_SYMTAB_HDRSZ, len);
 
 	/* copy rest of the shmem buffer to the file */
 	buf += UFTRACE_PYTHON_SYMTAB_HDRSZ;


### PR DESCRIPTION
The warning hardcoded "64" but UFTRACE_PYTHON_SYMTAB_HDRSZ is (48). Use the macro to keep them in sync, matching write_dbginfo().

I found it while i'm look around the python tracing codes. 