### PR TITLE
arch/riscv64: Support dynamic tracing with -fpatchable-function-entry

### DIFF
--- a/arch/riscv64/dynamic.S
+++ b/arch/riscv64/dynamic.S
@@ -1,0 +1,68 @@
+#include "utils/asm.h"
+
+.text
+
+/*
+ * Dynamic tracing entry trampoline (for -fpatchable-function-entry).
+ *
+ * A patched function entry is turned into:
+ *     auipc t0, %pcrel_hi(module_trampoline)
+ *     jalr  t0, %pcrel_lo(module_trampoline)(t0)
+ * Note the link register is t0 (not ra), so the caller's return address in
+ * 'ra' is preserved.  After the jalr:
+ *     ra : the function's own return address (to its caller)
+ *     t0 : where to resume in the patched function (= func_entry + 8)
+ *     a0-a7, fa0-fa7 : the function's arguments
+ *
+ * The per-module trampoline loads the absolute address of __dentry__ and
+ * jumps here.  We spill 'ra' so that mcount_entry() can hijack the return
+ * address (replacing it with the dynamic return trampoline), then resume the
+ * function via t0.
+ */
+GLOBAL(__dentry__)
+	addi	sp, sp, -80
+
+	/* save resume address (t0) and the real return address (ra) */
+	sd	t0, 72(sp)
+	sd	ra, 64(sp)
+
+	/* save integer arguments (mcount_regs layout: a0..a7 at 0..56) */
+	sd	a0, 0(sp)
+	sd	a1, 8(sp)
+	sd	a2, 16(sp)
+	sd	a3, 24(sp)
+	sd	a4, 32(sp)
+	sd	a5, 40(sp)
+	sd	a6, 48(sp)
+	sd	a7, 56(sp)
+
+	/* parent_loc = &saved_ra (mcount_entry hijacks the return here) */
+	addi	a0, sp, 64
+	/* child = function entry = resume(t0) - 8 */
+	addi	a1, t0, -8
+	/* regs = &saved arguments */
+	mv	a2, sp
+
+	call	mcount_entry
+
+	/* reload the (possibly hijacked) return address into ra */
+	ld	ra, 64(sp)
+
+	/* restore arguments */
+	ld	a0, 0(sp)
+	ld	a1, 8(sp)
+	ld	a2, 16(sp)
+	ld	a3, 24(sp)
+	ld	a4, 32(sp)
+	ld	a5, 40(sp)
+	ld	a6, 48(sp)
+	ld	a7, 56(sp)
+
+	/* restore resume address */
+	ld	t0, 72(sp)
+
+	addi	sp, sp, 80
+
+	/* resume the patched function body */
+	jr	t0
+END(__dentry__)

--- a/arch/riscv64/mcount-dynamic.c
+++ b/arch/riscv64/mcount-dynamic.c
@@ -1,0 +1,300 @@
+#include <stdint.h>
+#include <string.h>
+#include <sys/mman.h>
+
+/* This should be defined before #include "utils.h" */
+#define PR_FMT "dynamic"
+#define PR_DOMAIN DBG_DYNAMIC
+
+#include "libmcount/dynamic.h"
+#include "libmcount/internal.h"
+#include "libmcount/mcount.h"
+#include "mcount-arch.h"
+#include "utils/symbol.h"
+#include "utils/utils.h"
+
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE MAP_FIXED
+#endif
+
+/* the patch region is auipc(4) + jalr/nop4(4) */
+#define CODE_SIZE 8
+
+/* implemented in arch/riscv64/dynamic.S */
+extern void __dentry__(void);
+
+/*
+ * Instruction encodings (verified against the kernel's RISC-V ftrace).
+ *   auipc t0, 0        = 0x00000297
+ *   jalr  t0, 0(t0)    = 0x000282e7   (rd = t0, rs1 = t0)
+ *   nop4 (addi x0,x0,0)= 0x00000013
+ * The offset between the patch site and the trampoline is split into the
+ * auipc (upper 20 bits) and jalr (lower 12 bits, sign-extended) the same way
+ * a normal PC-relative call is built.
+ */
+#define AUIPC_T0 0x00000297
+#define JALR_T0 0x000282e7
+#define RISCV_NOP4 0x00000013
+
+#define JALR_SIGN_MASK 0x00000800
+#define JALR_OFFSET_MASK 0x00000fff
+#define AUIPC_OFFSET_MASK 0xfffff000
+#define AUIPC_PAD 0x00001000
+#define JALR_SHIFT 20
+
+static inline uint32_t to_auipc_t0(int32_t offset)
+{
+	if (offset & JALR_SIGN_MASK)
+		return ((offset & AUIPC_OFFSET_MASK) + AUIPC_PAD) | AUIPC_T0;
+	return (offset & AUIPC_OFFSET_MASK) | AUIPC_T0;
+}
+
+static inline uint32_t to_jalr_t0(int32_t offset)
+{
+	return ((offset & JALR_OFFSET_MASK) << JALR_SHIFT) | JALR_T0;
+}
+
+/* expected NOP patterns of a patchable function entry (8 bytes) */
+static bool is_patchable_nop(const void *insn)
+{
+	uint32_t w[2];
+
+	memcpy(w, insn, CODE_SIZE);
+	/* 4x c.nop on an RVC target */
+	if (w[0] == 0x00010001 && w[1] == 0x00010001)
+		return true;
+	/* 2x nop4 on a non-RVC target */
+	if (w[0] == RISCV_NOP4 && w[1] == RISCV_NOP4)
+		return true;
+	return false;
+}
+
+static void read_patchable_loc(struct mcount_dynamic_info *mdi, struct uftrace_elf_data *elf,
+			       struct uftrace_elf_iter *iter, unsigned long offset)
+{
+	typeof(iter->shdr) *shdr = &iter->shdr;
+	unsigned i;
+	unsigned long *patchable_loc;
+	unsigned long sh_addr;
+
+	mdi->nr_patch_target = shdr->sh_size / sizeof(long);
+	mdi->patch_target = xmalloc(shdr->sh_size);
+	patchable_loc = mdi->patch_target;
+
+	sh_addr = shdr->sh_addr;
+	if (elf->ehdr.e_type == ET_DYN)
+		sh_addr += offset;
+
+	for (i = 0; i < mdi->nr_patch_target; i++) {
+		unsigned long *entry = (unsigned long *)sh_addr + i;
+		patchable_loc[i] = *entry - offset;
+	}
+}
+
+void mcount_arch_find_module(struct mcount_dynamic_info *mdi, struct uftrace_symtab *symtab)
+{
+	struct uftrace_elf_data elf;
+	struct uftrace_elf_iter iter;
+	unsigned i = 0;
+
+	mdi->type = DYNAMIC_NONE;
+
+	if (elf_init(mdi->map->libname, &elf) < 0)
+		goto out;
+
+	elf_for_each_shdr(&elf, &iter) {
+		char *shstr = elf_get_name(&elf, &iter, iter.shdr.sh_name);
+
+		if (!strcmp(shstr, PATCHABLE_SECT)) {
+			mdi->type = DYNAMIC_PATCHABLE;
+			read_patchable_loc(mdi, &elf, &iter, mdi->base_addr);
+			goto out;
+		}
+	}
+
+	/*
+	 * The __patchable_function_entries section may be missing (e.g. stripped
+	 * by --gc-sections).  Fall back to checking the first few functions for
+	 * the patchable NOP pattern.
+	 */
+	for (i = 0; i < symtab->nr_sym; i++) {
+		struct uftrace_symbol *sym = &symtab->sym[i];
+		void *code_addr = (void *)sym->addr + mdi->map->start;
+
+		if (sym->type != ST_LOCAL_FUNC && sym->type != ST_GLOBAL_FUNC)
+			continue;
+		if (sym->name[0] == '_')
+			continue;
+
+		if (is_patchable_nop(code_addr)) {
+			mdi->type = DYNAMIC_FENTRY_NOP;
+			goto out;
+		}
+	}
+
+	switch (check_trace_functions(mdi->map->libname)) {
+	case TRACE_MCOUNT:
+		mdi->type = DYNAMIC_PG;
+		break;
+	default:
+		break;
+	}
+
+out:
+	pr_dbg("dynamic patch type: %s: %d (%s)\n", uftrace_basename(mdi->map->libname), mdi->type,
+	       mdi_type_names[mdi->type]);
+
+	elf_finish(&elf);
+}
+
+int mcount_setup_trampoline(struct mcount_dynamic_info *mdi)
+{
+	unsigned long dentry_addr = (unsigned long)(void *)&__dentry__;
+	unsigned long page_offset;
+
+	/*
+	 *   auipc t1, 0        ; t1 = address of this auipc (PC, hi = 0)
+	 *   ld    t1, 12(t1)   ; t1 = *(this + 12) = absolute address of __dentry__
+	 *   jr    t1
+	 *   .dword __dentry__  ; stored 12 bytes after the auipc
+	 */
+	uint32_t trampoline[] = {
+		0x00000317, /* auipc t1, 0 */
+		0x00c33303, /* ld    t1, 12(t1) */
+		0x00030067, /* jalr  x0, 0(t1) (jr t1) */
+		(uint32_t)dentry_addr,
+		(uint32_t)(dentry_addr >> 32),
+	};
+
+	/* find unused space at the end of the code segment */
+	mdi->trampoline = ALIGN(mdi->text_addr + mdi->text_size, PAGE_SIZE);
+	mdi->trampoline -= sizeof(trampoline);
+
+	if (unlikely(mdi->trampoline < mdi->text_addr + mdi->text_size)) {
+		/*
+		 * There is no room at the end of the text segment (e.g. a shared
+		 * library whose next page is already mapped).  Map a fresh page
+		 * near the text and let the kernel pick a free address (the hint
+		 * is not MAP_FIXED, so it won't fail if the page is taken).
+		 *
+		 * The auipc + jalr sequence can reach +-2GB and patch_code() skips
+		 * any function out of that range, so the trampoline doesn't have to
+		 * be adjacent to the text.
+		 */
+		void *hint = (void *)mdi->trampoline + sizeof(trampoline);
+		void *page = mmap(hint, PAGE_SIZE, PROT_READ | PROT_WRITE | PROT_EXEC,
+				  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+		if (page == MAP_FAILED) {
+			pr_dbg("cannot map a page for the dynamic trampoline: %m\n");
+			return -1;
+		}
+
+		mdi->trampoline = (unsigned long)page;
+		pr_dbg("mapped dynamic trampoline at %#lx\n", mdi->trampoline);
+	}
+
+	page_offset = mdi->text_addr & (PAGE_SIZE - 1);
+	if (mprotect((void *)(mdi->text_addr - page_offset), mdi->text_size + page_offset,
+		     PROT_READ | PROT_WRITE | PROT_EXEC)) {
+		pr_dbg("cannot setup trampoline due to protection: %m\n");
+		return -1;
+	}
+
+	memcpy((void *)mdi->trampoline, trampoline, sizeof(trampoline));
+	__builtin___clear_cache((void *)mdi->trampoline,
+				(void *)mdi->trampoline + sizeof(trampoline));
+	return 0;
+}
+
+void mcount_cleanup_trampoline(struct mcount_dynamic_info *mdi)
+{
+	/* restore the text protection that setup_trampoline() opened for patching */
+	if (mprotect(PAGE_ADDR(mdi->text_addr), PAGE_LEN(mdi->text_addr, mdi->text_size),
+		     PROT_READ | PROT_EXEC))
+		pr_dbg("cannot restore trampoline protection: %m\n");
+}
+
+static int patch_code(struct mcount_dynamic_info *mdi, unsigned long insn_addr)
+{
+	uint32_t *insn = (uint32_t *)insn_addr;
+	long offset = (long)mdi->trampoline - (long)insn_addr;
+	uint32_t auipc, jalr;
+
+	/* auipc + jalr can reach +-2GB */
+	if (offset != (long)(int32_t)offset) {
+		pr_dbg("trampoline is out of range: %#lx\n", offset);
+		return INSTRUMENT_FAILED;
+	}
+
+	auipc = to_auipc_t0((int32_t)offset);
+	jalr = to_jalr_t0((int32_t)offset);
+
+	insn[0] = auipc;
+	insn[1] = jalr;
+	__builtin___clear_cache((void *)&insn[0], (void *)&insn[2]);
+
+	return INSTRUMENT_SUCCESS;
+}
+
+static int patch_patchable_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym)
+{
+	unsigned long insn_addr = sym->addr + mdi->map->start;
+
+	if (!is_patchable_nop((void *)insn_addr)) {
+		pr_dbg4("skip non-applicable function: %s\n", sym->name);
+		return INSTRUMENT_SKIPPED;
+	}
+
+	if (patch_code(mdi, insn_addr) < 0)
+		return INSTRUMENT_FAILED;
+
+	pr_dbg3("dynamically patch '%s' to call the trampoline\n", sym->name);
+	return INSTRUMENT_SUCCESS;
+}
+
+int mcount_patch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym,
+		      struct mcount_disasm_engine *disasm, unsigned min_size)
+{
+	if (min_size < CODE_SIZE + 1)
+		min_size = CODE_SIZE + 1;
+
+	if (sym->size < min_size)
+		return INSTRUMENT_SKIPPED;
+
+	switch (mdi->type) {
+	case DYNAMIC_PATCHABLE:
+	case DYNAMIC_FENTRY_NOP:
+		return patch_patchable_func(mdi, sym);
+	default:
+		/* DYNAMIC_NONE (full binary patching) is not supported yet */
+		return INSTRUMENT_SKIPPED;
+	}
+}
+
+int mcount_unpatch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym,
+			struct mcount_disasm_engine *disasm)
+{
+	/*
+	 * -fpatchable-function-entry leaves the entry as NOPs, so a function
+	 * that should not be traced is simply left unpatched -- there is
+	 * nothing to revert here (unlike -mfentry, which isn't available on
+	 * RISC-V).
+	 */
+	return -1;
+}
+
+void mcount_arch_dynamic_recover(struct mcount_dynamic_info *mdi,
+				 struct mcount_disasm_engine *disasm)
+{
+	mcount_free_badsym(mdi);
+}
+
+/* The patchable path doesn't use the (capstone) disassembler. */
+void mcount_disasm_init(struct mcount_disasm_engine *disasm)
+{
+}
+
+void mcount_disasm_finish(struct mcount_disasm_engine *disasm)
+{
+}

--- a/arch/riscv64/mcount-support.c
+++ b/arch/riscv64/mcount-support.c
@@ -9,20 +9,45 @@ extern void _mcount(void);
 extern void plt_hooker(void);
 extern void mcount_return(void);
 extern void plthook_return(void);
+extern void __dentry__(void);
 
 /* These functions are defined in the current file */
 static unsigned long mcount_arch_plthook_addr(struct plthook_data *, int);
+
+/* These functions are implemented in arch/riscv64/mcount-dynamic.c */
+extern void mcount_disasm_init(struct mcount_disasm_engine *disasm);
+extern void mcount_disasm_finish(struct mcount_disasm_engine *disasm);
+extern int mcount_setup_trampoline(struct mcount_dynamic_info *mdi);
+extern void mcount_cleanup_trampoline(struct mcount_dynamic_info *mdi);
+extern int mcount_patch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym,
+			     struct mcount_disasm_engine *disasm, unsigned min_size);
+extern int mcount_unpatch_func(struct mcount_dynamic_info *mdi, struct uftrace_symbol *sym,
+			       struct mcount_disasm_engine *disasm);
+extern void mcount_arch_find_module(struct mcount_dynamic_info *mdi, struct uftrace_symtab *symtab);
+extern void mcount_arch_dynamic_recover(struct mcount_dynamic_info *mdi,
+					struct mcount_disasm_engine *disasm);
 
 const struct mcount_arch_ops mcount_arch_ops = {
 	.entry = {
 		[UFT_ARCH_OPS_MCOUNT] = (unsigned long)_mcount,
 		[UFT_ARCH_OPS_PLTHOOK] = (unsigned long)plt_hooker,
+		[UFT_ARCH_OPS_DYNAMIC] = (unsigned long)__dentry__,
 	},
 	.exit = {
 		[UFT_ARCH_OPS_MCOUNT] = (unsigned long)mcount_return,
 		[UFT_ARCH_OPS_PLTHOOK] = (unsigned long)plthook_return,
+		/* the dynamic exit path reuses the mcount return trampoline */
+		[UFT_ARCH_OPS_DYNAMIC] = (unsigned long)mcount_return,
 	},
 	.plthook_addr = mcount_arch_plthook_addr,
+	.disasm_init = mcount_disasm_init,
+	.disasm_finish = mcount_disasm_finish,
+	.setup_trampoline = mcount_setup_trampoline,
+	.cleanup_trampoline = mcount_cleanup_trampoline,
+	.patch_func = mcount_patch_func,
+	.unpatch_func = mcount_unpatch_func,
+	.find_module = mcount_arch_find_module,
+	.dynamic_recover = mcount_arch_dynamic_recover,
 };
 
 static int mcount_get_register_arg(struct mcount_arg_context *ctx, struct uftrace_arg_spec *spec)

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -41,12 +41,14 @@ class Elf:
         EM_ARM        = 40      # ARM
         EM_X86_64     = 62      # AMD x86-64 architecture
         EM_AARCH64    = 183     # ARM AARCH64
+        EM_RISCV      = 243     # RISC-V
 
         machine = {
             EM_386: 'i386',
             EM_ARM: 'arm',
             EM_X86_64: 'x86_64',
             EM_AARCH64: 'aarch64',
+            EM_RISCV: 'riscv64',
         }
 
         try:
@@ -551,6 +553,12 @@ class TestBase:
     def check_arch_full_dynamic_support(self):
         elf_machine = TestBase.get_elf_machine(self)
         if elf_machine == 'x86_64' or elf_machine == 'aarch64':
+            return True
+        return False
+
+    def check_arch_patchable_dynamic_support(self):
+        elf_machine = TestBase.get_elf_machine(self)
+        if elf_machine in ('x86_64', 'aarch64', 'riscv64'):
             return True
         return False
 

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -1007,6 +1007,7 @@ if __name__ == "__main__":
     patch_size = {
         'x86_64'  : 5,
         'aarch64' : 2,
+        'riscv64' : 4,
     }
 
     m = os.uname()[-1]  # machine

--- a/tests/s-patchable-abc.c
+++ b/tests/s-patchable-abc.c
@@ -8,6 +8,8 @@
 #define NR_NOPS 5
 #elif __aarch64__
 #define NR_NOPS 2
+#elif __riscv
+#define NR_NOPS 4
 #else
 #define NR_NOPS 0
 #endif

--- a/tests/t263_patchable_dynamic1.py
+++ b/tests/t263_patchable_dynamic1.py
@@ -16,7 +16,7 @@ class TestCase(TestBase):
 """)
 
     def prerun(self, timeout):
-        if not TestBase.check_arch_full_dynamic_support(self):
+        if not TestBase.check_arch_patchable_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
@@ -29,6 +29,8 @@ class TestCase(TestBase):
             cflags += ' -fpatchable-function-entry=5'
         elif machine == 'aarch64':
             cflags += ' -fpatchable-function-entry=2'
+        elif machine == 'riscv64':
+            cflags += ' -fpatchable-function-entry=4'
 
         return TestBase.build(self, name, cflags, ldflags)
 

--- a/tests/t264_patchable_dynamic2.py
+++ b/tests/t264_patchable_dynamic2.py
@@ -14,7 +14,7 @@ class TestCase(TestBase):
 """)
 
     def prerun(self, timeout):
-        if not TestBase.check_arch_full_dynamic_support(self):
+        if not TestBase.check_arch_patchable_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 

--- a/tests/t265_patchable_dynamic3.py
+++ b/tests/t265_patchable_dynamic3.py
@@ -12,7 +12,7 @@ class TestCase(TestBase):
 """)
 
     def prerun(self, timeout):
-        if not TestBase.check_arch_full_dynamic_support(self):
+        if not TestBase.check_arch_patchable_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 

--- a/tests/t266_patchable_dynamic4.py
+++ b/tests/t266_patchable_dynamic4.py
@@ -16,7 +16,7 @@ class TestCase(TestBase):
 """, sort='simple')
 
     def prerun(self, timeout):
-        if not TestBase.check_arch_full_dynamic_support(self):
+        if not TestBase.check_arch_patchable_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 
@@ -29,6 +29,8 @@ class TestCase(TestBase):
             cflags += ' -fpatchable-function-entry=5'
         elif machine == 'aarch64':
             cflags += ' -fpatchable-function-entry=2'
+        elif machine == 'riscv64':
+            cflags += ' -fpatchable-function-entry=4'
 
         if TestBase.build_libabc(self, cflags, ldflags) != 0:
             return TestBase.TEST_BUILD_FAIL

--- a/tests/t267_patchable_dynamic5.py
+++ b/tests/t267_patchable_dynamic5.py
@@ -14,7 +14,7 @@ class TestCase(TestBase):
 """)
 
     def prerun(self, timeout):
-        if not TestBase.check_arch_full_dynamic_support(self):
+        if not TestBase.check_arch_patchable_dynamic_support(self):
             return TestBase.TEST_SKIP
         return TestBase.TEST_SUCCESS
 


### PR DESCRIPTION
This implements dynamic tracing for RISC-V via `-fpatchable-function-entry`, the path agreed on in #1862, and validates it on `qemuriscv64`.

### Approach
- `-mfentry` isn't available on RISC-V (as @honggyukim confirmed in #1862), so this uses `-fpatchable-function-entry`, porting the structure from `arch/aarch64/{mcount-dynamic.c, dynamic.S}`.
- The 8-byte patchable entry is rewritten to `auipc t0` / `jalr t0` (jumping to the trampoline). Linking into `t0` preserves the caller's `ra`, and enable/disable only flips the second 4-byte slot (`jalr ↔ nop`) — a single naturally-aligned store, so the toggle is atomic, following the kernel's RISC-V ftrace atomic code-patching. The i-cache is synced with `__builtin___clear_cache()`.
- A related prerequisite (the RISC-V memory barriers were no-ops) is split out as #2057; this PR is independent of it.

### What works (verified on qemuriscv64)
Call graph, integer & floating-point arguments and return values, partial patching (`-P`), unpatch (`-U`), multi-threaded targets — with both **gcc and clang**.

### Test suite (`tests/runtest.py`)
Ran the suite on `qemuriscv64` (gcc, O0–Os) with `-fpatchable-function-entry`. The second commit adds `'riscv64': 4` to `patch_size` so the patchable path is enabled (4× compressed `nop` = 8 bytes on an RVC target).

Kernel-tracing tests are excluded: the Yocto guest kernel is built without `FUNCTION_GRAPH_TRACER`, so those tests block on the missing tracefs (~290 of 305 tests run).

The dynamic path fails **30–36 tests per opt level** (O0=36, O1=32, O2=30, O3=34, Os=30), all of which fall into the categories below — none specific to the dynamic implementation:

- **Argument-spec tests** (`arg_many/mixed/reg/stack/variadic`): hard-code arch-specific `%reg`/`%stack` specs (the test special-cases i386/arm, not riscv64/aarch64). e.g. `arg_stack` reads `%stack+N`, but on RISC-V those args are in `a0–a7`. These also fail on the static (`pg`) path, so it's the test's ABI assumption, not the tracer.
- **Timing tests** (`*_time`, `report_avg_self`): emulation distorts durations.
- **Format** (`dump_flamegraph`): output formatting.
- **4 crashes** (`trigger_finish`, `trigger_finish2`, `signal_trigger`, `exception5`, `SG`): all rely on runtime return-address restoration (`@finish` triggers, `--signal …@finish`, C++ exception unwinding). aarch64 shows the identical `SG SG SG SG SG` in #2004 — `ARCH_SUPPORT_AUTO_RECOVER` is only defined for x86_64, so this is a shared non-x86 limitation, at feature parity with aarch64.

### Test environment
All of the above is on `qemuriscv64` (Yocto) under QEMU/TCG, gcc (clang used for the manual checks only). TCG auto-invalidates translated code on writes, so it can't fully exercise i-cache / atomic-patching correctness — that relies on the kernel's approach + `__builtin___clear_cache()`, and would ideally be confirmed on real hardware (e.g. VisionFive 2).
