### PR TITLE
misc: Print enum definitions in dbginfo

### DIFF
--- a/misc/dbginfo.c
+++ b/misc/dbginfo.c
@@ -14,7 +14,8 @@ void print_debug_info(struct uftrace_dbg_info *dinfo, bool auto_args)
 	char *argspec = NULL;
 	char *retspec = NULL;
 
-	/* TODO: print enum definitions */
+	/* print enum definitions */
+	save_enum_def(&dinfo->enums, stdout);
 
 	for (i = 0; i < dinfo->nr_locs; i++) {
 		struct uftrace_dbg_loc *loc = &dinfo->locs[i];


### PR DESCRIPTION
The enum definitions parsed from DWARF were collected but never printed, so the enum types behind argspecs like @arg1/e:color could not be seen.

So this patch prints them ahead of the per-symbol info.