### PR TITLE
utils: fix asprintf return value check in Android uftrace_shmem_unlink

### DIFF
--- a/utils/shmem.c
+++ b/utils/shmem.c
@@ -67,7 +67,7 @@ int uftrace_shmem_unlink(const char *name)
 
 	uftrace_dir = uftrace_shmem_root();
 
-	if (asprintf(&fname, "%s/%s", uftrace_dir, name))
+	if (asprintf(&fname, "%s/%s", uftrace_dir, name) < 0)
 		return -1;
 	status = unlink(fname);
 	free(fname);


### PR DESCRIPTION
I stumbled upon this bug when I was going through the source code, there seems to be an issue here in the `uftrace_shmem_unlink()` function in the Android shmem utils function definition.

`asprintf()` returns `-1` on failure and the number of bytes printed in other times according to [here](https://man7.org/linux/man-pages/man3/asprintf.3.html).

Because any non-zero value evaluates to `true` here, a successful `asprintf()` call returns a positive value and it triggers the if condition and I assume this will cause `unlink()` to never be called in successful path formatting and also the memory in `asprintf()` to be leaked because `free(fname)` is skipped.

Interestingly, in `uftrace_shmem_open()` this is correct and has no issue.