### PR TITLE
tui: add ASCII fallback for non-UTF-8 locales

### DIFF
--- a/cmds/tui.c
+++ b/cmds/tui.c
@@ -2,12 +2,14 @@
 
 #include <errno.h>
 #include <inttypes.h>
+#include <langinfo.h>
 #include <locale.h>
 #include <ncurses.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -127,6 +129,7 @@ static struct tui_graph partial_graph;
 static struct tui_list tui_info;
 static struct tui_list tui_session;
 static char *tui_search;
+static bool is_utf8_locale;
 
 static const struct tui_window_ops graph_ops;
 static const struct tui_window_ops report_ops;
@@ -210,6 +213,23 @@ static char *report_sort_key[] = { OPT_SORT_KEYS,  "total_avg",	   "total_min",	
 static char *selected_report_sort_key[NUM_REPORT_FIELD];
 
 static int curr_sort_key = 0;
+
+static void check_utf8_locale(void)
+{
+	/* Use setlocale() to resolve the effective LC_CTYPE from
+	 * LC_ALL, LC_CTYPE, and LANG in priority order. It treats
+	 * empty values as unset and returns NULL when the locale
+	 * cannot be activated (e.g., not installed).
+	 */
+	if (setlocale(LC_CTYPE, "") != NULL) {
+		const char *codeset = nl_langinfo(CODESET);
+		is_utf8_locale =
+			(codeset && (strcasestr(codeset, "utf-8") || strcasestr(codeset, "utf8")));
+	}
+	else {
+		is_utf8_locale = false;
+	}
+}
 
 static void init_colors(void)
 {
@@ -1379,6 +1399,18 @@ static void print_graph_indent(struct tui_graph *graph, struct tui_graph_node *n
 {
 	int i;
 	struct tui_graph_node *parent = (void *)node->n.parent;
+	const char *vertical_line, *corner, *branch;
+
+	if (is_utf8_locale) {
+		vertical_line = "│";
+		corner = "└";
+		branch = "├";
+	}
+	else {
+		vertical_line = "| ";
+		corner = "`-";
+		branch = "+-";
+	}
 
 	for (i = 0; i < depth; i++) {
 		if (width < 3) {
@@ -1393,11 +1425,11 @@ static void print_graph_indent(struct tui_graph *graph, struct tui_graph_node *n
 		}
 
 		if (i < depth - 1 || single_child)
-			printw("  │");
+			printw("  %s", vertical_line);
 		else if (is_last_child(parent, node))
-			printw("  └");
+			printw("  %s", corner);
 		else
-			printw("  ├");
+			printw("  %s", branch);
 	}
 }
 
@@ -1418,7 +1450,10 @@ static void win_display_graph(struct tui_window *win, void *node)
 		return;
 	}
 
-	fold_sign = curr->folded ? "▶" : "─";
+	if (is_utf8_locale)
+		fold_sign = curr->folded ? "▶" : "─";
+	else
+		fold_sign = curr->folded ? ">" : "";
 
 	parent = win_parent_graph(win, node);
 	if (parent == NULL)
@@ -1446,10 +1481,16 @@ static void win_display_graph(struct tui_window *win, void *node)
 			w = COLS - width;
 			width += snprintf(buf, sizeof(buf), "%s(%d) ", fold_sign, curr->n.nr_calls);
 
-			/* handle UTF-8 character length */
+			/* handle character length */
 			if (strcmp(fold_sign, " ")) {
-				width -= 2;
-				w += 2;
+				if (is_utf8_locale) {
+					width -= 2;
+					w += 2;
+				}
+				else {
+					width -= 1;
+					w += 1;
+				}
 			}
 			printw("%.*s", w, buf);
 		}
@@ -3157,6 +3198,7 @@ int command_tui(int argc, char *argv[], struct uftrace_opts *opts)
 	tui_setup(&handle, opts);
 
 	setlocale(LC_ALL, "");
+	check_utf8_locale();
 
 	initscr();
 	init_colors();


### PR DESCRIPTION
When `LANG` is not set to a UTF-8 locale (common in Docker containers), the TUI graph view displays garbled characters like `~T~\ ~T~@(1)` instead of proper box-drawing characters.

This adds locale detection via `LANG`, `LC_CTYPE`, and `LC_ALL`, then falls back to ASCII characters when UTF-8 is not available:

- `│` → `|` (vertical line)
- `└` → `` ` `` (corner)
- `├` → `+` (junction)
- `▶` → `>` (fold indicator)
- `─` → space (unfold connector)

The width correction (`width -= 2` for `snprintf` byte vs column mismatch) now only applies to multi-byte UTF-8 characters, since ASCII chars have 1 byte = 1 display column. This fixes the cursor overflow and alignment issues reported in #1870.

Tested with `LANG=POSIX` and `LANG=en_US.UTF-8`.

Fixes: #1870