### PR TITLE
uftrace: Fix debuginfod remote waiting

### DIFF
--- a/cmds/record.c
+++ b/cmds/record.c
@@ -377,9 +377,6 @@ static void setup_child_environ(struct uftrace_opts *opts, int argc, char *argv[
 	put_libmcount_path(libpath);
 	setenv("XRAY_OPTIONS", "patch_premain=false", 1);
 	setenv("GLIBC_TUNABLES", "glibc.cpu.hwcaps=-IBT,-SHSTK", 1);
-
-	/* disable debuginfo daemon */
-	unsetenv("DEBUGINFOD_URLS");
 }
 
 static uint64_t calc_feat_mask(struct uftrace_opts *opts)

--- a/uftrace.c
+++ b/uftrace.c
@@ -1842,6 +1842,9 @@ int main(int argc, char *argv[])
 	if (!opts.libcall && opts.nest_libcall)
 		pr_err_ns("cannot use --no-libcall and --nest-libcall options together\n");
 
+	/* disable debuginfo daemon to avoid unintended network delay */
+	unsetenv("DEBUGINFOD_URLS");
+
 	switch (opts.mode) {
 	case UFTRACE_MODE_RECORD:
 		ret = command_record(argc, argv, &opts);


### PR DESCRIPTION
The current location of disabling debuginfo daemon is applied only for the record thread, but dwfl_module_getdwarf(), which requires network connection, is called main thread and others as well.

libdwfl honors DEBUGINFOD_URLS automatically while loading separate debug files.  This can make record and replay wait for a remote server even though the user did not request network access.

If there is some problems connecting the debuginfod remotely, then uftrace record or replay both silently wait very long time as follows.
```
  $ time uftrace record t-abc
      ...
  real    0m22.726s
  user    0m1.264s
  sys     0m0.179s

  $ time uftrace replay --no-pager
      ...
  real    0m3.773s
  user    0m0.209s
  sys     0m0.028s
```
In order to avoid this subtle and critical problem, this patch relocate the `unsetenv("DEBUGINFOD_URLS")` logic in the initial stage even before the command check branch so that it can be applied to all the threads being created.