### PR TITLE
symbol: Fix memory leak when dynamic symbol count is zero

### DIFF
--- a/utils/symbol.c
+++ b/utils/symbol.c
@@ -701,8 +701,12 @@ int load_elf_dynsymtab(struct uftrace_symtab *dsymtab, struct uftrace_elf_data *
 out_sort:
 	pr_dbg4("loaded %zd symbols\n", dsymtab->nr_sym);
 
-	if (dsymtab->nr_sym == 0)
+	if (dsymtab->nr_sym == 0) {
+		free(dsymtab->sym);
+		dsymtab->sym = NULL;
+		dsymtab->nr_alloc = 0;
 		goto out;
+	}
 
 	/* also fixup the size of symbol table */
 	sort_dynsymtab(dsymtab);


### PR DESCRIPTION
When `load_elf_dynsymtab()` finds no valid dynamic symbols (`nr_sym == 0`) , it jumps to the out label. This leaves the pre-allocated symbol array unfreed in `dsymtab->sym`.

This change frees the pre-allocated memory and resets `dsymtab->sym` and `nr_alloc` to prevent memory leaks.